### PR TITLE
Fixing  benchmarks

### DIFF
--- a/FEM/rf_random_walk.cpp
+++ b/FEM/rf_random_walk.cpp
@@ -14,10 +14,12 @@
    07/2005 PCH Implementation
 **************************************************************************/
 
+#include "rf_random_walk.h"
+
+#include "FileTools.h"
 #include "Output.h"
 #include "matrix_class.h"
 #include "rf_fluid_momentum.h"
-#include "rf_random_walk.h"
 #include "rf_tim_new.h"
 #include "rfmat_cp.h"
 
@@ -5978,11 +5980,10 @@ void DATWriteParticleFile(int current_time_step)
 	sprintf(now, "%i", current_time_step);
 	string nowstr = now;
 
-	string vtk_file_name = FileName + "_RWPT_";
-	vtk_file_name += nowstr;
-	vtk_file_name += ".particles.vtk";
-	fstream vtk_file(vtk_file_name.data(), ios::out);
-	vtk_file.setf(ios::scientific, ios::floatfield);
+	string vtk_file_name =  pathJoin(defaultOutputPath, FileName);
+	vtk_file_name += "_RWPT_" + nowstr + ".particles.vtk";
+	fstream vtk_file (vtk_file_name.data(),ios::out);
+	vtk_file.setf(ios::scientific,ios::floatfield);
 	vtk_file.precision(12);
 	if (!vtk_file.good())
 		return;

--- a/scripts/cmake/benchmarks/JOD.cmake
+++ b/scripts/cmake/benchmarks/JOD.cmake
@@ -5,9 +5,9 @@ Benchmark(AUTHOR JOD
 	CONFIG FEM
 	RUNTIME 1
 	OUTPUT_FILES
-		OVERLAND_FLOW/gian_quad_domain_OVERLAND_FLOW_quad.tec
-		OVERLAND_FLOW/gian_quad_time_POINT4_OVERLAND_FLOW.tec
-		OVERLAND_FLOW/gian_quad_time_POINT5_OVERLAND_FLOW.tec
+		gian_quad_domain_OVERLAND_FLOW_quad.tec
+		gian_quad_time_POINT4_OVERLAND_FLOW.tec
+		gian_quad_time_POINT5_OVERLAND_FLOW.tec
 )
 
 Benchmark(AUTHOR JOD

--- a/scripts/cmake/benchmarks/UJG.cmake
+++ b/scripts/cmake/benchmarks/UJG.cmake
@@ -25,8 +25,8 @@ Benchmark(AUTHOR UJG
 	CONFIG FEM
 	RUNTIME 2
 	OUTPUT_FILES
-		HM/hm_cc_tri_s_domain_DEFORMATION_FLOW_tri.tec
-		HM/hm_cc_tri_s_time_POINT2_DEFORMATION_FLOW.tec
+		hm_cc_tri_s_domain_DEFORMATION_FLOW_tri.tec
+		hm_cc_tri_s_time_POINT2_DEFORMATION_FLOW.tec
 )
 
 Benchmark(AUTHOR UJG
@@ -156,8 +156,8 @@ Benchmark(AUTHOR UJG
 	CONFIG FEM
 	RUNTIME 3
 	OUTPUT_FILES
-		creep/m_crp_tri_domain_tri.tec
-		creep/m_crp_tri_time_POINT2.tec
+		m_crp_tri_domain_tri.tec
+		m_crp_tri_time_POINT2.tec
 )
 
 Benchmark(AUTHOR UJG
@@ -178,7 +178,7 @@ Benchmark(AUTHOR UJG
 	PATH HM/hm_foot_tet
 	CONFIG FEM
 	RUNTIME 63
-	OUTPUT_FILES 32
+	OUTPUT_FILES
 		hm_foot_tet_domain_DEFORMATION_FLOW_tet.tec
 		hm_foot_tet_ply_OUT_AXIS_t1_DEFORMATION_FLOW.tec
 )


### PR DESCRIPTION
There are several benchmarks failed with the open source code of ogs5. This PR is aimed to fix the failed benchmarks that are listed below:

- [x]  AKS-H_us/RSM/AT_5 (Failed)
- [ ]  BG-ECLIPSE_DUMUX/kinetic_CO2phase_generation_E100/CO2phase_gen_E100 (Failed)
- [ ]  BG-ECLIPSE_DUMUX/kinetic_CO2phase_generation_E300/CO2phase_gen_E300 (Failed)
- [x]  JOD-OVERLAND_FLOW/gian_quad (Failed)
- [ ]  MW-DENSITY-DEPENDENT_FLOW/goswami-clement/constrBC_PressAsHead_tri/HM (Failed)
- [ ]  MW-DENSITY-DEPENDENT_FLOW/goswami-clement/wholeBC_PressAsHead_tri/HM (Failed)
- [x]  UJG-HM/hm_cc_tri_s (Failed)
- [x]  UJG-M/creep/m_crp_tri (Failed)
- [x]  UJG-HM/hm_foot_tet (Failed)
- [x]  YS-RWPT/Harter/colloid_t (Failed)
- [x]  YS-RWPT/3DGrain/3d_grain (Failed)
- [x]  YS-RWPT/HomoCube/3DRWPTCubTet (Failed)
- [x]  YS-RWPT/Forchheimer/forchheimer_rwpt (Failed)

Those need freeqc
- [ ]  BG-C/2d_Cl_transport_Clay/Nuklidtransport (Failed)
- [ ]  CB-C/Engesgaard/Kin/slow_kin_pqc/pds (Failed)
- [ ]  CB-C/Engesgaard/Kin/slow_kin_pqc_krc/pds (Failed)
- [ ]  CB-C/NAPL-dissolution/1D_NAPL-diss_flow/lin/1D_TPF_resS_flow (Failed)