### PR TITLE
increase the precision for pqc input file

### DIFF
--- a/FEM/rf_react.cpp
+++ b/FEM/rf_react.cpp
@@ -2027,7 +2027,7 @@ double unitfactor_l = 1, unitfactor_s = 1;
 
 // precision output file
 	out_file->setf(ios::scientific,ios::floatfield);
-	out_file->precision(12);
+	out_file->precision(16);
 
 /* zeilenweise lesen */
 	while(!pqc_infile.eof())


### PR DESCRIPTION
according to the reviewer comment regarding to the precision for pqc input, it's recommended to increase the precision from 12 to 16.