### PR TITLE
fix an uninitialized member variable in CMediumPropertiesGroup

### DIFF
--- a/FEM/rf_mmp_new.h
+++ b/FEM/rf_mmp_new.h
@@ -316,7 +316,7 @@ public:
 class CMediumPropertiesGroup                      //YD
 {
    public:
-      CMediumPropertiesGroup() {OrigSize=0;}
+      CMediumPropertiesGroup() : m_msh(NULL), OrigSize(0) {}
       void Set(CRFProcess* m_pcs);
       std::string pcs_name;
       std::string pcs_type_name;


### PR DESCRIPTION
as titled