### PR TITLE
Improvement in shape function computation

### DIFF
--- a/FEM/CMakeLists.txt
+++ b/FEM/CMakeLists.txt
@@ -49,6 +49,7 @@ set( HEADERS
 	tools.h
 	vtk.h
 	OutputTools.h
+	ShapeFunctionPool.h
 )
 
 set( SOURCES
@@ -102,7 +103,6 @@ set( SOURCES
 	Stiff_Bulirsch-Stoer.cpp
 	tools.cpp
 	vtk.cpp
-	ShapeFunctionPool.h
 	ShapeFunctionPool.cpp
 )
 

--- a/FEM/CMakeLists.txt
+++ b/FEM/CMakeLists.txt
@@ -102,6 +102,8 @@ set( SOURCES
 	Stiff_Bulirsch-Stoer.cpp
 	tools.cpp
 	vtk.cpp
+	ShapeFunctionPool.h
+	ShapeFunctionPool.cpp
 )
 
 if(NOT OGS_LSOLVER STREQUAL PETSC)

--- a/FEM/DUMUX.cpp
+++ b/FEM/DUMUX.cpp
@@ -1276,7 +1276,7 @@ void CDUMUXData::WriteDataToGeoSys(CRFProcess* m_pcs)
 			m_ele = m_msh->ele_vector[i]; // get element
 			if (m_ele->GetMark()) // Marked for use
 			{ // Configure Element for interpolation of node velocities to GP velocities
-				fem->ConfigElement(m_ele, m_pcs->m_num->ele_gauss_points);
+				fem->ConfigElement(m_ele);
 
 				std::string tempstring;
 				tempstring = "";

--- a/FEM/Output.cpp
+++ b/FEM/Output.cpp
@@ -3818,8 +3818,10 @@ void COutput::CalculateTotalFlux(CFEMesh* msh, vector<long>& nodes_on_geo, vecto
 					                   * mfp_vector[0]->SpecificHeatCapacity() * mfp_vector[0]->Density();
 			}
 			///
-			fem_assembler->FaceNormalFluxIntegration(elements_at_geo[i], nodesFVal, nodesFVal_adv, nodesFace, face, m_pcs, face->normal_vector);
-			for (k = 0; k < nfn; k++) {
+			fem_assembler->FaceNormalFluxIntegration(elements_at_geo[i], nodesFVal, nodesFVal_adv, nodesFace, face,
+			                                         m_pcs, face->normal_vector);
+			for (k = 0; k < nfn; k++)
+			{
 				e_node = elem->GetNode(nodesFace[k]);
 				// -->PETSC
 				NVal_diff[G2L[e_node->GetIndex()]] += fac * nodesFVal[k];

--- a/FEM/Output.cpp
+++ b/FEM/Output.cpp
@@ -3795,8 +3795,9 @@ void COutput::CalculateTotalFlux(CFEMesh* msh, vector<long>& nodes_on_geo, vecto
 				fac = 0.5; // Not a surface face
 			face->SetFace(elem, j);
 			face->SetOrder(msh->getOrder());
+			face->FillTransformMatrix();
 			face->ComputeVolume();
-			face->SetNormalVector();
+			face->SetNormalVector();  // to get it directly from TransformMatrix
 			face->DirectNormalVector();
 			fem_assembler->setOrder(msh->getOrder() + 1);
 			fem_assembler->ConfigElement(face, true); // 2D fem

--- a/FEM/Output.cpp
+++ b/FEM/Output.cpp
@@ -18,6 +18,7 @@
 #include <string>
 
 #include <cfloat> // DBL_EPSILON
+#include <algorithm> // remove-if
 
 #include "BuildInfo.h"
 #include "FEMIO/GeoIO.h"
@@ -477,6 +478,7 @@ ios::pos_type COutput::Read(std::ifstream& in_str, const GEOLIB::GEOObjects& geo
 				}
 				if (Keyword(line_string))
 					return position;
+				std::remove_if(line_string.begin(), line_string.end(), ::isspace);
 				mfp_value_vector.push_back(line_string);
 			}
 

--- a/FEM/Output.cpp
+++ b/FEM/Output.cpp
@@ -3722,13 +3722,12 @@ void COutput::CalculateTotalFlux(CFEMesh* msh, vector<long>& nodes_on_geo, vecto
 	double fac, nodesFVal[8], nodesFVal_adv[8], flux[3]; // , poro;
 	// CMediumProperties *MediaProp;
 
-	int Axisymm = 1; // ani-axisymmetry
-	if (msh->isAxisymmetry())
-		Axisymm = -1; // Axisymmetry is true
-
 	CElem* elem = NULL;
 	CElem* face = new CElem(1);
-	FiniteElement::CElement* element = new FiniteElement::CElement(Axisymm * msh->GetCoordinateFlag());
+
+	FiniteElement::CElement* fem_assembler = m_pcs_flow->getLinearFEMAssembler();
+	assert(fem_assembler);
+
 	CNode* e_node = NULL;
 	CElem* e_nei = NULL;
 	set<long> set_nodes_on_geo;
@@ -3799,8 +3798,8 @@ void COutput::CalculateTotalFlux(CFEMesh* msh, vector<long>& nodes_on_geo, vecto
 			face->ComputeVolume();
 			face->SetNormalVector();
 			face->DirectNormalVector();
-			element->setOrder(msh->getOrder() + 1);
-			element->ConfigElement(face, m_pcs_flow->m_num->ele_gauss_points, true); // 2D fem
+			fem_assembler->setOrder(msh->getOrder() + 1);
+			fem_assembler->ConfigElement(face, true); // 2D fem
 
 			for (k = 0; k < nfn; k++)
 			{
@@ -3818,10 +3817,8 @@ void COutput::CalculateTotalFlux(CFEMesh* msh, vector<long>& nodes_on_geo, vecto
 					                   * mfp_vector[0]->SpecificHeatCapacity() * mfp_vector[0]->Density();
 			}
 			///
-			element->FaceNormalFluxIntegration(elements_at_geo[i], nodesFVal, nodesFVal_adv, nodesFace, face, m_pcs,
-			                                   face->normal_vector);
-			for (k = 0; k < nfn; k++)
-			{
+			fem_assembler->FaceNormalFluxIntegration(elements_at_geo[i], nodesFVal, nodesFVal_adv, nodesFace, face, m_pcs, face->normal_vector);
+			for (k = 0; k < nfn; k++) {
 				e_node = elem->GetNode(nodesFace[k]);
 				// -->PETSC
 				NVal_diff[G2L[e_node->GetIndex()]] += fac * nodesFVal[k];
@@ -3841,7 +3838,6 @@ void COutput::CalculateTotalFlux(CFEMesh* msh, vector<long>& nodes_on_geo, vecto
 	NVal_diff.clear();
 	NVal_adv.clear();
 	G2L.clear();
-	delete element;
 	delete face;
 }
 

--- a/FEM/OutputTools.h
+++ b/FEM/OutputTools.h
@@ -106,13 +106,11 @@ inline double getElementMMP(int mmp_id, MeshLib::CElem* ele, CRFProcess* m_pcs)
 {
 	double gp[3] = {.0, .0, .0};
 	double theta = 1.0;
-	int gp_r, gp_s, gp_t;
 	ele->SetOrder(false);
 	CFiniteElementStd* fem = m_pcs->GetAssember();
-	fem->ConfigElement(ele, m_pcs->m_num->ele_gauss_points, false);
+	fem->ConfigElement(ele, false);
 	fem->Config();
-	fem->SetGaussPoint(0, gp_r, gp_s, gp_t);
-	fem->ComputeShapefct(1);
+	fem->getShapeFunctionCentroid();
 	CMediumProperties* mmp = mmp_vector[ele->GetPatchIndex()];
 	double val = ELEMENT_MMP_VALUES::getValue(mmp, mmp_id, ele->GetIndex(), gp, theta);
 	return val;

--- a/FEM/ShapeFunctionPool.cpp
+++ b/FEM/ShapeFunctionPool.cpp
@@ -1,0 +1,213 @@
+/*! \file ShapeFunctionPool.cpp
+    \brief Compute shape functions and their gradients with respect to
+     the local coodinates, and store the results
+
+     \author Wenqing Wang
+     \date Feb. 2015
+ 
+     \copyright
+      Copyright (c) 2015, OpenGeoSys Community (http://www.opengeosys.org)
+             Distributed under a Modified BSD License.
+             See accompanying file LICENSE.txt or
+             http://www.opengeosys.org/project/license
+*/
+
+#include "ShapeFunctionPool.h"
+
+#include <cassert>     /* assert */
+#include "fem_ele.h"
+
+namespace FiniteElement
+{
+ShapeFunctionPool::ShapeFunctionPool(
+			const std::vector<MshElemType::type>& elem_types,
+			CElement& quadrature, const int num_sample_gs_pnts)
+{
+	const std::size_t n_ele_types = elem_types.size();
+	_shape_function.reserve(n_ele_types);
+	_shape_function_center.reserve(n_ele_types);
+	_grad_shape_function.reserve(n_ele_types);
+	_grad_shape_function_center.reserve(n_ele_types);
+
+	for (std::size_t i=0; i<n_ele_types; i++)
+	{
+		_shape_function.push_back(NULL);
+		_shape_function_center.push_back(NULL);
+		_grad_shape_function.push_back(NULL);
+		_grad_shape_function_center.push_back(NULL);
+	}
+
+	int num_elem_nodes[2][MshElemType::LAST];
+	int dim_elem[MshElemType::LAST];
+
+	int id = static_cast<int>(MshElemType::LINE) - 1;
+	num_elem_nodes[0][id] = 2;
+	num_elem_nodes[1][id] = 3;
+	dim_elem[id] = 1;
+
+	id = static_cast<int>(MshElemType::QUAD) - 1;
+	num_elem_nodes[0][id] = 4;
+	num_elem_nodes[1][id] = 9;
+	dim_elem[id] = 2;
+
+	id = static_cast<int>(MshElemType::QUAD8) - 1;
+	num_elem_nodes[0][id] = 4;
+	num_elem_nodes[1][id] = 8;
+	dim_elem[id] = 2;
+
+	id = static_cast<int>(MshElemType::TRIANGLE) - 1;
+	num_elem_nodes[0][id] = 3;
+	num_elem_nodes[1][id] = 6;
+	dim_elem[id] = 2;
+
+	id = static_cast<int>(MshElemType::HEXAHEDRON) - 1;
+	num_elem_nodes[0][id] = 8;
+	num_elem_nodes[1][id] = 20;
+	dim_elem[id] = 3;
+
+	id = static_cast<int>(MshElemType::TETRAHEDRON) - 1;
+	num_elem_nodes[0][id] = 4;
+	num_elem_nodes[1][id] = 10;
+	dim_elem[id] = 3;
+
+	id = static_cast<int>(MshElemType::PRISM) - 1;
+	num_elem_nodes[0][id] = 6;
+	num_elem_nodes[1][id] = 15;
+	dim_elem[id] = 3;
+
+	id = static_cast<int>(MshElemType::PYRAMID) - 1;
+	num_elem_nodes[0][id] = 5;
+	num_elem_nodes[1][id] = 13;
+	dim_elem[id] = 3;
+
+	//std::vector<int> elem_type_ids
+	for (std::size_t i=0; i<elem_types.size(); i++)
+	{
+		const MshElemType::type e_type = elem_types[i];
+		if (e_type == MshElemType::INVALID)
+			continue;
+		// Set number of integration points.
+		quadrature.SetGaussPointNumber(num_sample_gs_pnts);
+		quadrature.SetIntegrationPointNumber(e_type);
+
+		const int type_id = static_cast<int>(e_type) - 1;
+		int num_int_pnts = quadrature.GetNumGaussPoints();
+		const int num_nodes = num_elem_nodes[quadrature.getOrder() - 1][type_id];
+		_shape_function_center[type_id] = new double[num_nodes];
+		const int size_shape_fct = num_nodes * num_int_pnts;
+		_shape_function[type_id] = new double[size_shape_fct];
+		_grad_shape_function[type_id] = new double[dim_elem[type_id] * size_shape_fct];
+		_grad_shape_function_center[type_id] = new double[dim_elem[type_id] * num_nodes];
+	}
+
+	computeQuadratures(elem_types, num_elem_nodes, dim_elem, quadrature, num_sample_gs_pnts);
+}
+
+ShapeFunctionPool::~ShapeFunctionPool()
+{
+	for (std::size_t i=0; i<_shape_function.size(); i++)
+	{
+		if (_shape_function[i])
+			delete [] _shape_function[i];
+		_shape_function[i] = NULL;
+	}
+
+	for (std::size_t i=0; i<_shape_function_center.size(); i++)
+	{
+		if (_shape_function_center[i])
+			delete [] _shape_function_center[i];
+		_shape_function_center[i] = NULL;
+	}
+
+	for (std::size_t i=0; i<_shape_function.size(); i++)
+	{
+		if (_grad_shape_function[i])
+			delete [] _grad_shape_function[i];
+		_grad_shape_function[i] = NULL;
+	}
+
+	for (std::size_t i=0; i<_grad_shape_function_center.size(); i++)
+	{
+		if (_grad_shape_function_center[i])
+			delete [] _grad_shape_function_center[i];
+		_grad_shape_function_center[i] = NULL;
+	}
+}
+
+void ShapeFunctionPool::
+	computeQuadratures(const std::vector<MshElemType::type>& elem_types,
+	                   const int num_elem_nodes[2][MshElemType::LAST],
+					   const int dim_elem[],
+		               CElement& quadrature, const int num_sample_gs_pnts)
+{
+	const int order = quadrature.getOrder();
+	for (std::size_t i=0; i<elem_types.size(); i++)
+	{
+		const MshElemType::type e_type = elem_types[i];
+		if (e_type == MshElemType::INVALID)
+			continue;
+
+		const int type_id = static_cast<int>(e_type) - 1;
+		quadrature.ConfigShapefunction(e_type);
+
+    	const int nnodes = num_elem_nodes[order-1][type_id];
+    	const int elem_dim = dim_elem[type_id];
+
+		double* shape_function_center_values = _shape_function_center[type_id];
+		quadrature.SetCenterGP(e_type);
+		quadrature.ComputeShapefct(order, shape_function_center_values);
+		double* grad_shape_function_center_values = _grad_shape_function_center[type_id];
+		quadrature.computeGradShapefctLocal(order, grad_shape_function_center_values);
+
+		double* shape_function_values = _shape_function[type_id];
+		double* dshape_function_values = _grad_shape_function[type_id];
+		// Set number of integration points.
+		quadrature.SetGaussPointNumber(num_sample_gs_pnts);
+		quadrature.SetIntegrationPointNumber(e_type);
+
+		for (int gp = 0; gp < quadrature.GetNumGaussPoints(); gp++)
+	    {
+			int gp_r, gp_s, gp_t;
+			quadrature.SetGaussPoint(e_type, gp, gp_r, gp_s, gp_t);
+			double* shape_function_values_gs
+				    = &shape_function_values[gp * nnodes];
+			quadrature.ComputeShapefct(order, shape_function_values_gs);
+
+			double* dshape_function_values_gs
+				    = &dshape_function_values[gp * nnodes * elem_dim];
+			quadrature.computeGradShapefctLocal(order, dshape_function_values_gs);
+		}
+	}
+}
+
+double* ShapeFunctionPool::
+getShapeFunctionValues(const MshElemType::type elem_type) const
+{
+	assert(_shape_function[static_cast<int>(elem_type)-1]);
+	return _shape_function[static_cast<int>(elem_type)-1];
+}
+
+double* ShapeFunctionPool::
+getShapeFunctionCenterValues(const MshElemType::type elem_type) const
+{
+	assert(_shape_function_center[static_cast<int>(elem_type)-1]);
+	return _shape_function_center[static_cast<int>(elem_type)-1];
+}
+
+double* ShapeFunctionPool::
+getGradShapeFunctionValues(const MshElemType::type elem_type) const
+{
+	assert(_grad_shape_function[static_cast<int>(elem_type)-1]);
+	return _grad_shape_function[static_cast<int>(elem_type)-1];
+}
+
+double* ShapeFunctionPool::
+getGradShapeFunctionCenterValues(const MshElemType::type elem_type) const
+{
+	assert(_grad_shape_function_center[static_cast<int>(elem_type)-1]);
+	return _grad_shape_function_center[static_cast<int>(elem_type)-1];
+}
+
+} // end namespace
+
+

--- a/FEM/ShapeFunctionPool.cpp
+++ b/FEM/ShapeFunctionPool.cpp
@@ -25,6 +25,7 @@ ShapeFunctionPool::ShapeFunctionPool(
 {
 	const std::size_t n_ele_types = elem_types.size();
 	_shape_function.reserve(n_ele_types);
+	_shape_function_size.reserve(n_ele_types);
 	_shape_function_center.reserve(n_ele_types);
 	_grad_shape_function.reserve(n_ele_types);
 	_grad_shape_function_center.reserve(n_ele_types);
@@ -32,6 +33,7 @@ ShapeFunctionPool::ShapeFunctionPool(
 	for (std::size_t i=0; i<n_ele_types; i++)
 	{
 		_shape_function.push_back(NULL);
+		_shape_function_size.push_back(0);
 		_shape_function_center.push_back(NULL);
 		_grad_shape_function.push_back(NULL);
 		_grad_shape_function_center.push_back(NULL);
@@ -96,6 +98,7 @@ ShapeFunctionPool::ShapeFunctionPool(
 		_shape_function_center[type_id] = new double[num_nodes];
 		const int size_shape_fct = num_nodes * num_int_pnts;
 		_shape_function[type_id] = new double[size_shape_fct];
+		_shape_function_size[type_id] = size_shape_fct;
 		_grad_shape_function[type_id] = new double[dim_elem[type_id] * size_shape_fct];
 		_grad_shape_function_center[type_id] = new double[dim_elem[type_id] * num_nodes];
 	}
@@ -150,8 +153,8 @@ void ShapeFunctionPool::
 		const int type_id = static_cast<int>(e_type) - 1;
 		quadrature.ConfigShapefunction(e_type);
 
-    	const int nnodes = num_elem_nodes[order-1][type_id];
-    	const int elem_dim = dim_elem[type_id];
+		const int nnodes = num_elem_nodes[order-1][type_id];
+		const int elem_dim = dim_elem[type_id];
 
 		double* shape_function_center_values = _shape_function_center[type_id];
 		quadrature.SetCenterGP(e_type);
@@ -185,6 +188,12 @@ getShapeFunctionValues(const MshElemType::type elem_type) const
 {
 	assert(_shape_function[static_cast<int>(elem_type)-1]);
 	return _shape_function[static_cast<int>(elem_type)-1];
+}
+
+unsigned ShapeFunctionPool::
+getShapeFunctionArraySize(const MshElemType::type elem_type) const
+{
+	return _shape_function_size[static_cast<int>(elem_type)-1];
 }
 
 double* ShapeFunctionPool::

--- a/FEM/ShapeFunctionPool.cpp
+++ b/FEM/ShapeFunctionPool.cpp
@@ -4,7 +4,7 @@
 
      \author Wenqing Wang
      \date Feb. 2015
- 
+
      \copyright
       Copyright (c) 2015, OpenGeoSys Community (http://www.opengeosys.org)
              Distributed under a Modified BSD License.
@@ -14,14 +14,13 @@
 
 #include "ShapeFunctionPool.h"
 
-#include <cassert>     /* assert */
+#include <cassert> /* assert */
 #include "fem_ele.h"
 
 namespace FiniteElement
 {
-ShapeFunctionPool::ShapeFunctionPool(
-			const std::vector<MshElemType::type>& elem_types,
-			CElement& quadrature, const int num_sample_gs_pnts)
+ShapeFunctionPool::ShapeFunctionPool(const std::vector<MshElemType::type>& elem_types, CElement& quadrature,
+                                     const int num_sample_gs_pnts)
 {
 	const std::size_t n_ele_types = elem_types.size();
 	_shape_function.reserve(n_ele_types);
@@ -30,7 +29,7 @@ ShapeFunctionPool::ShapeFunctionPool(
 	_grad_shape_function.reserve(n_ele_types);
 	_grad_shape_function_center.reserve(n_ele_types);
 
-	for (std::size_t i=0; i<n_ele_types; i++)
+	for (std::size_t i = 0; i < n_ele_types; i++)
 	{
 		_shape_function.push_back(NULL);
 		_shape_function_size.push_back(0);
@@ -82,8 +81,8 @@ ShapeFunctionPool::ShapeFunctionPool(
 	num_elem_nodes[1][id] = 13;
 	dim_elem[id] = 3;
 
-	//std::vector<int> elem_type_ids
-	for (std::size_t i=0; i<elem_types.size(); i++)
+	// std::vector<int> elem_type_ids
+	for (std::size_t i = 0; i < elem_types.size(); i++)
 	{
 		const MshElemType::type e_type = elem_types[i];
 		if (e_type == MshElemType::INVALID)
@@ -108,43 +107,41 @@ ShapeFunctionPool::ShapeFunctionPool(
 
 ShapeFunctionPool::~ShapeFunctionPool()
 {
-	for (std::size_t i=0; i<_shape_function.size(); i++)
+	for (std::size_t i = 0; i < _shape_function.size(); i++)
 	{
 		if (_shape_function[i])
-			delete [] _shape_function[i];
+			delete[] _shape_function[i];
 		_shape_function[i] = NULL;
 	}
 
-	for (std::size_t i=0; i<_shape_function_center.size(); i++)
+	for (std::size_t i = 0; i < _shape_function_center.size(); i++)
 	{
 		if (_shape_function_center[i])
-			delete [] _shape_function_center[i];
+			delete[] _shape_function_center[i];
 		_shape_function_center[i] = NULL;
 	}
 
-	for (std::size_t i=0; i<_shape_function.size(); i++)
+	for (std::size_t i = 0; i < _shape_function.size(); i++)
 	{
 		if (_grad_shape_function[i])
-			delete [] _grad_shape_function[i];
+			delete[] _grad_shape_function[i];
 		_grad_shape_function[i] = NULL;
 	}
 
-	for (std::size_t i=0; i<_grad_shape_function_center.size(); i++)
+	for (std::size_t i = 0; i < _grad_shape_function_center.size(); i++)
 	{
 		if (_grad_shape_function_center[i])
-			delete [] _grad_shape_function_center[i];
+			delete[] _grad_shape_function_center[i];
 		_grad_shape_function_center[i] = NULL;
 	}
 }
 
-void ShapeFunctionPool::
-	computeQuadratures(const std::vector<MshElemType::type>& elem_types,
-	                   const int num_elem_nodes[2][MshElemType::LAST],
-					   const int dim_elem[],
-		               CElement& quadrature, const int num_sample_gs_pnts)
+void ShapeFunctionPool::computeQuadratures(const std::vector<MshElemType::type>& elem_types,
+                                           const int num_elem_nodes[2][MshElemType::LAST], const int dim_elem[],
+                                           CElement& quadrature, const int num_sample_gs_pnts)
 {
 	const int order = quadrature.getOrder();
-	for (std::size_t i=0; i<elem_types.size(); i++)
+	for (std::size_t i = 0; i < elem_types.size(); i++)
 	{
 		const MshElemType::type e_type = elem_types[i];
 		if (e_type == MshElemType::INVALID)
@@ -153,7 +150,7 @@ void ShapeFunctionPool::
 		const int type_id = static_cast<int>(e_type) - 1;
 		quadrature.ConfigShapefunction(e_type);
 
-		const int nnodes = num_elem_nodes[order-1][type_id];
+		const int nnodes = num_elem_nodes[order - 1][type_id];
 		const int elem_dim = dim_elem[type_id];
 
 		double* shape_function_center_values = _shape_function_center[type_id];
@@ -169,54 +166,45 @@ void ShapeFunctionPool::
 		quadrature.SetIntegrationPointNumber(e_type);
 
 		for (int gp = 0; gp < quadrature.GetNumGaussPoints(); gp++)
-	    {
+		{
 			int gp_r, gp_s, gp_t;
 			quadrature.SetGaussPoint(e_type, gp, gp_r, gp_s, gp_t);
-			double* shape_function_values_gs
-				    = &shape_function_values[gp * nnodes];
+			double* shape_function_values_gs = &shape_function_values[gp * nnodes];
 			quadrature.ComputeShapefct(order, shape_function_values_gs);
 
-			double* dshape_function_values_gs
-				    = &dshape_function_values[gp * nnodes * elem_dim];
+			double* dshape_function_values_gs = &dshape_function_values[gp * nnodes * elem_dim];
 			quadrature.computeGradShapefctLocal(order, dshape_function_values_gs);
 		}
 	}
 }
 
-double* ShapeFunctionPool::
-getShapeFunctionValues(const MshElemType::type elem_type) const
+double* ShapeFunctionPool::getShapeFunctionValues(const MshElemType::type elem_type) const
 {
-	assert(_shape_function[static_cast<int>(elem_type)-1]);
-	return _shape_function[static_cast<int>(elem_type)-1];
+	assert(_shape_function[static_cast<int>(elem_type) - 1]);
+	return _shape_function[static_cast<int>(elem_type) - 1];
 }
 
-unsigned ShapeFunctionPool::
-getShapeFunctionArraySize(const MshElemType::type elem_type) const
+unsigned ShapeFunctionPool::getShapeFunctionArraySize(const MshElemType::type elem_type) const
 {
-	return _shape_function_size[static_cast<int>(elem_type)-1];
+	return _shape_function_size[static_cast<int>(elem_type) - 1];
 }
 
-double* ShapeFunctionPool::
-getShapeFunctionCenterValues(const MshElemType::type elem_type) const
+double* ShapeFunctionPool::getShapeFunctionCenterValues(const MshElemType::type elem_type) const
 {
-	assert(_shape_function_center[static_cast<int>(elem_type)-1]);
-	return _shape_function_center[static_cast<int>(elem_type)-1];
+	assert(_shape_function_center[static_cast<int>(elem_type) - 1]);
+	return _shape_function_center[static_cast<int>(elem_type) - 1];
 }
 
-double* ShapeFunctionPool::
-getGradShapeFunctionValues(const MshElemType::type elem_type) const
+double* ShapeFunctionPool::getGradShapeFunctionValues(const MshElemType::type elem_type) const
 {
-	assert(_grad_shape_function[static_cast<int>(elem_type)-1]);
-	return _grad_shape_function[static_cast<int>(elem_type)-1];
+	assert(_grad_shape_function[static_cast<int>(elem_type) - 1]);
+	return _grad_shape_function[static_cast<int>(elem_type) - 1];
 }
 
-double* ShapeFunctionPool::
-getGradShapeFunctionCenterValues(const MshElemType::type elem_type) const
+double* ShapeFunctionPool::getGradShapeFunctionCenterValues(const MshElemType::type elem_type) const
 {
-	assert(_grad_shape_function_center[static_cast<int>(elem_type)-1]);
-	return _grad_shape_function_center[static_cast<int>(elem_type)-1];
+	assert(_grad_shape_function_center[static_cast<int>(elem_type) - 1]);
+	return _grad_shape_function_center[static_cast<int>(elem_type) - 1];
 }
 
 } // end namespace
-
-

--- a/FEM/ShapeFunctionPool.cpp
+++ b/FEM/ShapeFunctionPool.cpp
@@ -38,8 +38,8 @@ ShapeFunctionPool::ShapeFunctionPool(const std::vector<MshElemType::type>& elem_
 		_grad_shape_function_center.push_back(NULL);
 	}
 
-	int num_elem_nodes[2][MshElemType::LAST];
-	int dim_elem[MshElemType::LAST];
+	int num_elem_nodes[2][MshElemType::NUM_ELEM_TYPES];
+	int dim_elem[MshElemType::NUM_ELEM_TYPES];
 
 	int id = static_cast<int>(MshElemType::LINE) - 1;
 	num_elem_nodes[0][id] = 2;
@@ -137,7 +137,8 @@ ShapeFunctionPool::~ShapeFunctionPool()
 }
 
 void ShapeFunctionPool::computeQuadratures(const std::vector<MshElemType::type>& elem_types,
-                                           const int num_elem_nodes[2][MshElemType::LAST], const int dim_elem[],
+                                           const int num_elem_nodes[2][MshElemType::NUM_ELEM_TYPES],
+                                           const int dim_elem[],
                                            CElement& quadrature, const int num_sample_gs_pnts)
 {
 	const int order = quadrature.getOrder();

--- a/FEM/ShapeFunctionPool.h
+++ b/FEM/ShapeFunctionPool.h
@@ -65,7 +65,7 @@ private:
 	std::vector<double*> _grad_shape_function_center;
 
 	void computeQuadratures(const std::vector<MshElemType::type>& elem_types,
-	                        const int num_elem_nodes[2][MshElemType::LAST],
+	                        const int num_elem_nodes[2][MshElemType::NUM_ELEM_TYPES],
 	                        const int dim_elem[],
 	                        CElement& quadrature,
 	                        const int num_sample_gs_pnts);

--- a/FEM/ShapeFunctionPool.h
+++ b/FEM/ShapeFunctionPool.h
@@ -36,6 +36,8 @@ public:
 
 	/// Get shape function values of an element type
 	double* getShapeFunctionValues(const MshElemType::type elem_type) const;
+	/// Get the size of shape function array of an element type.
+	unsigned getShapeFunctionArraySize(const MshElemType::type elem_type) const;
 
 	/// Get shape function values at the element centroid of an element type
 	double* getShapeFunctionCenterValues(const MshElemType::type elem_type) const;
@@ -49,13 +51,18 @@ public:
 private:
 	/// Results of shape functions of all integration points.
 	std::vector<double*> _shape_function; 
+	/// Sizes of the arrays of shape function results.
+	std::vector<unsigned> _shape_function_size;
+
 	/// Results of shape functions of all integration points at element centroid.
 	std::vector<double*> _shape_function_center; 
+
 	/// Results of the gradient of shape functions with respect to
 	/// local coordinates of all integration points.
-	std::vector<double*> _grad_shape_function; 
+	std::vector<double*> _grad_shape_function;
+
 	/// Results of the gradient of shape functions of all integration points at element centroid.
-	std::vector<double*> _grad_shape_function_center; 
+	std::vector<double*> _grad_shape_function_center;
 
 	void computeQuadratures(const std::vector<MshElemType::type>& elem_types,
 		                    const int num_elem_nodes[2][MshElemType::LAST],

--- a/FEM/ShapeFunctionPool.h
+++ b/FEM/ShapeFunctionPool.h
@@ -1,0 +1,68 @@
+/*! \file ShapeFunctionPool.h
+    \brief Compute shape functions and their gradients with respect to
+     the local coodinates, and store the results
+
+     \author Wenqing Wang
+     \date Feb. 2015
+ 
+     \copyright
+      Copyright (c) 2015, OpenGeoSys Community (http://www.opengeosys.org)
+             Distributed under a Modified BSD License.
+             See accompanying file LICENSE.txt or
+             http://www.opengeosys.org/project/license
+*/
+#ifndef OGS_SHAPEFUNCTIONPOOL_H
+#define OGS_SHAPEFUNCTIONPOOL_H
+
+#include <vector>
+
+#include "MSHEnums.h"
+
+namespace FiniteElement
+{
+class CElement;
+
+class ShapeFunctionPool
+{
+public:
+	/*!
+		\param elem_types          All involved element types.
+		\param quadrature          Numerical integration object.
+		\param num_sample_gs_pnts  Number of sample Gauss points.
+	*/
+	ShapeFunctionPool(const std::vector<MshElemType::type>& elem_types,
+		              CElement& quadrature, const int num_sample_gs_pnts);
+	~ShapeFunctionPool();
+
+	/// Get shape function values of an element type
+	double* getShapeFunctionValues(const MshElemType::type elem_type) const;
+
+	/// Get shape function values at the element centroid of an element type
+	double* getShapeFunctionCenterValues(const MshElemType::type elem_type) const;
+
+	/// Get the values of the gradient of shape function of an element type
+	double* getGradShapeFunctionValues(const MshElemType::type elem_type) const;
+
+	/// Get the gradient of shape function values at the element centroid of an element type
+	double* getGradShapeFunctionCenterValues(const MshElemType::type elem_type) const;
+
+private:
+	/// Results of shape functions of all integration points.
+	std::vector<double*> _shape_function; 
+	/// Results of shape functions of all integration points at element centroid.
+	std::vector<double*> _shape_function_center; 
+	/// Results of the gradient of shape functions with respect to
+	/// local coordinates of all integration points.
+	std::vector<double*> _grad_shape_function; 
+	/// Results of the gradient of shape functions of all integration points at element centroid.
+	std::vector<double*> _grad_shape_function_center; 
+
+	void computeQuadratures(const std::vector<MshElemType::type>& elem_types,
+		                    const int num_elem_nodes[2][MshElemType::LAST],
+							const int dim_elem[],
+		                    CElement& quadrature,
+							const int num_sample_gs_pnts);
+};
+} // end namespace
+
+#endif

--- a/FEM/ShapeFunctionPool.h
+++ b/FEM/ShapeFunctionPool.h
@@ -4,7 +4,7 @@
 
      \author Wenqing Wang
      \date Feb. 2015
- 
+
      \copyright
       Copyright (c) 2015, OpenGeoSys Community (http://www.opengeosys.org)
              Distributed under a Modified BSD License.
@@ -26,12 +26,12 @@ class ShapeFunctionPool
 {
 public:
 	/*!
-		\param elem_types          All involved element types.
-		\param quadrature          Numerical integration object.
-		\param num_sample_gs_pnts  Number of sample Gauss points.
+	    \param elem_types          All involved element types.
+	    \param quadrature          Numerical integration object.
+	    \param num_sample_gs_pnts  Number of sample Gauss points.
 	*/
-	ShapeFunctionPool(const std::vector<MshElemType::type>& elem_types,
-		              CElement& quadrature, const int num_sample_gs_pnts);
+	ShapeFunctionPool(const std::vector<MshElemType::type>& elem_types, CElement& quadrature,
+	                  const int num_sample_gs_pnts);
 	~ShapeFunctionPool();
 
 	/// Get shape function values of an element type
@@ -50,12 +50,12 @@ public:
 
 private:
 	/// Results of shape functions of all integration points.
-	std::vector<double*> _shape_function; 
+	std::vector<double*> _shape_function;
 	/// Sizes of the arrays of shape function results.
 	std::vector<unsigned> _shape_function_size;
 
 	/// Results of shape functions of all integration points at element centroid.
-	std::vector<double*> _shape_function_center; 
+	std::vector<double*> _shape_function_center;
 
 	/// Results of the gradient of shape functions with respect to
 	/// local coordinates of all integration points.
@@ -65,10 +65,10 @@ private:
 	std::vector<double*> _grad_shape_function_center;
 
 	void computeQuadratures(const std::vector<MshElemType::type>& elem_types,
-		                    const int num_elem_nodes[2][MshElemType::LAST],
-							const int dim_elem[],
-		                    CElement& quadrature,
-							const int num_sample_gs_pnts);
+	                        const int num_elem_nodes[2][MshElemType::LAST],
+	                        const int dim_elem[],
+	                        CElement& quadrature,
+	                        const int num_sample_gs_pnts);
 };
 } // end namespace
 

--- a/FEM/ShapeFunctionPool.h
+++ b/FEM/ShapeFunctionPool.h
@@ -32,37 +32,35 @@ public:
 	*/
 	ShapeFunctionPool(const std::vector<MshElemType::type>& elem_types, CElement& quadrature,
 	                  const int num_sample_gs_pnts);
-	~ShapeFunctionPool();
+	~ShapeFunctionPool() {}
 
 	/// Get shape function values of an element type
-	double* getShapeFunctionValues(const MshElemType::type elem_type) const;
+	const double* getShapeFunctionValues(const MshElemType::type elem_type) const;
 	/// Get the size of shape function array of an element type.
 	unsigned getShapeFunctionArraySize(const MshElemType::type elem_type) const;
 
 	/// Get shape function values at the element centroid of an element type
-	double* getShapeFunctionCenterValues(const MshElemType::type elem_type) const;
+	const double* getShapeFunctionCenterValues(const MshElemType::type elem_type) const;
 
 	/// Get the values of the gradient of shape function of an element type
-	double* getGradShapeFunctionValues(const MshElemType::type elem_type) const;
+	const double* getGradShapeFunctionValues(const MshElemType::type elem_type) const;
 
 	/// Get the gradient of shape function values at the element centroid of an element type
-	double* getGradShapeFunctionCenterValues(const MshElemType::type elem_type) const;
+	const double* getGradShapeFunctionCenterValues(const MshElemType::type elem_type) const;
 
 private:
 	/// Results of shape functions of all integration points.
-	std::vector<double*> _shape_function;
-	/// Sizes of the arrays of shape function results.
-	std::vector<unsigned> _shape_function_size;
+	std::vector< std::vector<double> > _shape_function;
 
 	/// Results of shape functions of all integration points at element centroid.
-	std::vector<double*> _shape_function_center;
+	std::vector< std::vector<double> > _shape_function_center;
 
 	/// Results of the gradient of shape functions with respect to
 	/// local coordinates of all integration points.
-	std::vector<double*> _grad_shape_function;
+	std::vector< std::vector<double> > _grad_shape_function;
 
 	/// Results of the gradient of shape functions of all integration points at element centroid.
-	std::vector<double*> _grad_shape_function_center;
+	std::vector< std::vector<double> > _grad_shape_function_center;
 
 	void computeQuadratures(const std::vector<MshElemType::type>& elem_types,
 	                        const int num_elem_nodes[2][MshElemType::NUM_ELEM_TYPES],

--- a/FEM/fem_ele.cpp
+++ b/FEM/fem_ele.cpp
@@ -15,6 +15,7 @@
 #include "fem_ele.h"
 
 #include <cfloat>
+#include <cassert>
 
 #include "msh_elem.h"
 #include "rf_pcs.h"
@@ -979,10 +980,16 @@ void CElement::getShapefunctValues(const int gp, const int order) const
 {
 	if(order == 1)
 	{
+		assert(static_cast<unsigned>(gp * nnodes)
+			< _shape_function_pool_ptr[0]->getShapeFunctionArraySize(MeshElement->GetElementType()));
+
 		shapefct = &_shape_function_result_ptr[0][nnodes * gp];
 	}
 	else if(order == 2)
 	{
+		assert(static_cast<unsigned>(gp * nnodesHQ)
+			< _shape_function_pool_ptr[1]->getShapeFunctionArraySize(MeshElement->GetElementType()));
+
 		shapefctHQ = &_shape_function_result_ptr[1][nnodesHQ * gp];
 	}
 }

--- a/FEM/fem_ele.cpp
+++ b/FEM/fem_ele.cpp
@@ -36,14 +36,11 @@ namespace FiniteElement
    Last modified:
 **************************************************************************/
 CElement::CElement(int CoordFlag, const int order)
-	: MeshElement(NULL), Order(order), ele_dim(1), dim_grad(1),
-	  nGaussPoints(1), nGauss(2),
-	  ShapeFunction(NULL), ShapeFunctionHQ(NULL),
-	  GradShapeFunction(NULL), GradShapeFunctionHQ(NULL), _is_mixed_order(false),
-	  T_Flag(false), C_Flag(false), F_Flag(false), D_Flag(0), RD_Flag(false),
-	  extrapo_method(ExtrapolationMethod::EXTRAPO_LINEAR)
+    : MeshElement(NULL), Order(order), ele_dim(1), dim_grad(1), nGaussPoints(1), nGauss(2), ShapeFunction(NULL),
+      ShapeFunctionHQ(NULL), GradShapeFunction(NULL), GradShapeFunctionHQ(NULL), _is_mixed_order(false), T_Flag(false),
+      C_Flag(false), F_Flag(false), D_Flag(0), RD_Flag(false), extrapo_method(ExtrapolationMethod::EXTRAPO_LINEAR)
 {
-	for (int i=0; i<2; i++)
+	for (int i = 0; i < 2; i++)
 	{
 		_shape_function_pool_ptr[i] = NULL;
 		_shape_function_result_ptr[i] = NULL;
@@ -61,34 +58,34 @@ CElement::CElement(int CoordFlag, const int order)
 	//
 	dim = CoordFlag / 10;
 	coordinate_system = CoordFlag;
-	for(int i = 0; i < 4; i++)
+	for (int i = 0; i < 4; i++)
 		unit[i] = 0.0;
 
 	int dim_jacobian = 1;
 	int size_dshapefct = 6;
 	int size_dshapefctHQ = 9;
 	int max_intgration_points = 27;
-	switch(dim)
+	switch (dim)
 	{
-	case 1:                               //OK
-		// Memory allocated for maxium 3 nodes elements
-		dim_jacobian = 1;
-		size_dshapefct = 3 * max_intgration_points;
-		size_dshapefctHQ = 3 * max_intgration_points;
-		break;
-	case 2:
-		// Memory allocated for maxium 9 nodes elements
-		dim_jacobian = 4;
-		size_dshapefct = 18 * max_intgration_points;
-		size_dshapefctHQ = 18 * max_intgration_points;
-		break;
-	case 3:
-		// Memory allocated for maxium 20 nodes elements
-		dim_jacobian = 9;
-		size_dshapefct = 24 * max_intgration_points;
-		size_dshapefctHQ = 60 * max_intgration_points;
-		//
-		break;
+		case 1: // OK
+			// Memory allocated for maxium 3 nodes elements
+			dim_jacobian = 1;
+			size_dshapefct = 3 * max_intgration_points;
+			size_dshapefctHQ = 3 * max_intgration_points;
+			break;
+		case 2:
+			// Memory allocated for maxium 9 nodes elements
+			dim_jacobian = 4;
+			size_dshapefct = 18 * max_intgration_points;
+			size_dshapefctHQ = 18 * max_intgration_points;
+			break;
+		case 3:
+			// Memory allocated for maxium 20 nodes elements
+			dim_jacobian = 9;
+			size_dshapefct = 24 * max_intgration_points;
+			size_dshapefctHQ = 60 * max_intgration_points;
+			//
+			break;
 	}
 
 	Jacobian = new double[dim_jacobian];
@@ -128,11 +125,11 @@ CElement::CElement(int CoordFlag, const int order)
 CElement::~CElement()
 {
 	if (Jacobian)
-		delete  [] Jacobian;
-	delete [] _determinants_all;
-	delete [] _inv_jacobian_all;
-	delete [] _dshapefct_all;
-	delete [] _dshapefctHQ_all;
+		delete[] Jacobian;
+	delete[] _determinants_all;
+	delete[] _inv_jacobian_all;
+	delete[] _dshapefct_all;
+	delete[] _dshapefctHQ_all;
 
 #if defined(USE_PETSC) // || defined(other parallel libs)//03~04.3012. WW
 	if (idxm)
@@ -179,9 +176,9 @@ void CElement::ConfigElement(CElem* MElement, const bool FaceIntegration)
 		if (dim != ele_dim)
 		{
 			dim_grad = dim;
-//            a_node0 = MeshElement->nodes[0];      //07.04.2007. WW
-			double const* const coords_node_0 (MeshElement->nodes[0]->getData());
-			for(int i = 0; i < nNodes; i++)
+			//            a_node0 = MeshElement->nodes[0];      //07.04.2007. WW
+			double const* const coords_node_0(MeshElement->nodes[0]->getData());
+			for (int i = 0; i < nNodes; i++)
 			{
 				double const* const coords_node_i(MeshElement->nodes[i]->getData());
 				//               a_node = MeshElement->nodes[i];    //07.04.2007. WW
@@ -243,11 +240,14 @@ void CElement::ConfigElement(CElem* MElement, const bool FaceIntegration)
 				case 2:
 					if (coordinate_system % 10 == 2)
 					{
-						double const* const coords_node_i (
-						        MeshElement->nodes[i]->getData());
-						X[i] = coords_node_i[0];
-						Y[i] = coords_node_i[2];
-						Z[i] = coords_node_i[1];
+						for (int i = 0; i < nNodes; i++)
+						{
+							double const* const coords_node_i(MeshElement->nodes[i]->getData());
+							X[i] = coords_node_i[0];
+							Y[i] = coords_node_i[2];
+							Z[i] = coords_node_i[1];
+						}
+						done = true;
 					}
 					break;
 			}
@@ -266,23 +266,23 @@ void CElement::ConfigElement(CElem* MElement, const bool FaceIntegration)
 		}
 	}
 #if defined(USE_PETSC) // || defined(other parallel libs)//03~04.3012. WW
-	if(!FaceIntegration)
+	if (!FaceIntegration)
 	{
-		if(MeshElement->g_index) // ghost nodes pcs->pcs_number_of_primary_nvals
+		if (MeshElement->g_index) // ghost nodes pcs->pcs_number_of_primary_nvals
 		{
 			act_nodes = MeshElement->g_index[0];
 			act_nodes_h = MeshElement->g_index[1];
 
-			for(int i = 0; i < act_nodes_h; i++)
+			for (int i = 0; i < act_nodes_h; i++)
 			{
-				local_idx[i] = MeshElement->g_index[i+2];
+				local_idx[i] = MeshElement->g_index[i + 2];
 			}
 		}
 		else
 		{
 			act_nodes = nnodes;
 			act_nodes_h = nnodesHQ;
-			for(int i = 0; i < act_nodes_h; i++)
+			for (int i = 0; i < act_nodes_h; i++)
 			{
 				local_idx[i] = i;
 			}
@@ -314,7 +314,7 @@ void CElement::calculateRadius(const int gp)
 {
 	Radius = 0.0;
 	getShapefunctValues(gp, 1);
-	for(int i = 0; i < nnodes; i++)
+	for (int i = 0; i < nnodes; i++)
 		Radius += shapefct[i] * X[i];
 }
 
@@ -336,42 +336,42 @@ void CElement::setOrder(const int order)
 
 void CElement::SetIntegrationPointNumber(const MshElemType::type elem_type)
 {
-	switch(elem_type)
+	switch (elem_type)
 	{
-	case MshElemType::LINE:
-		//nGauss = 2;
-		nGaussPoints = nGauss;
-		return;
-	case MshElemType::QUAD:
-	case MshElemType::QUAD8:
-		nGaussPoints = nGauss * nGauss;
-		return;
-	case MshElemType::HEXAHEDRON:
-		nGaussPoints = nGauss * nGauss * nGauss;
-		return;
-	case MshElemType::TRIANGLE:
-		nGaussPoints = 3; //nGauss = 3; // Fixed to 3
-		return;
-	case MshElemType::TETRAHEDRON:
-		//	   nGaussPoints = nGauss = 15;  // Fixed to 15
-		nGaussPoints = 5; //nGauss = 5; // Fixed to 5
-		return;
-	case MshElemType::PRISM:
-		nGaussPoints = 6;         // Fixed to 6
-		//nGauss = 3;               // Fixed to 3
-		return;
-	case MshElemType::PYRAMID:
-		if (Order == 1)
-			nGaussPoints = 5; //nGauss = 5;
-		else
-			nGaussPoints = 8; //nGauss = 8;  //13;
-		return;
-	case MshElemType::INVALID:
-		std::cerr << "[CElement::ConfigNumerics] invalid element type" << std::endl;
-		break;
-	default:
-		std::cerr << "[CElement::ConfigNumerics] unknown element type" << std::endl;
-		break;
+		case MshElemType::LINE:
+			// nGauss = 2;
+			nGaussPoints = nGauss;
+			return;
+		case MshElemType::QUAD:
+		case MshElemType::QUAD8:
+			nGaussPoints = nGauss * nGauss;
+			return;
+		case MshElemType::HEXAHEDRON:
+			nGaussPoints = nGauss * nGauss * nGauss;
+			return;
+		case MshElemType::TRIANGLE:
+			nGaussPoints = 3; // nGauss = 3; // Fixed to 3
+			return;
+		case MshElemType::TETRAHEDRON:
+			//	   nGaussPoints = nGauss = 15;  // Fixed to 15
+			nGaussPoints = 5; // nGauss = 5; // Fixed to 5
+			return;
+		case MshElemType::PRISM:
+			nGaussPoints = 6; // Fixed to 6
+			// nGauss = 3;               // Fixed to 3
+			return;
+		case MshElemType::PYRAMID:
+			if (Order == 1)
+				nGaussPoints = 5; // nGauss = 5;
+			else
+				nGaussPoints = 8; // nGauss = 8;  //13;
+			return;
+		case MshElemType::INVALID:
+			std::cerr << "[CElement::ConfigNumerics] invalid element type" << std::endl;
+			break;
+		default:
+			std::cerr << "[CElement::ConfigNumerics] unknown element type" << std::endl;
+			break;
 	}
 }
 
@@ -388,92 +388,92 @@ void CElement::ConfigShapefunction(MshElemType::type elem_type)
 {
 	SetIntegrationPointNumber(elem_type);
 
-	switch(elem_type)
+	switch (elem_type)
 	{
-	case MshElemType::LINE:
-		ele_dim = 1;
-		//nGauss = 2;
-		nGaussPoints = nGauss;
-		ShapeFunction = ShapeFunctionLine;
-		ShapeFunctionHQ = ShapeFunctionLineHQ;
-		GradShapeFunction = GradShapeFunctionLine;
-		GradShapeFunctionHQ = GradShapeFunctionLineHQ;
-		extrapo_method = ExtrapolationMethod::EXTRAPO_LINEAR;
-		return;
-	case MshElemType::QUAD:
-		ele_dim = 2;
-		nGaussPoints = nGauss * nGauss;
-		ShapeFunction = ShapeFunctionQuad;
-		ShapeFunctionHQ = ShapeFunctionQuadHQ;
-		GradShapeFunction = GradShapeFunctionQuad;
-		GradShapeFunctionHQ = GradShapeFunctionQuadHQ;
-		extrapo_method = ExtrapolationMethod::EXTRAPO_LINEAR;
-		return;
-	case MshElemType::QUAD8:
-		ele_dim = 2;
-		nGaussPoints = nGauss * nGauss;
-		ShapeFunction = ShapeFunctionQuad;
-		ShapeFunctionHQ = ShapeFunctionQuadHQ8;
-		GradShapeFunction = GradShapeFunctionQuad;
-		GradShapeFunctionHQ = GradShapeFunctionQuadHQ8;
-		extrapo_method = ExtrapolationMethod::EXTRAPO_LINEAR;
-		return;
-	case MshElemType::HEXAHEDRON:
-		ele_dim = 3;
-		nGaussPoints = nGauss * nGauss * nGauss;
-		ShapeFunction = ShapeFunctionHex;
-		ShapeFunctionHQ = ShapeFunctionHexHQ;
-		GradShapeFunction = GradShapeFunctionHex;
-		GradShapeFunctionHQ = GradShapeFunctionHexHQ;
-		extrapo_method = ExtrapolationMethod::EXTRAPO_LINEAR;
-		return;
-	case MshElemType::TRIANGLE:
-		ele_dim = 2;
-		nGaussPoints = 3; //nGauss = 3; // Fixed to 3
-		ShapeFunction = ShapeFunctionTri;
-		ShapeFunctionHQ = ShapeFunctionTriHQ;
-		GradShapeFunction = GradShapeFunctionTri;
-		GradShapeFunctionHQ = GradShapeFunctionTriHQ;
-		extrapo_method = ExtrapolationMethod::EXTRAPO_LINEAR;
-		return;
-	case MshElemType::TETRAHEDRON:
-		ele_dim = 3;
-		//	   nGaussPoints = nGauss = 15;  // Fixed to 15
-		nGaussPoints = 5; //nGauss = 5; // Fixed to 5
-		ShapeFunction = ShapeFunctionTet;
-		ShapeFunctionHQ = ShapeFunctionTetHQ;
-		GradShapeFunction = GradShapeFunctionTet;
-		GradShapeFunctionHQ = GradShapeFunctionTetHQ;
-		extrapo_method = ExtrapolationMethod::EXTRAPO_LINEAR;
-		return;
-	case MshElemType::PRISM:
-		ele_dim = 3;
-		nGaussPoints = 6;         // Fixed to 6
-		//nGauss = 3;               // Fixed to 3
-		ShapeFunction = ShapeFunctionPri;
-		ShapeFunctionHQ = ShapeFunctionPriHQ;
-		GradShapeFunction = GradShapeFunctionPri;
-		GradShapeFunctionHQ = GradShapeFunctionPriHQ;
-		extrapo_method = ExtrapolationMethod::EXTRAPO_AVERAGE;
-		return;
-	case MshElemType::PYRAMID:
-		ele_dim = 3;
-		if (Order == 1)
-			nGaussPoints = 5; //nGauss = 5;
-		else
-			nGaussPoints = 8; //nGauss = 8;  //13;
-		ShapeFunction = ShapeFunctionPyra;
-		ShapeFunctionHQ = ShapeFunctionPyraHQ13;
-		GradShapeFunction = GradShapeFunctionPyra;
-		GradShapeFunctionHQ = GradShapeFunctionPyraHQ13;
-		extrapo_method = ExtrapolationMethod::EXTRAPO_AVERAGE;
-		return;
-	case MshElemType::INVALID:
-		std::cerr << "[CElement::ConfigNumerics] invalid element type" << std::endl;
-		break;
-	default:
-		std::cerr << "[CElement::ConfigNumerics] unknown element type" << std::endl;
-		break;
+		case MshElemType::LINE:
+			ele_dim = 1;
+			// nGauss = 2;
+			nGaussPoints = nGauss;
+			ShapeFunction = ShapeFunctionLine;
+			ShapeFunctionHQ = ShapeFunctionLineHQ;
+			GradShapeFunction = GradShapeFunctionLine;
+			GradShapeFunctionHQ = GradShapeFunctionLineHQ;
+			extrapo_method = ExtrapolationMethod::EXTRAPO_LINEAR;
+			return;
+		case MshElemType::QUAD:
+			ele_dim = 2;
+			nGaussPoints = nGauss * nGauss;
+			ShapeFunction = ShapeFunctionQuad;
+			ShapeFunctionHQ = ShapeFunctionQuadHQ;
+			GradShapeFunction = GradShapeFunctionQuad;
+			GradShapeFunctionHQ = GradShapeFunctionQuadHQ;
+			extrapo_method = ExtrapolationMethod::EXTRAPO_LINEAR;
+			return;
+		case MshElemType::QUAD8:
+			ele_dim = 2;
+			nGaussPoints = nGauss * nGauss;
+			ShapeFunction = ShapeFunctionQuad;
+			ShapeFunctionHQ = ShapeFunctionQuadHQ8;
+			GradShapeFunction = GradShapeFunctionQuad;
+			GradShapeFunctionHQ = GradShapeFunctionQuadHQ8;
+			extrapo_method = ExtrapolationMethod::EXTRAPO_LINEAR;
+			return;
+		case MshElemType::HEXAHEDRON:
+			ele_dim = 3;
+			nGaussPoints = nGauss * nGauss * nGauss;
+			ShapeFunction = ShapeFunctionHex;
+			ShapeFunctionHQ = ShapeFunctionHexHQ;
+			GradShapeFunction = GradShapeFunctionHex;
+			GradShapeFunctionHQ = GradShapeFunctionHexHQ;
+			extrapo_method = ExtrapolationMethod::EXTRAPO_LINEAR;
+			return;
+		case MshElemType::TRIANGLE:
+			ele_dim = 2;
+			nGaussPoints = 3; // nGauss = 3; // Fixed to 3
+			ShapeFunction = ShapeFunctionTri;
+			ShapeFunctionHQ = ShapeFunctionTriHQ;
+			GradShapeFunction = GradShapeFunctionTri;
+			GradShapeFunctionHQ = GradShapeFunctionTriHQ;
+			extrapo_method = ExtrapolationMethod::EXTRAPO_LINEAR;
+			return;
+		case MshElemType::TETRAHEDRON:
+			ele_dim = 3;
+			//	   nGaussPoints = nGauss = 15;  // Fixed to 15
+			nGaussPoints = 5; // nGauss = 5; // Fixed to 5
+			ShapeFunction = ShapeFunctionTet;
+			ShapeFunctionHQ = ShapeFunctionTetHQ;
+			GradShapeFunction = GradShapeFunctionTet;
+			GradShapeFunctionHQ = GradShapeFunctionTetHQ;
+			extrapo_method = ExtrapolationMethod::EXTRAPO_LINEAR;
+			return;
+		case MshElemType::PRISM:
+			ele_dim = 3;
+			nGaussPoints = 6; // Fixed to 6
+			// nGauss = 3;               // Fixed to 3
+			ShapeFunction = ShapeFunctionPri;
+			ShapeFunctionHQ = ShapeFunctionPriHQ;
+			GradShapeFunction = GradShapeFunctionPri;
+			GradShapeFunctionHQ = GradShapeFunctionPriHQ;
+			extrapo_method = ExtrapolationMethod::EXTRAPO_AVERAGE;
+			return;
+		case MshElemType::PYRAMID:
+			ele_dim = 3;
+			if (Order == 1)
+				nGaussPoints = 5; // nGauss = 5;
+			else
+				nGaussPoints = 8; // nGauss = 8;  //13;
+			ShapeFunction = ShapeFunctionPyra;
+			ShapeFunctionHQ = ShapeFunctionPyraHQ13;
+			GradShapeFunction = GradShapeFunctionPyra;
+			GradShapeFunctionHQ = GradShapeFunctionPyraHQ13;
+			extrapo_method = ExtrapolationMethod::EXTRAPO_AVERAGE;
+			return;
+		case MshElemType::INVALID:
+			std::cerr << "[CElement::ConfigNumerics] invalid element type" << std::endl;
+			break;
+		default:
+			std::cerr << "[CElement::ConfigNumerics] unknown element type" << std::endl;
+			break;
 	}
 }
 
@@ -487,7 +487,7 @@ void CElement::ConfigShapefunction(MshElemType::type elem_type)
 double CElement::interpolate(double const* const nodalVal, const int order) const
 {
 	const int nn = (order == 2) ? nnodesHQ : nnodes;
-	double const * const inTerpo = (order == 2) ? shapefctHQ : shapefct;
+	double const* const inTerpo = (order == 2) ? shapefctHQ : shapefct;
 	double val = 0.0;
 	for (int i = 0; i < nn; i++)
 		val += nodalVal[i] * inTerpo[i];
@@ -561,7 +561,7 @@ void CElement::computeJacobian(const int gp, const int order, const bool inverse
 	double DetJac = 0.0;
 
 	double* dN = NULL;
-	if(order == 2)
+	if (order == 2)
 	{
 		nodes_number = nnodesHQ;
 		dN = dshapefctHQ;
@@ -571,79 +571,80 @@ void CElement::computeJacobian(const int gp, const int order, const bool inverse
 		dN = dshapefct;
 	}
 
-	for(size_t i = 0; i < ele_dim*ele_dim; i++)
+	for (size_t i = 0; i < ele_dim * ele_dim; i++)
 		Jacobian[i] = 0.0;
 	//--------------------------------------------------------------------
 	switch (ele_dim)
 	{
-	//................................................................
-	case 1:
+		//................................................................
+		case 1:
 		{
 			// If Line in X or Z direction, coordinate is saved in local X
 			// If Line in 3D space, a transform is applied and cast coordinate in local X
-			const double dx = X[1] - X[0];         //+Y[1]-Y[0];
+			const double dx = X[1] - X[0]; //+Y[1]-Y[0];
 			Jacobian[0] = 0.5 * dx;
 
 			if (!inverse)
-			return;
+				return;
 
 			invJacobian = &_inv_jacobian_all[gp * 1];
 			invJacobian[0] = 2.0 / dx;
 			DetJac = Jacobian[0];
-			//WW
-			//if(MeshElement->area>0)
-			//DetJac *= MeshElement->area;// Moved to CFiniteElementStd::setMaterial() 
-			//WW          DetJac*=MeshElement->GetFluxArea();//CMCD
-			if(axisymmetry)
+			// WW
+			// if(MeshElement->area>0)
+			// DetJac *= MeshElement->area;// Moved to CFiniteElementStd::setMaterial()
+			// WW          DetJac*=MeshElement->GetFluxArea();//CMCD
+			if (axisymmetry)
 			{
 				calculateRadius(gp);
-				DetJac *= Radius; //2.0*pai*Radius;
+				DetJac *= Radius; // 2.0*pai*Radius;
 			}
 		}
 		break;
-	//................................................................
-	case 2:
-		for(int i = 0,j = nodes_number; i < nodes_number; i++,j++)
-		{
-			Jacobian[0] += X[i] * dN[i];
-			Jacobian[1] += Y[i] * dN[i];
-			Jacobian[2] += X[i] * dN[j];
-			Jacobian[3] += Y[i] * dN[j];
-		}
+		//................................................................
+		case 2:
+			for (int i = 0, j = nodes_number; i < nodes_number; i++, j++)
+			{
+				Jacobian[0] += X[i] * dN[i];
+				Jacobian[1] += Y[i] * dN[i];
+				Jacobian[2] += X[i] * dN[j];
+				Jacobian[3] += Y[i] * dN[j];
+			}
 
-		if (!inverse)
-			return;
+			if (!inverse)
+				return;
 
-		invJacobian = &_inv_jacobian_all[gp * 4];
-		DetJac =  Jacobian[0] * Jacobian[3] - Jacobian[1] * Jacobian[2];
-		if (fabs(DetJac) < MKleinsteZahl)
+			invJacobian = &_inv_jacobian_all[gp * 4];
+			DetJac = Jacobian[0] * Jacobian[3] - Jacobian[1] * Jacobian[2];
+			if (fabs(DetJac) < MKleinsteZahl)
+			{
+				std::cout << "\n*** Jacobian: Det == 0 " << DetJac << "\n";
+				abort();
+			}
+			invJacobian[0] = Jacobian[3];
+			invJacobian[1] = -Jacobian[1];
+			invJacobian[2] = -Jacobian[2];
+			invJacobian[3] = Jacobian[0];
+			for (size_t i = 0; i < ele_dim * ele_dim; i++)
+				invJacobian[i] /= DetJac;
+			//
+			// By WW
+			// if(MeshElement->area>0)
+			// DetJac *= MeshElement->area;// Moved to CFiniteElementStd::setMaterial()
+			// WW          DetJac*=MeshElement->GetFluxArea();//CMCD
+			if (axisymmetry)
+			{
+				calculateRadius(gp);
+				DetJac *= Radius; // 2.0*pai*Radius;
+			}
+			break;
+		//................................................................
+		case 3:
 		{
-			std::cout << "\n*** Jacobian: Det == 0 " << DetJac << "\n";
-			abort();
-		}
-		invJacobian[0] = Jacobian[3];
-		invJacobian[1] = -Jacobian[1];
-		invJacobian[2] = -Jacobian[2];
-		invJacobian[3] = Jacobian[0];
-		for(size_t i = 0; i < ele_dim * ele_dim; i++)
-			invJacobian[i] /= DetJac;
-		//
-		//By WW
-		//if(MeshElement->area>0)
-			//DetJac *= MeshElement->area;// Moved to CFiniteElementStd::setMaterial() 
-		//WW          DetJac*=MeshElement->GetFluxArea();//CMCD
-		if(axisymmetry)
-		{
-			calculateRadius(gp);
-			DetJac *= Radius; //2.0*pai*Radius;
-		}
-		break;
-	//................................................................
-	case 3: {
-		for(int i = 0; i < nodes_number; i++)
-		{
-			const int j = i + nodes_number;
-			const int k = i + 2 * nodes_number;
+			for (int i = 0; i < nodes_number; i++)
+			{
+				const int j = i + nodes_number;
+				const int k = i + 2 * nodes_number;
 
 				Jacobian[0] += X[i] * dN[i];
 				Jacobian[1] += Y[i] * dN[i];
@@ -653,46 +654,43 @@ void CElement::computeJacobian(const int gp, const int order, const bool inverse
 				Jacobian[4] += Y[i] * dN[j];
 				Jacobian[5] += Z[i] * dN[j];
 
-			Jacobian[6] += X[i] * dN[k];
-			Jacobian[7] += Y[i] * dN[k];
-			Jacobian[8] += Z[i] * dN[k];
-		}
+				Jacobian[6] += X[i] * dN[k];
+				Jacobian[7] += Y[i] * dN[k];
+				Jacobian[8] += Z[i] * dN[k];
+			}
 
-		if (!inverse)
-			return;
+			if (!inverse)
+				return;
 
-		invJacobian = &_inv_jacobian_all[gp * 9];
-		DetJac = Jacobian[0] *
-		         (Jacobian[4] * Jacobian[8] - Jacobian[7] * Jacobian[5])
-		         + Jacobian[6] *
-		         (Jacobian[1] * Jacobian[5] - Jacobian[4] * Jacobian[2])
-		         + Jacobian[3] *
-		         (Jacobian[2] * Jacobian[7] - Jacobian[8] * Jacobian[1]);
+			invJacobian = &_inv_jacobian_all[gp * 9];
+			DetJac = Jacobian[0] * (Jacobian[4] * Jacobian[8] - Jacobian[7] * Jacobian[5])
+			         + Jacobian[6] * (Jacobian[1] * Jacobian[5] - Jacobian[4] * Jacobian[2])
+			         + Jacobian[3] * (Jacobian[2] * Jacobian[7] - Jacobian[8] * Jacobian[1]);
 
-		if (fabs(DetJac) < MKleinsteZahl)
-		{
-			std::cout << "\n*** Jacobian: DetJac == 0 " << DetJac << "\n";
-			abort();
-		}
-		invJacobian[0] =  Jacobian[4] * Jacobian[8] - Jacobian[7] * Jacobian[5];
-		invJacobian[1] =  Jacobian[2] * Jacobian[7] - Jacobian[1] * Jacobian[8];
-		invJacobian[2] =  Jacobian[1] * Jacobian[5] - Jacobian[2] * Jacobian[4];
-		//
-		invJacobian[3] =  Jacobian[5] * Jacobian[6] - Jacobian[8] * Jacobian[3];
-		invJacobian[4] =  Jacobian[0] * Jacobian[8] - Jacobian[6] * Jacobian[2];
-		invJacobian[5] =  Jacobian[2] * Jacobian[3] - Jacobian[5] * Jacobian[0];
-		//
-		invJacobian[6] =  Jacobian[3] * Jacobian[7] - Jacobian[6] * Jacobian[4];
-		invJacobian[7] =  Jacobian[1] * Jacobian[6] - Jacobian[7] * Jacobian[0];
-		invJacobian[8] =  Jacobian[0] * Jacobian[4] - Jacobian[3] * Jacobian[1];
-		for(size_t i = 0; i < ele_dim * ele_dim; i++)
-			invJacobian[i] /= DetJac;
-		break;
-	} // end case 3
+			if (fabs(DetJac) < MKleinsteZahl)
+			{
+				std::cout << "\n*** Jacobian: DetJac == 0 " << DetJac << "\n";
+				abort();
+			}
+			invJacobian[0] = Jacobian[4] * Jacobian[8] - Jacobian[7] * Jacobian[5];
+			invJacobian[1] = Jacobian[2] * Jacobian[7] - Jacobian[1] * Jacobian[8];
+			invJacobian[2] = Jacobian[1] * Jacobian[5] - Jacobian[2] * Jacobian[4];
+			//
+			invJacobian[3] = Jacobian[5] * Jacobian[6] - Jacobian[8] * Jacobian[3];
+			invJacobian[4] = Jacobian[0] * Jacobian[8] - Jacobian[6] * Jacobian[2];
+			invJacobian[5] = Jacobian[2] * Jacobian[3] - Jacobian[5] * Jacobian[0];
+			//
+			invJacobian[6] = Jacobian[3] * Jacobian[7] - Jacobian[6] * Jacobian[4];
+			invJacobian[7] = Jacobian[1] * Jacobian[6] - Jacobian[7] * Jacobian[0];
+			invJacobian[8] = Jacobian[0] * Jacobian[4] - Jacobian[3] * Jacobian[1];
+			for (size_t i = 0; i < ele_dim * ele_dim; i++)
+				invJacobian[i] /= DetJac;
+			break;
+		} // end case 3
 	}
 	//--------------------------------------------------------------------
 	// Use absolute value (for grids by gmsh, whose orientation is clockwise)
-	_determinants_all[gp] =  fabs(DetJac);
+	_determinants_all[gp] = fabs(DetJac);
 }
 /***************************************************************************
    GeoSys - Funktion: CElement::RealCoordinates
@@ -713,11 +711,11 @@ void CElement::RealCoordinates(double* realXYZ)
 {
 	int i;
 	double* df = shapefct;
-	if(Order == 2)
+	if (Order == 2)
 	{
 		df = shapefctHQ;
 	}
-	for(i = 0; i < 3; i++)
+	for (i = 0; i < 3; i++)
 		realXYZ[i] = 0.0;
 
 	for (i = 0; i < nNodes; i++)
@@ -771,68 +769,65 @@ void CElement::UnitCoordinates(double* realXYZ)
 		realXYZ[i] = unit[i];
 }
 
-void CElement::SetGaussPoint(const int gp, int& gp_r,
-	                             int& gp_s, int& gp_t)
+void CElement::SetGaussPoint(const int gp, int& gp_r, int& gp_s, int& gp_t)
 {
-	SetGaussPoint(MeshElement->GetElementType(), 
-		          gp, gp_r, gp_s, gp_t);
+	SetGaussPoint(MeshElement->GetElementType(), gp, gp_r, gp_s, gp_t);
 }
 
 /***************************************************************************
 
    08/2005     WW        Prism element
  **************************************************************************/
-void CElement::SetGaussPoint(const MshElemType::type elem_type, 
-	                         const int gp, int& gp_r, int& gp_s, int& gp_t)
+void CElement::SetGaussPoint(const MshElemType::type elem_type, const int gp, int& gp_r, int& gp_s, int& gp_t)
 {
-	switch(elem_type)
+	switch (elem_type)
 	{
-	case MshElemType::LINE:               // Line
-		gp_r = gp;
-		unit[0] = MXPGaussPkt(nGauss, gp_r);
-		return;
-	case MshElemType::QUAD8:               // Quadralateral
-	case MshElemType::QUAD:               // Quadralateral
-		gp_r = (int)(gp / nGauss);
-		gp_s = gp % nGauss;
-		unit[0] = MXPGaussPkt(nGauss, gp_r);
-		unit[1] = MXPGaussPkt(nGauss, gp_s);
-		return;
-	case MshElemType::HEXAHEDRON:         // Hexahedra
-		gp_r = (int)(gp / (nGauss * nGauss));
-		gp_s = (gp % (nGauss * nGauss));
-		gp_t = gp_s % nGauss;
-		gp_s /= nGauss;
-		unit[0] = MXPGaussPkt(nGauss, gp_r);
-		unit[1] = MXPGaussPkt(nGauss, gp_s);
-		unit[2] = MXPGaussPkt(nGauss, gp_t);
-		return;
-	case MshElemType::TRIANGLE:           // Triangle
-		SamplePointTriHQ(gp, unit);
-		break;
-	case MshElemType::TETRAHEDRON:        // Tedrahedra
-		//To be flexible          SamplePointTet15(gp, unit);
-		SamplePointTet5(gp, unit);
-		return;
-	case MshElemType::PRISM:              // Prism
-		// nGaussPoints = 6;         // Fixed to 6
-		// nGauss = 3;               // Fixed to 3
-		gp_r = gp % 3; // gp % nGauss
-		SamplePointTriHQ(gp_r, unit);		
-		//
-		gp_s = nGaussPoints/3; // nGaussPoints/nGauss
-		gp_t = (int)(gp / 3);  // gp/nGauss
-		unit[2] = MXPGaussPkt(gp_s,  gp_t);
-		return;
-	case MshElemType::PYRAMID: // Pyramid
-		if (Order == 1)
-			SamplePointPyramid5(gp, unit);
-		else
-			SamplePointPyramid8(gp, unit);  //SamplePointPyramid13(gp, unit);
-		return;
-	default:
-		std::cerr << "CElement::SetGaussPoint invalid mesh element type given" << std::endl;
-		break;
+		case MshElemType::LINE: // Line
+			gp_r = gp;
+			unit[0] = MXPGaussPkt(nGauss, gp_r);
+			return;
+		case MshElemType::QUAD8: // Quadralateral
+		case MshElemType::QUAD: // Quadralateral
+			gp_r = (int)(gp / nGauss);
+			gp_s = gp % nGauss;
+			unit[0] = MXPGaussPkt(nGauss, gp_r);
+			unit[1] = MXPGaussPkt(nGauss, gp_s);
+			return;
+		case MshElemType::HEXAHEDRON: // Hexahedra
+			gp_r = (int)(gp / (nGauss * nGauss));
+			gp_s = (gp % (nGauss * nGauss));
+			gp_t = gp_s % nGauss;
+			gp_s /= nGauss;
+			unit[0] = MXPGaussPkt(nGauss, gp_r);
+			unit[1] = MXPGaussPkt(nGauss, gp_s);
+			unit[2] = MXPGaussPkt(nGauss, gp_t);
+			return;
+		case MshElemType::TRIANGLE: // Triangle
+			SamplePointTriHQ(gp, unit);
+			break;
+		case MshElemType::TETRAHEDRON: // Tedrahedra
+			// To be flexible          SamplePointTet15(gp, unit);
+			SamplePointTet5(gp, unit);
+			return;
+		case MshElemType::PRISM: // Prism
+			// nGaussPoints = 6;         // Fixed to 6
+			// nGauss = 3;               // Fixed to 3
+			gp_r = gp % 3; // gp % nGauss
+			SamplePointTriHQ(gp_r, unit);
+			//
+			gp_s = nGaussPoints / 3; // nGaussPoints/nGauss
+			gp_t = (int)(gp / 3); // gp/nGauss
+			unit[2] = MXPGaussPkt(gp_s, gp_t);
+			return;
+		case MshElemType::PYRAMID: // Pyramid
+			if (Order == 1)
+				SamplePointPyramid5(gp, unit);
+			else
+				SamplePointPyramid8(gp, unit); // SamplePointPyramid13(gp, unit);
+			return;
+		default:
+			std::cerr << "CElement::SetGaussPoint invalid mesh element type given" << std::endl;
+			break;
 	}
 }
 /***************************************************************************
@@ -853,48 +848,45 @@ void CElement::SetGaussPoint(const MshElemType::type elem_type,
  **************************************************************************/
 double CElement::GetGaussData(int gp, int& gp_r, int& gp_s, int& gp_t)
 {
-	switch(MeshElement->GetElementType())
+	switch (MeshElement->GetElementType())
 	{
-	case MshElemType::LINE:               // Line
-		gp_r = gp;
-		return _determinants_all[gp] * MXPGaussFkt(nGauss, gp_r);
-	case MshElemType::QUAD8:               // Quadralateral
-	case MshElemType::QUAD:               // Quadralateral
-		gp_r = (int)(gp / nGauss);
-		gp_s = gp % nGauss;
-		return _determinants_all[gp] *
-			  MXPGaussFkt(nGauss, gp_r) * MXPGaussFkt(nGauss, gp_s);
-	case MshElemType::HEXAHEDRON:         // Hexahedra
-		gp_r = (int)(gp / (nGauss * nGauss));
-		gp_s = (gp % (nGauss * nGauss));
-		gp_t = gp_s % nGauss;
-		gp_s /= nGauss;
-		return _determinants_all[gp]
-			  * MXPGaussFkt(nGauss, gp_r) * MXPGaussFkt(nGauss, gp_s)
-		      * MXPGaussFkt(nGauss, gp_t);
-	case MshElemType::TRIANGLE:           // Triangle
-		SamplePointTriHQ(gp, unit);
-		return _determinants_all[gp] * unit[2];           // Weights
-	case MshElemType::TETRAHEDRON:        // Tedrahedra
-		//To be flexible          SamplePointTet15(gp, unit);
-		SamplePointTet5(gp, unit);
-		return _determinants_all[gp] * unit[3];           // Weights
-	case MshElemType::PRISM:              // Prism nGauss=3
-		gp_r = gp % 3; // gp % nGauss
-		//
-		gp_s = nGaussPoints/3; // nGaussPoints/nGauss
-		gp_t = (int)(gp / 3);  // gp/nGauss
-		return _determinants_all[gp] * MXPGaussFktTri(3, gp_r)
-			  * MXPGaussFkt(gp_s, gp_t);
-	case MshElemType::PYRAMID: // Pyramid
-		if (Order == 1)
-			SamplePointPyramid5(gp, unit);
-		else
-			SamplePointPyramid8(gp, unit);  //SamplePointPyramid13(gp, unit);
-		return _determinants_all[gp] * unit[3];           // Weights
-	default:
-		std::cerr << "CElement::GetGaussData invalid mesh element type given" << std::endl;
-		return 0.;
+		case MshElemType::LINE: // Line
+			gp_r = gp;
+			return _determinants_all[gp] * MXPGaussFkt(nGauss, gp_r);
+		case MshElemType::QUAD8: // Quadralateral
+		case MshElemType::QUAD: // Quadralateral
+			gp_r = (int)(gp / nGauss);
+			gp_s = gp % nGauss;
+			return _determinants_all[gp] * MXPGaussFkt(nGauss, gp_r) * MXPGaussFkt(nGauss, gp_s);
+		case MshElemType::HEXAHEDRON: // Hexahedra
+			gp_r = (int)(gp / (nGauss * nGauss));
+			gp_s = (gp % (nGauss * nGauss));
+			gp_t = gp_s % nGauss;
+			gp_s /= nGauss;
+			return _determinants_all[gp] * MXPGaussFkt(nGauss, gp_r) * MXPGaussFkt(nGauss, gp_s)
+			       * MXPGaussFkt(nGauss, gp_t);
+		case MshElemType::TRIANGLE: // Triangle
+			SamplePointTriHQ(gp, unit);
+			return _determinants_all[gp] * unit[2]; // Weights
+		case MshElemType::TETRAHEDRON: // Tedrahedra
+			// To be flexible          SamplePointTet15(gp, unit);
+			SamplePointTet5(gp, unit);
+			return _determinants_all[gp] * unit[3]; // Weights
+		case MshElemType::PRISM: // Prism nGauss=3
+			gp_r = gp % 3; // gp % nGauss
+			//
+			gp_s = nGaussPoints / 3; // nGaussPoints/nGauss
+			gp_t = (int)(gp / 3); // gp/nGauss
+			return _determinants_all[gp] * MXPGaussFktTri(3, gp_r) * MXPGaussFkt(gp_s, gp_t);
+		case MshElemType::PYRAMID: // Pyramid
+			if (Order == 1)
+				SamplePointPyramid5(gp, unit);
+			else
+				SamplePointPyramid8(gp, unit); // SamplePointPyramid13(gp, unit);
+			return _determinants_all[gp] * unit[3]; // Weights
+		default:
+			std::cerr << "CElement::GetGaussData invalid mesh element type given" << std::endl;
+			return 0.;
 	}
 	return 0.;
 }
@@ -923,12 +915,12 @@ void CElement::FaceIntegration(double* NodeVal)
 		double fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 
 		getShapefunctValues(gp, Order);
-		double* sf = (Order == 1)? shapefct : shapefctHQ;
+		double* sf = (Order == 1) ? shapefct : shapefctHQ;
 
 		if (this->axisymmetry)
 		{
 			calculateRadius(gp);
-			fkt *= Radius;         //2.0*pai*radius;
+			fkt *= Radius; // 2.0*pai*radius;
 		}
 
 		double val = 0.0;
@@ -949,7 +941,7 @@ void CElement::DomainIntegration(double* NodeVal)
 
 	getShapeFunctionPtr(MeshElement->GetElementType());
 
-	//double det = MeshElement->GetVolume();
+	// double det = MeshElement->GetVolume();
 	for (int i = 0; i < nNodes; i++)
 		dbuff[i] = 0.0;
 	// Loop over Gauss points
@@ -964,9 +956,9 @@ void CElement::DomainIntegration(double* NodeVal)
 		if (this->axisymmetry)
 		{
 			calculateRadius(gp);
-			fkt *= Radius;         //2.0*pai*radius;
+			fkt *= Radius; // 2.0*pai*radius;
 		}
-		double* sf = (Order == 1)? shapefct : shapefctHQ;
+		double* sf = (Order == 1) ? shapefct : shapefctHQ;
 
 		double val = 0.0;
 		// Interpolation of value at Gauss point
@@ -982,17 +974,17 @@ void CElement::DomainIntegration(double* NodeVal)
 
 void CElement::getShapefunctValues(const int gp, const int order) const
 {
-	if(order == 1)
+	if (order == 1)
 	{
 		assert(static_cast<unsigned>(gp * nnodes)
-			< _shape_function_pool_ptr[0]->getShapeFunctionArraySize(MeshElement->GetElementType()));
+		       < _shape_function_pool_ptr[0]->getShapeFunctionArraySize(MeshElement->GetElementType()));
 
 		shapefct = &_shape_function_result_ptr[0][nnodes * gp];
 	}
-	else if(order == 2)
+	else if (order == 2)
 	{
 		assert(static_cast<unsigned>(gp * nnodesHQ)
-			< _shape_function_pool_ptr[1]->getShapeFunctionArraySize(MeshElement->GetElementType()));
+		       < _shape_function_pool_ptr[1]->getShapeFunctionArraySize(MeshElement->GetElementType()));
 
 		shapefctHQ = &_shape_function_result_ptr[1][nnodesHQ * gp];
 	}
@@ -1000,65 +992,55 @@ void CElement::getShapefunctValues(const int gp, const int order) const
 
 void CElement::ComputeShapefct(const int order, double shape_function[])
 {
-	if(order == 1)
+	if (order == 1)
 		ShapeFunction(shape_function, unit);
-	else if(order == 2)
+	else if (order == 2)
 		ShapeFunctionHQ(shape_function, unit);
 }
 
 void CElement::computeGradShapefctLocal(const int order, double grad_shape_fucntion[])
 {
-	if(order == 1)
+	if (order == 1)
 		GradShapeFunction(grad_shape_fucntion, unit);
-	else if(order == 2)
+	else if (order == 2)
 		GradShapeFunctionHQ(grad_shape_fucntion, unit);
 }
 
 void CElement::getShapeFunctionCentroid()
 {
 	if (_shape_function_pool_ptr[0])
-		shapefct
-		= (_shape_function_pool_ptr[0])->getShapeFunctionCenterValues(MeshElement->GetElementType());
+		shapefct = (_shape_function_pool_ptr[0])->getShapeFunctionCenterValues(MeshElement->GetElementType());
 	if (_shape_function_pool_ptr[1])
-		shapefctHQ
-			= (_shape_function_pool_ptr[1])->getShapeFunctionCenterValues(MeshElement->GetElementType());
-
+		shapefctHQ = (_shape_function_pool_ptr[1])->getShapeFunctionCenterValues(MeshElement->GetElementType());
 }
 
 void CElement::getGradShapeFunctionCentroid()
 {
 	if (_shape_function_pool_ptr[0])
-		dshapefct
-		= (_shape_function_pool_ptr[0])->getGradShapeFunctionCenterValues(MeshElement->GetElementType());
+		dshapefct = (_shape_function_pool_ptr[0])->getGradShapeFunctionCenterValues(MeshElement->GetElementType());
 	if (_shape_function_pool_ptr[1])
-		dshapefctHQ
-			= (_shape_function_pool_ptr[1])->getGradShapeFunctionCenterValues(MeshElement->GetElementType());
-
+		dshapefctHQ = (_shape_function_pool_ptr[1])->getGradShapeFunctionCenterValues(MeshElement->GetElementType());
 }
 
 void CElement::getShapeFunctionPtr(const MshElemType::type elem_type)
 {
 	if (_shape_function_pool_ptr[0])
-		_shape_function_result_ptr[0]
-			= (_shape_function_pool_ptr[0])->getShapeFunctionValues(elem_type);
+		_shape_function_result_ptr[0] = (_shape_function_pool_ptr[0])->getShapeFunctionValues(elem_type);
 	if (_shape_function_pool_ptr[1])
-		_shape_function_result_ptr[1]
-			= (_shape_function_pool_ptr[1])->getShapeFunctionValues(elem_type);
+		_shape_function_result_ptr[1] = (_shape_function_pool_ptr[1])->getShapeFunctionValues(elem_type);
 }
 
 void CElement::getGradShapeFunctionPtr(const MshElemType::type elem_type)
 {
 	if (_shape_function_pool_ptr[0])
-		_grad_shape_function_result_ptr[0]
-			= (_shape_function_pool_ptr[0])->getGradShapeFunctionValues(elem_type);
+		_grad_shape_function_result_ptr[0] = (_shape_function_pool_ptr[0])->getGradShapeFunctionValues(elem_type);
 	if (_shape_function_pool_ptr[1])
-		_grad_shape_function_result_ptr[1]
-			= (_shape_function_pool_ptr[1])->getGradShapeFunctionValues(elem_type);
+		_grad_shape_function_result_ptr[1] = (_shape_function_pool_ptr[1])->getGradShapeFunctionValues(elem_type);
 }
 
 void CElement::getGradShapefunctValues(const int gp, const int order) const
 {
-	if(order == 1)
+	if (order == 1)
 	{
 		dshapefct = &_dshapefct_all[nnodes * dim_grad * gp];
 	}
@@ -1085,14 +1067,13 @@ void CElement::getGradShapefunctValues(const int gp, const int order) const
    10/2005     WW        2D element transform in 3D space
    06/2007     WW        1D in 2D
  **************************************************************************/
-void CElement::ComputeGradShapefct(const int gp, const int order,
-	                               const bool is_face_integration)
+void CElement::ComputeGradShapefct(const int gp, const int order, const bool is_face_integration)
 {
 	setOrder(order);
 
 	double* dshp_fct_local = NULL;
 	double* dshp_fct = NULL;
-	if(order == 1)
+	if (order == 1)
 	{
 		dshp_fct_local = dshapefct;
 		dshp_fct = &_dshapefct_all[nNodes * dim_grad * gp];
@@ -1105,16 +1086,19 @@ void CElement::ComputeGradShapefct(const int gp, const int order,
 
 	int j_times_ele_dim_plus_k, j_times_nNodes_plus_i;
 	double Var[3];
-	for(int i = 0; i < nNodes; i++)
+	for (int i = 0; i < nNodes; i++)
 	{
 		size_t j(0);
-		for (j = 0, j_times_nNodes_plus_i = i; j < ele_dim; j++, j_times_nNodes_plus_i += nNodes) {
+		for (j = 0, j_times_nNodes_plus_i = i; j < ele_dim; j++, j_times_nNodes_plus_i += nNodes)
+		{
 			Var[j] = dshp_fct_local[j_times_nNodes_plus_i];
 			dshp_fct[j_times_nNodes_plus_i] = 0.0;
 		}
-		for (j = 0, j_times_ele_dim_plus_k = 0, j_times_nNodes_plus_i = i; j < ele_dim; j++, j_times_nNodes_plus_i
-						+= nNodes) {
-			for (size_t k = 0; k < ele_dim; k++, j_times_ele_dim_plus_k++) {
+		for (j = 0, j_times_ele_dim_plus_k = 0, j_times_nNodes_plus_i = i; j < ele_dim;
+		     j++, j_times_nNodes_plus_i += nNodes)
+		{
+			for (size_t k = 0; k < ele_dim; k++, j_times_ele_dim_plus_k++)
+			{
 				dshp_fct[j_times_nNodes_plus_i] += invJacobian[j_times_ele_dim_plus_k] * Var[k];
 			}
 		}
@@ -1127,8 +1111,8 @@ void CElement::ComputeGradShapefct(const int gp, const int order,
 	if ((dim == 3 && ele_dim == 1) || (dim == 2 && ele_dim == 1))
 		for (int i = 0; i < nNodes; i++)
 		{
-			for(size_t j = 1; j < dim; j++)
-				dshp_fct[j * nNodes + i] = (*MeshElement->transform_tensor)(j) * dshp_fct[i];
+			for (size_t j = 1; j < dim; j++)
+				dshp_fct[j * nNodes + i] = (*MeshElement->transform_tensor)(j)*dshp_fct[i];
 			dshp_fct[i] *= (*MeshElement->transform_tensor)(0);
 		}
 	// 2D element in 3D
@@ -1138,22 +1122,22 @@ void CElement::ComputeGradShapefct(const int gp, const int order,
 		for (size_t i = 0; i < n_nodes_times_ele_dim; i++)
 			dbuff0[i] = dshp_fct[i];
 		for (int i = 0; i < nNodes; i++)
-			for (size_t j = 0; j < dim; j++) {
+			for (size_t j = 0; j < dim; j++)
+			{
 				dshp_fct[j * nNodes + i] = 0.0;
 				for (size_t k = 0; k < ele_dim; k++)
-					dshp_fct[j * nNodes + i] += (*MeshElement->transform_tensor)(j, k) * dbuff0[k
-									* nNodes + i];
+					dshp_fct[j * nNodes + i] += (*MeshElement->transform_tensor)(j, k) * dbuff0[k * nNodes + i];
 			}
 	}
 }
 
 void CElement::getLocalGradShapefunctValues(const int gp, const int order)
 {
-	if(order == 1)
+	if (order == 1)
 	{
 		dshapefct = &_grad_shape_function_result_ptr[0][nnodes * ele_dim * gp];
 	}
-	else if(order == 2)
+	else if (order == 2)
 	{
 		dshapefctHQ = &_grad_shape_function_result_ptr[1][nnodesHQ * ele_dim * gp];
 	}
@@ -1176,13 +1160,12 @@ void CElement::ComputeGradShapefctInElement(const bool is_face_integration)
  **************************************************************************/
 void CElement::SetCenterGP(const MshElemType::type elem_type)
 {
-	const MshElemType::type e_type = (elem_type == MshElemType::INVALID)
-		? MeshElement->GetElementType() : elem_type;
+	const MshElemType::type e_type = (elem_type == MshElemType::INVALID) ? MeshElement->GetElementType() : elem_type;
 	// Center of the reference element
 	unit[0] = unit[1] = unit[2] = 0.0;
-	if(e_type == MshElemType::TRIANGLE)
+	if (e_type == MshElemType::TRIANGLE)
 		unit[0] = unit[1] = 1.0 / 3.0;
-	else if(e_type == MshElemType::TETRAHEDRON)
+	else if (e_type == MshElemType::TETRAHEDRON)
 		unit[0] = unit[1] = unit[2] = 0.25;
 }
 /***************************************************************************
@@ -1227,13 +1210,72 @@ int CElement::GetLocalIndex(const int gp_r, const int gp_s, int gp_t)
 			else if (r > 0.0 && fabs(s) < MKleinsteZahl)
 				LoIndex = 7;
 			else if (fabs(r) < MKleinsteZahl && fabs(s) < MKleinsteZahl)
-				return -1;
-		}
-		break;
-	default:
-		std::cerr << "CElement::GetLocalIndex invalid mesh element type given"
-		          << std::endl;
-		break;
+				LoIndex = 8;
+			break;
+		case MshElemType::HEXAHEDRON: // Hexahedra
+			r = MXPGaussPkt(nGauss, gp_r);
+			s = MXPGaussPkt(nGauss, gp_s);
+			t = MXPGaussPkt(nGauss, gp_t);
+
+			if (t > 0.0)
+			{
+				if (r > 0.0 && s > 0.0)
+					LoIndex = 0;
+				else if (r < 0.0 && s > 0.0)
+					LoIndex = 1;
+				else if (r < 0.0 && s < 0.0)
+					LoIndex = 2;
+				else if (r > 0.0 && s < 0.0)
+					LoIndex = 3;
+				else if (fabs(r) < MKleinsteZahl && s > 0.0)
+					LoIndex = 8;
+				else if (r < 0.0 && fabs(s) < MKleinsteZahl)
+					LoIndex = 9;
+				else if (fabs(r) < MKleinsteZahl && s < 0.0)
+					LoIndex = 10;
+				else if (r > 0.0 && fabs(s) < MKleinsteZahl)
+					LoIndex = 11;
+				else if (fabs(r) < MKleinsteZahl && fabs(s) < MKleinsteZahl)
+					return -1;
+			}
+			else if (fabs(t) < MKleinsteZahl)
+			{
+				if (fabs(r) < MKleinsteZahl || fabs(s) < MKleinsteZahl)
+					return -1;
+				if (r > 0.0 && s > 0.0)
+					LoIndex = 16;
+				else if (r < 0.0 && s > 0.0)
+					LoIndex = 17;
+				else if (r < 0.0 && s < 0.0)
+					LoIndex = 18;
+				else if (r > 0.0 && s < 0.0)
+					LoIndex = 19;
+			}
+			if (t < 0.0)
+			{
+				if (r > 0.0 && s > 0.0)
+					LoIndex = 4;
+				else if (r < 0.0 && s > 0.0)
+					LoIndex = 5;
+				else if (r < 0.0 && s < 0.0)
+					LoIndex = 6;
+				else if (r > 0.0 && s < 0.0)
+					LoIndex = 7;
+				else if (fabs(r) < MKleinsteZahl && s > 0.0)
+					LoIndex = 12;
+				else if (r < 0.0 && fabs(s) < MKleinsteZahl)
+					LoIndex = 13;
+				else if (fabs(r) < MKleinsteZahl && s < 0.0)
+					LoIndex = 14;
+				else if (r > 0.0 && fabs(s) < MKleinsteZahl)
+					LoIndex = 15;
+				else if (fabs(r) < MKleinsteZahl && fabs(s) < MKleinsteZahl)
+					return -1;
+			}
+			break;
+		default:
+			std::cerr << "CElement::GetLocalIndex invalid mesh element type given" << std::endl;
+			break;
 	}
 	return LoIndex;
 }
@@ -1249,64 +1291,78 @@ void CElement::SetExtropoGaussPoints(const int i)
 	//
 	switch (ElementType)
 	{
-	case MshElemType::TRIANGLE:           // Triangle
-		// Compute values at verteces
-		// Compute values at verteces
-		switch (i)
-		{
-		case 0:
-			unit[0] = -0.1666666666667;
-			unit[1] = -0.1666666666667;
+		case MshElemType::TRIANGLE: // Triangle
+			// Compute values at verteces
+			// Compute values at verteces
+			switch (i)
+			{
+				case 0:
+					unit[0] = -0.1666666666667;
+					unit[1] = -0.1666666666667;
+					break;
+				case 1:
+					unit[0] = 1.6666666666667;
+					unit[1] = -0.1666666666667;
+					break;
+				case 2:
+					unit[0] = -0.1666666666667;
+					unit[1] = 1.6666666666667;
+					break;
+			}
 			break;
-		case 1:
-			unit[0] = 1.6666666666667;
-			unit[1] = -0.1666666666667;
+		case MshElemType::QUAD8: // Quadralateral element
+		case MshElemType::QUAD: // Quadralateral element
+			// Extropolation over nodes
+			switch (i)
+			{
+				case 0:
+					unit[0] = Xi_p;
+					unit[1] = Xi_p;
+					break;
+				case 1:
+					unit[0] = -Xi_p;
+					unit[1] = Xi_p;
+					break;
+				case 2:
+					unit[0] = -Xi_p;
+					unit[1] = -Xi_p;
+					break;
+				case 3:
+					unit[0] = Xi_p;
+					unit[1] = -Xi_p;
+					break;
+			}
 			break;
-		case 2:
-			unit[0] = -0.1666666666667;
-			unit[1] = 1.6666666666667;
-			break;
-		}
-		break;
-	case MshElemType::QUAD8:               // Quadralateral element
-	case MshElemType::QUAD:               // Quadralateral element
-		// Extropolation over nodes
-		switch (i)
-		{
-		case 0:
-			unit[0] = Xi_p;
-			unit[1] = Xi_p;
-			break;
-		case 1:
-			unit[0] = -Xi_p;
-			unit[1] = Xi_p;
-			break;
-		case 2:
-			unit[0] = -Xi_p;
-			unit[1] = -Xi_p;
-			break;
-		case 3:
-			unit[0] = Xi_p;
-			unit[1] = -Xi_p;
-			break;
-		}
-		break;
-	case MshElemType::HEXAHEDRON:         // Hexahedra
-		if (i < 4)
-		{
-			j = i;
-			unit[2] = Xi_p;
-		}
-		else
-		{
-			j = i - 4;
-			unit[2] = -Xi_p;
-		}
-		switch (j)
-		{
-		case 0:
-			unit[0] = Xi_p;
-			unit[1] = Xi_p;
+		case MshElemType::HEXAHEDRON: // Hexahedra
+			if (i < 4)
+			{
+				j = i;
+				unit[2] = Xi_p;
+			}
+			else
+			{
+				j = i - 4;
+				unit[2] = -Xi_p;
+			}
+			switch (j)
+			{
+				case 0:
+					unit[0] = Xi_p;
+					unit[1] = Xi_p;
+					break;
+				case 1:
+					unit[0] = -Xi_p;
+					unit[1] = Xi_p;
+					break;
+				case 2:
+					unit[0] = -Xi_p;
+					unit[1] = -Xi_p;
+					break;
+				case 3:
+					unit[0] = Xi_p;
+					unit[1] = -Xi_p;
+					break;
+			}
 			break;
 		case MshElemType::TETRAHEDRON: // Tedrahedra
 			// Compute values at verteces
@@ -1331,6 +1387,7 @@ void CElement::SetExtropoGaussPoints(const int i)
 					unit[0] = -0.166666666666667;
 					unit[1] = -0.166666666666667;
 					unit[2] = 1.5;
+					break;
 			}
 			break;
 		case MshElemType::LINE:
@@ -1341,7 +1398,7 @@ void CElement::SetExtropoGaussPoints(const int i)
 			SamplePointPyramid5(i, unit);
 			break;
 		default:
-			unit[0] = unit[1] = unit[2] = 0.; //07.01.2011. WW
+			unit[0] = unit[1] = unit[2] = 0.; // 07.01.2011. WW
 			break;
 	}
 }
@@ -1354,9 +1411,7 @@ void CElement::SetExtropoGaussPoints(const int i)
 double CElement::CalcXi_p()
 {
 	MshElemType::type ElementType = MeshElement->GetElementType();
-	if (  ElementType == MshElemType::LINE
-		|| ElementType == MshElemType::QUAD
-		|| ElementType == MshElemType::HEXAHEDRON)
+	if (ElementType == MshElemType::LINE || ElementType == MshElemType::QUAD || ElementType == MshElemType::HEXAHEDRON)
 	{
 		double r = .0;
 		for (gp = 0; gp < nGauss; gp++)
@@ -1529,11 +1584,11 @@ void CElement::FaceNormalFluxIntegration(long /*element_index*/, double* NodeVal
 	// Loop over Gauss points
 	for (gp = 0; gp < nGaussPoints; gp++)
 	{
-		int gp_r, gp_s, gp_t;	
+		int gp_r, gp_s, gp_t;
 		const double fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 
 		getShapefunctValues(gp, Order);
-		double const* sf = (Order == 1)? shapefct : shapefctHQ;
+		double const* sf = (Order == 1) ? shapefct : shapefctHQ;
 
 		normal_diff_flux_interpol = 0.0;
 

--- a/FEM/fem_ele.cpp
+++ b/FEM/fem_ele.cpp
@@ -1334,12 +1334,14 @@ void CElement::SetExtropoGaussPoints(const int i)
 			}
 			break;
 		case MshElemType::LINE:
+			unit[0] = -Xi_p;
+			unit[1] = Xi_p;
 			break;
 		case MshElemType::PYRAMID: // WW. 09.2012. WW
 			SamplePointPyramid5(i, unit);
 			break;
 		default:
-			unit[0] = unit[1] = unit[2] = 0.; // 07.01.2011. WW
+			unit[0] = unit[1] = unit[2] = 0.; //07.01.2011. WW
 			break;
 	}
 }
@@ -1351,9 +1353,10 @@ void CElement::SetExtropoGaussPoints(const int i)
  **************************************************************************/
 double CElement::CalcXi_p()
 {
-	double Xi_p = 0.0;
 	MshElemType::type ElementType = MeshElement->GetElementType();
-	if (ElementType == MshElemType::QUAD || ElementType == MshElemType::HEXAHEDRON)
+	if (  ElementType == MshElemType::LINE
+		|| ElementType == MshElemType::QUAD
+		|| ElementType == MshElemType::HEXAHEDRON)
 	{
 		double r = .0;
 		for (gp = 0; gp < nGauss; gp++)
@@ -1364,9 +1367,10 @@ double CElement::CalcXi_p()
 		}
 		r = 1.0 / Xi_p;
 		Xi_p = r;
+		return Xi_p;
 	}
-
-	return Xi_p;
+	else
+		return 0.;
 }
 
 /***************************************************************************

--- a/FEM/fem_ele.cpp
+++ b/FEM/fem_ele.cpp
@@ -589,7 +589,7 @@ void CElement::computeJacobian(const int gp, const int order, const bool inverse
 			DetJac = Jacobian[0];
 			//WW
 			//if(MeshElement->area>0)
-			DetJac *= MeshElement->area;
+			//DetJac *= MeshElement->area;// Moved to CFiniteElementStd::setMaterial() 
 			//WW          DetJac*=MeshElement->GetFluxArea();//CMCD
 			if(axisymmetry)
 			{
@@ -627,7 +627,7 @@ void CElement::computeJacobian(const int gp, const int order, const bool inverse
 		//
 		//By WW
 		//if(MeshElement->area>0)
-		DetJac *= MeshElement->area;
+			//DetJac *= MeshElement->area;// Moved to CFiniteElementStd::setMaterial() 
 		//WW          DetJac*=MeshElement->GetFluxArea();//CMCD
 		if(axisymmetry)
 		{

--- a/FEM/fem_ele.cpp
+++ b/FEM/fem_ele.cpp
@@ -504,14 +504,10 @@ double CElement::interpolate(double const* const nodalVal, const int order) cons
 double CElement::interpolate(const int idx, CRFProcess* m_pcs, const int order)
 {
 	int i;
-	int nn = nnodes;
-	double* inTerpo = shapefct;
+	const int nn = (order == 2) ? nnodesHQ : nnodes;
+	const double* inTerpo = (order == 2) ? shapefctHQ : shapefct;
 	double val = 0.0;
-	if (order == 2)
-	{
-		nn = nnodes;
-		inTerpo = shapefctHQ;
-	}
+
 	//
 	for (i = 0; i < nn; i++)
 		node_val[i] = m_pcs->GetNodeValue(nodes[i], idx);
@@ -557,23 +553,14 @@ double CElement::elemnt_average(const int idx, CRFProcess* m_pcs, const int orde
 **************************************************************************/
 void CElement::computeJacobian(const int gp, const int order, const bool inverse)
 {
-	int nodes_number = nnodes;
-	double DetJac = 0.0;
 
-	double* dN = NULL;
-	if (order == 2)
-	{
-		nodes_number = nnodesHQ;
-		dN = dshapefctHQ;
-	}
-	else
-	{
-		dN = dshapefct;
-	}
+	const int nodes_number = (order == 2) ? nnodesHQ : nnodes;
+	const double* dN = (order == 2) ? dshapefctHQ : dshapefct;
 
 	for (size_t i = 0; i < ele_dim * ele_dim; i++)
 		Jacobian[i] = 0.0;
 	//--------------------------------------------------------------------
+	double DetJac = 0.0;
 	switch (ele_dim)
 	{
 		//................................................................
@@ -710,11 +697,8 @@ void CElement::computeJacobian(const int gp, const int order, const bool inverse
 void CElement::RealCoordinates(double* realXYZ)
 {
 	int i;
-	double* df = shapefct;
-	if (Order == 2)
-	{
-		df = shapefctHQ;
-	}
+	const double* df = (Order == 2) ? shapefctHQ : shapefct;
+
 	for (i = 0; i < 3; i++)
 		realXYZ[i] = 0.0;
 
@@ -915,7 +899,7 @@ void CElement::FaceIntegration(double* NodeVal)
 		double fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 
 		getShapefunctValues(gp, Order);
-		double* sf = (Order == 1) ? shapefct : shapefctHQ;
+		const double* sf = (Order == 1) ? shapefct : shapefctHQ;
 
 		if (this->axisymmetry)
 		{
@@ -958,7 +942,7 @@ void CElement::DomainIntegration(double* NodeVal)
 			calculateRadius(gp);
 			fkt *= Radius; // 2.0*pai*radius;
 		}
-		double* sf = (Order == 1) ? shapefct : shapefctHQ;
+		const double* sf = (Order == 1) ? shapefct : shapefctHQ;
 
 		double val = 0.0;
 		// Interpolation of value at Gauss point
@@ -1071,16 +1055,15 @@ void CElement::ComputeGradShapefct(const int gp, const int order, const bool is_
 {
 	setOrder(order);
 
-	double* dshp_fct_local = NULL;
 	double* dshp_fct = NULL;
+	const double* dshp_fct_local = (order == 1) ? dshapefct : dshapefctHQ;
+
 	if (order == 1)
 	{
-		dshp_fct_local = dshapefct;
 		dshp_fct = &_dshapefct_all[nNodes * dim_grad * gp];
 	}
 	else
 	{
-		dshp_fct_local = dshapefctHQ;
 		dshp_fct = &_dshapefctHQ_all[nNodes * dim_grad * gp];
 	}
 

--- a/FEM/fem_ele.cpp
+++ b/FEM/fem_ele.cpp
@@ -39,7 +39,7 @@ CElement::CElement(int CoordFlag, const int order)
 	  ShapeFunction(NULL), ShapeFunctionHQ(NULL),
 	  GradShapeFunction(NULL), GradShapeFunctionHQ(NULL), _is_mixed_order(false),
 	  T_Flag(false), C_Flag(false), F_Flag(false), D_Flag(0), RD_Flag(false),
-	  extrapo_method(ExtrapolationMethod::EXTRAPO_LINEAR), invJacobian(NULL)
+	  extrapo_method(ExtrapolationMethod::EXTRAPO_LINEAR)
 {
 	for (int i=0; i<2; i++)
 	{
@@ -987,12 +987,12 @@ void CElement::getShapefunctValues(const int gp, const int order) const
 	}
 }
 
-void CElement::ComputeShapefct(const int order, double shape_fucntion[])
+void CElement::ComputeShapefct(const int order, double shape_function[])
 {
 	if(order == 1)
-		ShapeFunction(shape_fucntion, unit);
+		ShapeFunction(shape_function, unit);
 	else if(order == 2)
-		ShapeFunctionHQ(shape_fucntion, unit);
+		ShapeFunctionHQ(shape_function, unit);
 }
 
 void CElement::computeGradShapefctLocal(const int order, double grad_shape_fucntion[])

--- a/FEM/fem_ele.cpp
+++ b/FEM/fem_ele.cpp
@@ -36,7 +36,7 @@ namespace FiniteElement
    Last modified:
 **************************************************************************/
 CElement::CElement(int CoordFlag, const int order)
-	: MeshElement(NULL), Order(order), ele_dim(1), nGaussPoints(1), nGauss(3),
+	: MeshElement(NULL), Order(order), ele_dim(1), nGaussPoints(1), nGauss(2),
 	  ShapeFunction(NULL), ShapeFunctionHQ(NULL),
 	  GradShapeFunction(NULL), GradShapeFunctionHQ(NULL), _is_mixed_order(false),
 	  T_Flag(false), C_Flag(false), F_Flag(false), D_Flag(0), RD_Flag(false),
@@ -262,7 +262,6 @@ void CElement::ConfigElement(CElem* MElement, const bool FaceIntegration)
 			Z[i] = coords[2];
 		}
 	}
-
 #if defined(USE_PETSC) // || defined(other parallel libs)//03~04.3012. WW
 	if(!FaceIntegration)
 	{

--- a/FEM/fem_ele.cpp
+++ b/FEM/fem_ele.cpp
@@ -36,9 +36,12 @@ namespace FiniteElement
    Last modified:
 **************************************************************************/
 CElement::CElement(int CoordFlag, const int order)
-    : MeshElement(NULL), Order(order), ele_dim(1), dim_grad(1), nGaussPoints(1), nGauss(2), ShapeFunction(NULL),
-      ShapeFunctionHQ(NULL), GradShapeFunction(NULL), GradShapeFunctionHQ(NULL), _is_mixed_order(false), T_Flag(false),
-      C_Flag(false), F_Flag(false), D_Flag(0), RD_Flag(false), extrapo_method(ExtrapolationMethod::EXTRAPO_LINEAR)
+    : MeshElement(NULL), Order(order), ele_dim(1), _ele_global_dim(1),
+      nGaussPoints(1), nGauss(2), ShapeFunction(NULL),
+      ShapeFunctionHQ(NULL), GradShapeFunction(NULL), GradShapeFunctionHQ(NULL),
+      _is_mixed_order(false), T_Flag(false),
+      C_Flag(false), F_Flag(false), D_Flag(0), RD_Flag(false),
+      extrapo_method(ExtrapolationMethod::EXTRAPO_LINEAR)
 {
 	for (int i = 0; i < 2; i++)
 	{
@@ -160,7 +163,7 @@ void CElement::ConfigElement(CElem* MElement, const bool FaceIntegration)
 	nnodes = MeshElement->nnodes;
 	nnodesHQ = MeshElement->nnodesHQ;
 	ele_dim = MeshElement->GetDimension();
-	dim_grad = ele_dim;
+	_ele_global_dim = ele_dim;
 	bool done = false;
 	if (MeshElement->quadratic)
 		nNodes = nnodesHQ;
@@ -174,7 +177,7 @@ void CElement::ConfigElement(CElem* MElement, const bool FaceIntegration)
 	{
 		if (dim != ele_dim)
 		{
-			dim_grad = dim;
+			_ele_global_dim = dim;
 			//            a_node0 = MeshElement->nodes[0];      //07.04.2007. WW
 			double const* const coords_node_0(MeshElement->nodes[0]->getData());
 			for (int i = 0; i < nNodes; i++)
@@ -1025,11 +1028,11 @@ void CElement::getGradShapefunctValues(const int gp, const int order) const
 {
 	if (order == 1)
 	{
-		dshapefct = &_dshapefct_all[nnodes * dim_grad * gp];
+		dshapefct = &_dshapefct_all[nnodes * _ele_global_dim * gp];
 	}
 	else
 	{
-		dshapefctHQ = &_dshapefctHQ_all[nnodesHQ * dim_grad * gp];
+		dshapefctHQ = &_dshapefctHQ_all[nnodesHQ * _ele_global_dim * gp];
 	}
 }
 
@@ -1059,11 +1062,11 @@ void CElement::ComputeGradShapefct(const int gp, const int order, const bool is_
 
 	if (order == 1)
 	{
-		dshp_fct = &_dshapefct_all[nNodes * dim_grad * gp];
+		dshp_fct = &_dshapefct_all[nNodes * _ele_global_dim * gp];
 	}
 	else
 	{
-		dshp_fct = &_dshapefctHQ_all[nNodes * dim_grad * gp];
+		dshp_fct = &_dshapefctHQ_all[nNodes * _ele_global_dim * gp];
 	}
 
 	int j_times_ele_dim_plus_k, j_times_nNodes_plus_i;

--- a/FEM/fem_ele.cpp
+++ b/FEM/fem_ele.cpp
@@ -711,9 +711,11 @@ void CElement::RealCoordinates(double* realXYZ)
 {
 	int i;
 	double* df = shapefct;
-	if (Order == 2)
+	if(Order == 2)
+	{
 		df = shapefctHQ;
-	for (i = 0; i < 3; i++)
+	}
+	for(i = 0; i < 3; i++)
 		realXYZ[i] = 0.0;
 
 	for (i = 0; i < nNodes; i++)

--- a/FEM/fem_ele.cpp
+++ b/FEM/fem_ele.cpp
@@ -1396,17 +1396,19 @@ void CElement::SetExtropoGaussPoints(const int i)
 double CElement::CalcXi_p()
 {
 	MshElemType::type ElementType = MeshElement->GetElementType();
-	if (ElementType == MshElemType::LINE || ElementType == MshElemType::QUAD || ElementType == MshElemType::HEXAHEDRON)
+	Xi_p = 0.0;
+	if (   ElementType == MshElemType::LINE
+		|| ElementType == MshElemType::QUAD
+		|| ElementType == MshElemType::QUAD8
+		|| ElementType == MshElemType::HEXAHEDRON)
 	{
-		double r = .0;
 		for (gp = 0; gp < nGauss; gp++)
 		{
-			r = MXPGaussPkt(nGauss, gp);
-			if (fabs(r) > Xi_p)
-				Xi_p = fabs(r);
+			const double r = fabs(MXPGaussPkt(nGauss, gp));
+			if (r > Xi_p)
+				Xi_p = r;
 		}
-		r = 1.0 / Xi_p;
-		Xi_p = r;
+		Xi_p = 1.0 / Xi_p;
 		return Xi_p;
 	}
 	else

--- a/FEM/fem_ele.cpp
+++ b/FEM/fem_ele.cpp
@@ -36,7 +36,8 @@ namespace FiniteElement
    Last modified:
 **************************************************************************/
 CElement::CElement(int CoordFlag, const int order)
-	: MeshElement(NULL), Order(order), ele_dim(1), nGaussPoints(1), nGauss(2),
+	: MeshElement(NULL), Order(order), ele_dim(1), dim_grad(1),
+	  nGaussPoints(1), nGauss(2),
 	  ShapeFunction(NULL), ShapeFunctionHQ(NULL),
 	  GradShapeFunction(NULL), GradShapeFunctionHQ(NULL), _is_mixed_order(false),
 	  T_Flag(false), C_Flag(false), F_Flag(false), D_Flag(0), RD_Flag(false),
@@ -163,6 +164,7 @@ void CElement::ConfigElement(CElem* MElement, const bool FaceIntegration)
 	nnodes = MeshElement->nnodes;
 	nnodesHQ = MeshElement->nnodesHQ;
 	ele_dim = MeshElement->GetDimension();
+	dim_grad = ele_dim;
 	bool done = false;
 	if (MeshElement->quadratic)
 		nNodes = nnodesHQ;
@@ -176,9 +178,10 @@ void CElement::ConfigElement(CElem* MElement, const bool FaceIntegration)
 	{
 		if (dim != ele_dim)
 		{
-			//            a_node0 = MeshElement->nodes[0];      //07.04.2007. WW
-			double const* const coords_node_0(MeshElement->nodes[0]->getData());
-			for (int i = 0; i < nNodes; i++)
+			dim_grad = dim;
+//            a_node0 = MeshElement->nodes[0];      //07.04.2007. WW
+			double const* const coords_node_0 (MeshElement->nodes[0]->getData());
+			for(int i = 0; i < nNodes; i++)
 			{
 				double const* const coords_node_i(MeshElement->nodes[i]->getData());
 				//               a_node = MeshElement->nodes[i];    //07.04.2007. WW
@@ -1057,11 +1060,11 @@ void CElement::getGradShapefunctValues(const int gp, const int order) const
 {
 	if(order == 1)
 	{
-		dshapefct = &_dshapefct_all[nnodes * ele_dim * gp];
+		dshapefct = &_dshapefct_all[nnodes * dim_grad * gp];
 	}
 	else
 	{
-		dshapefctHQ = &_dshapefctHQ_all[nnodesHQ * ele_dim * gp];
+		dshapefctHQ = &_dshapefctHQ_all[nnodesHQ * dim_grad * gp];
 	}
 }
 
@@ -1092,12 +1095,12 @@ void CElement::ComputeGradShapefct(const int gp, const int order,
 	if(order == 1)
 	{
 		dshp_fct_local = dshapefct;
-		dshp_fct = &_dshapefct_all[nNodes * ele_dim * gp];
+		dshp_fct = &_dshapefct_all[nNodes * dim_grad * gp];
 	}
 	else
 	{
 		dshp_fct_local = dshapefctHQ;
-		dshp_fct = &_dshapefctHQ_all[nNodes * ele_dim * gp];
+		dshp_fct = &_dshapefctHQ_all[nNodes * dim_grad * gp];
 	}
 
 	int j_times_ele_dim_plus_k, j_times_nNodes_plus_i;

--- a/FEM/fem_ele.h
+++ b/FEM/fem_ele.h
@@ -88,13 +88,13 @@ public:
 	// Set Gauss point
 	void SetGaussPoint(const int gp, int& gp_r, int& gp_s, int& gp_t);
 
-	void setShapeFunctionPool(ShapeFunctionPool* const lin_shape_fct_pool, ShapeFunctionPool* const quad_shape_fct_pool)
+	void setShapeFunctionPool(const ShapeFunctionPool* const lin_shape_fct_pool, const ShapeFunctionPool* const quad_shape_fct_pool)
 	{
 		_shape_function_pool_ptr[0] = lin_shape_fct_pool;
 		_shape_function_pool_ptr[1] = quad_shape_fct_pool;
 	};
 
-	ShapeFunctionPool* getShapeFunctionPool(int order_id) const { return _shape_function_pool_ptr[order_id]; }
+	const ShapeFunctionPool* getShapeFunctionPool(int order_id) const { return _shape_function_pool_ptr[order_id]; }
 
 	// Get Gauss integration information
 	double GetGaussData(int gp, int& gp_r, int& gp_s, int& gp_t);
@@ -227,13 +227,13 @@ protected:
 	/// Pointer to _inv_jacobian_all for a integation point
 	double* invJacobian;
 	/// Pointer to _shape_function_pool_ptr for a integation point
-	mutable double* shapefct;
+	mutable const double* shapefct;
 	/// Pointer to _shape_function_pool_ptr for a integation point
-	mutable double* shapefctHQ;
+	mutable const double* shapefctHQ;
 	/// Pointer to _dshapefct_all for a integation point
-	mutable double* dshapefct;
+	mutable const double* dshapefct;
 	/// Pointer to _dshapefctHQ_all for a integation point
-	mutable double* dshapefctHQ;
+	mutable const double* dshapefctHQ;
 
 	/// The values of the determinants of the inversed Jacobians
 	/// of all integation points.
@@ -258,14 +258,14 @@ protected:
 
 	/// Pointers to ShapeFunctionPool for two orders.
 	/// [0]: Linear, [1] Quadratic
-	ShapeFunctionPool* _shape_function_pool_ptr[2];
+	mutable const ShapeFunctionPool* _shape_function_pool_ptr[2];
 	/// Pointers to the start element of the shape function result array
 	//  for the present element for two orders.
 	/// [0]: Linear, [1] Quadratic
-	double* _shape_function_result_ptr[2];
+	mutable const double* _shape_function_result_ptr[2];
 	/// Pointers to the start element of the gradient (local) shape function
 	//  result array for the present element for two orders.
-	double* _grad_shape_function_result_ptr[2];
+	mutable const double* _grad_shape_function_result_ptr[2];
 
 	void getGradShapeFunctionPtr(const MshElemType::type elem_type);
 

--- a/FEM/fem_ele.h
+++ b/FEM/fem_ele.h
@@ -99,6 +99,11 @@ public:
 		_shape_function_pool_ptr[1] = quad_shape_fct_pool;
 	};
 
+	ShapeFunctionPool* getShapeFunctionPool(int order_id) const
+	{
+		return _shape_function_pool_ptr[order_id];
+	}
+
 	// Get Gauss integration information
 	double GetGaussData(int gp, int& gp_r, int& gp_s, int& gp_t);
 

--- a/FEM/fem_ele.h
+++ b/FEM/fem_ele.h
@@ -229,8 +229,9 @@ protected:
 	// Order of shape functions
 	// Displacement, 2. Others, 1. Default, 1
 	int Order;
-	size_t ele_dim;                          // Dimension of element
-	size_t dim;                              // Dimension of real dimension
+	size_t ele_dim;                       // Dimension of element
+	size_t dim;                           // Dimension of real dimension
+	size_t dim_grad;                      // Gradient dimension
 	int nGaussPoints;                     // Number of Gauss points
 	int nGauss;                           // Number of sample points for Gauss integration
 	int gp;                               // Gauss point index.

--- a/FEM/fem_ele.h
+++ b/FEM/fem_ele.h
@@ -79,30 +79,22 @@ public:
 	//
 	void ConfigElement(CElem* MElement, const bool FaceIntegration = false);
 
-	void setElement(CElem* MElement)
-	{MeshElement = MElement;}
+	void setElement(CElem* MElement) { MeshElement = MElement; }
 
 	void setOrder(const int order);
-	int getOrder() const {return Order;}
+	int getOrder() const { return Order; }
 	// Set Gauss point
-	void SetGaussPoint(const MshElemType::type elem_type, const int gp,
-		               int& gp_r, int& gp_s, int& gp_t);
+	void SetGaussPoint(const MshElemType::type elem_type, const int gp, int& gp_r, int& gp_s, int& gp_t);
 	// Set Gauss point
 	void SetGaussPoint(const int gp, int& gp_r, int& gp_s, int& gp_t);
 
-	void setShapeFunctionPool(ShapeFunctionPool* const
-						      lin_shape_fct_pool, 
-							  ShapeFunctionPool* const
-						      quad_shape_fct_pool)
+	void setShapeFunctionPool(ShapeFunctionPool* const lin_shape_fct_pool, ShapeFunctionPool* const quad_shape_fct_pool)
 	{
 		_shape_function_pool_ptr[0] = lin_shape_fct_pool;
 		_shape_function_pool_ptr[1] = quad_shape_fct_pool;
 	};
 
-	ShapeFunctionPool* getShapeFunctionPool(int order_id) const
-	{
-		return _shape_function_pool_ptr[order_id];
-	}
+	ShapeFunctionPool* getShapeFunctionPool(int order_id) const { return _shape_function_pool_ptr[order_id]; }
 
 	// Get Gauss integration information
 	double GetGaussData(int gp, int& gp_r, int& gp_s, int& gp_t);
@@ -119,8 +111,7 @@ public:
 	// Compute values of shape function at integral point unit
 	void ComputeShapefct(const int order, double shape_function[]);
 	// Compute the Jacobian matrix. Return its determinate
-	void computeJacobian(const int gp, const int order,
-		                 const bool inverse = true);
+	void computeJacobian(const int gp, const int order, const bool inverse = true);
 
 	// Get the pointer to the gradient of shape function array
 	// in the shape function pool for element centroid
@@ -130,15 +121,11 @@ public:
 	// Compute values of the derivatives of shape function at integral point
 	void ComputeGradShapefctInElement(const bool is_face_integration);
 	// Compute values of the derivatives of shape function at integral point
-	void ComputeGradShapefct(const int gp, const int order,
-		                     const bool is_face_integration = false);
+	void ComputeGradShapefct(const int gp, const int order, const bool is_face_integration = false);
 	// Compute values of the derivatives of shape function at integral point
 	void computeGradShapefctLocal(const int order, double grad_shape_fucntion[]);
-	
-	void setMixedOrderFlag(const bool is_mixed_order)
-	{
-		_is_mixed_order = is_mixed_order;
-	}
+
+	void setMixedOrderFlag(const bool is_mixed_order) { _is_mixed_order = is_mixed_order; }
 
 	// Compute the real coordinates from known unit coordinates
 	void RealCoordinates(double* realXYZ);
@@ -157,19 +144,16 @@ public:
 	// Compute the local finite element matrices
 	void LocalAssembly(const long, const int) {}
 	// Set the number of Gauss points
-	//26.03.2007 WW
-	void SetGaussPointNumber(const int nGuassP)
-	{
-		nGauss = nGuassP;
-	}
+	// 26.03.2007 WW
+	void SetGaussPointNumber(const int nGuassP) { nGauss = nGuassP; }
 
 	void SetIntegrationPointNumber(const MshElemType::type elem_type);
 
 	// Get values;
-	int GetNumGaussPoints() const {return nGaussPoints; }
-	int GetNumGaussSamples() const {return nGauss; }
-	int Dim() const {return ele_dim; }
-	double Getdshapefct(int in) {return dshapefct[in];}
+	int GetNumGaussPoints() const { return nGaussPoints; }
+	int GetNumGaussSamples() const { return nGauss; }
+	int Dim() const { return ele_dim; }
+	double Getdshapefct(int in) { return dshapefct[in]; }
 
 	// Integrate Neumman type BC
 	void FaceIntegration(double* NodeVal);
@@ -184,6 +168,7 @@ public:
 	bool isFluidPressureCoupling() const { return F_Flag; }
 	int isDeformationCoupling() const { return D_Flag; }
 	int isConcentrationCoupling() const { return C_Flag; }
+
 	// Interpolate Gauss values
 	double interpolate(double const* const nodalVal, const int order = 1) const;
 	double interpolate(const int idx, CRFProcess* m_pcs, const int order = 1);
@@ -191,9 +176,9 @@ public:
 	double elemnt_average(const int idx, CRFProcess* m_pcs, const int order = 1);
 
 	void SetCenterGP(const MshElemType::type elem_type = MshElemType::INVALID);
-	int GetGPindex() const {return gp; }
-	int GetElementIndex() const {return Index; }
-	CElem* GetMeshElement() const         //OK
+	int GetGPindex() const { return gp; }
+	int GetElementIndex() const { return Index; }
+	CElem* GetMeshElement() const // OK
 	{
 		return MeshElement;
 	}
@@ -202,6 +187,7 @@ public:
 
 	// DDC 05/2006
 	void SetElementNodesDomain(long* ele_nodes) { element_nodes_dom = ele_nodes; }
+
 	void SetRWPT(const int idx) // PCH
 	{
 		PT_Flag = idx;
@@ -229,15 +215,15 @@ protected:
 	// Order of shape functions
 	// Displacement, 2. Others, 1. Default, 1
 	int Order;
-	size_t ele_dim;                       // Dimension of element
-	size_t dim;                           // Dimension of real dimension
-	size_t dim_grad;                      // Gradient dimension
-	int nGaussPoints;                     // Number of Gauss points
-	int nGauss;                           // Number of sample points for Gauss integration
-	int gp;                               // Gauss point index.
-	mutable double unit[4];               // Local coordintes
+	size_t ele_dim; // Dimension of element
+	size_t dim; // Dimension of real dimension
+	size_t dim_grad; // Gradient dimension
+	int nGaussPoints; // Number of Gauss points
+	int nGauss; // Number of sample points for Gauss integration
+	int gp; // Gauss point index.
+	mutable double unit[4]; // Local coordintes
 
-	double* Jacobian;                     // Jacobian matrix
+	double* Jacobian; // Jacobian matrix
 	/// Pointer to _inv_jacobian_all for a integation point
 	double* invJacobian;
 	/// Pointer to _shape_function_pool_ptr for a integation point
@@ -250,9 +236,9 @@ protected:
 	mutable double* dshapefctHQ;
 
 	/// The values of the determinants of the inversed Jacobians
-	/// of all integation points. 
+	/// of all integation points.
 	double* _determinants_all;
-	/// The values of the inversed Jacobians of all integation points. 
+	/// The values of the inversed Jacobians of all integation points.
 	double* _inv_jacobian_all;
 	/// The values of derivatives of linear shape functions all integation points.
 	double* _dshapefct_all;
@@ -325,19 +311,19 @@ protected:
 	double Z[20];
 	double node_val[20];
 	double dbuff[20];
-	double dbuff0[27];                 // Auxullary
+	double dbuff0[27]; // Auxullary
 
 #if defined(USE_PETSC) // || defined(other parallel libs)//03~04.3012. WW
 	int act_nodes; //> activated nodes
 	int act_nodes_h; //> activated nodes for high order elements
-	int *idxm;  //> global indices of local matrix rows
-	int *idxn;  //> global indices of local matrix columns
-	int *local_idx; //> local index for local assemble
-	//double *local_matrix; //>  local matrix
-	//double *local_vec; //>  local vector
+	int* idxm; //> global indices of local matrix rows
+	int* idxn; //> global indices of local matrix columns
+	int* local_idx; //> local index for local assemble
+// double *local_matrix; //>  local matrix
+// double *local_vec; //>  local vector
 #endif
 	ExtrapolationMethod::type extrapo_method;
-	ExtrapolationMethod::type GetExtrapoMethod() {return extrapo_method; }
+	ExtrapolationMethod::type GetExtrapoMethod() { return extrapo_method; }
 };
 
 /*------------------------------------------------------------------
@@ -388,6 +374,7 @@ public:
 	Matrix* GetCouplingMatrixA() { return CouplingA; }
 	Matrix* GetCouplingMatrixB() { return CouplingB; }
 	Vec* GetRHS() { return RHS; }
+
 private:
 	// TODO in more gernal way for the case of sym and unsym. WW      SymMatrix *Mass;
 	//      SymMatrix *Laplace;

--- a/FEM/fem_ele.h
+++ b/FEM/fem_ele.h
@@ -215,9 +215,12 @@ protected:
 	// Order of shape functions
 	// Displacement, 2. Others, 1. Default, 1
 	int Order;
+
 	size_t ele_dim; // Dimension of element
-	size_t dim; // Dimension of real dimension
-	size_t dim_grad; // Gradient dimension
+	size_t dim;     // Dimension of the space
+	// Dimension of the space where an element exists.
+	size_t _ele_global_dim;
+
 	int nGaussPoints; // Number of Gauss points
 	int nGauss; // Number of sample points for Gauss integration
 	int gp; // Gauss point index.

--- a/FEM/fem_ele.h
+++ b/FEM/fem_ele.h
@@ -111,7 +111,7 @@ public:
 	// Compute values of shape function at integral point unit
 	void ComputeShapefct(const int order, double shape_function[]);
 	// Compute the Jacobian matrix. Return its determinate
-	void computeJacobian(const int gp, const int order, const bool inverse = true);
+	void computeJacobian(const int gp, const int order, const bool need_inverse = true);
 
 	// Get the pointer to the gradient of shape function array
 	// in the shape function pool for element centroid
@@ -223,7 +223,7 @@ protected:
 	int gp; // Gauss point index.
 	mutable double unit[4]; // Local coordintes
 
-	double* Jacobian; // Jacobian matrix
+	double* _Jacobian; // Jacobian matrix
 	/// Pointer to _inv_jacobian_all for a integation point
 	double* invJacobian;
 	/// Pointer to _shape_function_pool_ptr for a integation point

--- a/FEM/fem_ele.h
+++ b/FEM/fem_ele.h
@@ -112,7 +112,7 @@ public:
 	// Get the pointer to the shape function array in the shape function pool
 	void getShapeFunctionPtr(const MshElemType::type elem_type);
 	// Compute values of shape function at integral point unit
-	void ComputeShapefct(const int order, double shape_fucntion[]);
+	void ComputeShapefct(const int order, double shape_function[]);
 	// Compute the Jacobian matrix. Return its determinate
 	void computeJacobian(const int gp, const int order,
 		                 const bool inverse = true);

--- a/FEM/fem_ele_std.cpp
+++ b/FEM/fem_ele_std.cpp
@@ -9021,8 +9021,7 @@ void CFiniteElementStd::Config()
 **************************************************************************/
 void CFiniteElementStd::Assembly()
 {
-	int i;
-	Config(); // 26.08.2008
+	Config();                             //26.08.2008
 
 	// If output matrices and vectors. 07.2011. WW
 	if (pcs->Write_Matrix)
@@ -9070,31 +9069,28 @@ void CFiniteElementStd::Assembly()
 				// Turn off the partial-pressure-based model for Snw equation
 				pcs->PartialPS = 0;
 
-				pcs->ML_Cap = 0;
-				AssembleParabolicEquation();
-				pcs->ML_Cap = 0;
-
-				AssembleRHSVector();
-				Assemble_Gravity_Multiphase();
-			}
-			add2GlobalMatrixII();
-			break;
-		//....................................................................
-		case EPT_COMPONENTAL_FLOW: // Componental flow
-			for (i = 0; i < nnodes; i++)
-				NodalVal_Sat[i] = pcs->GetNodeValue(nodes[i], idxS);
-			break;
-		//....................................................................
-		case EPT_HEAT_TRANSPORT: // Heat transport
-			heat_phase_change = false; // ?2WW
-			//  if(SolidProp->GetCapacityModel()==2) // Boiling model
-			//    CalNodalEnthalpy();
-			// CMCD4213
-			AssembleMixedHyperbolicParabolicEquation();
-			if (FluidProp->density_model == 14 && MediaProp->heat_diffusion_model == 1 && cpl_pcs)
-				Assemble_RHS_HEAT_TRANSPORT(); // This include when need pressure terms n dp/dt + nv.Nabla p//AKS
-			if (MediaProp->evaporation == 647)
-				Assemble_RHS_HEAT_TRANSPORT2(); // AKS
+			AssembleRHSVector();
+			Assemble_Gravity_Multiphase();
+		}
+		add2GlobalMatrixII();
+		break;
+	//....................................................................
+	case EPT_COMPONENTAL_FLOW:                               // Componental flow
+		for(int i = 0; i < nnodes; i++)
+			NodalVal_Sat[i] = pcs->GetNodeValue(nodes[i], idxS);
+		break;
+	//....................................................................
+	case EPT_HEAT_TRANSPORT:                               // Heat transport
+		heat_phase_change = false; // ?2WW
+		//  if(SolidProp->GetCapacityModel()==2) // Boiling model
+		//    CalNodalEnthalpy();
+		//CMCD4213
+		AssembleMixedHyperbolicParabolicEquation();
+		if(FluidProp->density_model == 14 && MediaProp->heat_diffusion_model == 1 &&
+		   cpl_pcs )
+			Assemble_RHS_HEAT_TRANSPORT();  // This include when need pressure terms n dp/dt + nv.Nabla p//AKS
+		if(MediaProp->evaporation == 647)
+			Assemble_RHS_HEAT_TRANSPORT2();  //AKS
 
 #if defined(USE_PETSC) // || defined(other parallel libs)//03~04.3012. WW
 			add2GlobalMatrixII();

--- a/FEM/fem_ele_std.cpp
+++ b/FEM/fem_ele_std.cpp
@@ -4121,11 +4121,17 @@ void CFiniteElementStd::UpwindAlphaMass(double* alpha)
 void CFiniteElementStd::UpwindSummandMass(const int gp, int& gp_r, int& gp_s, int& gp_t, double* alpha, double* summand)
 
 {
-	int i;
 	//
-	GetGaussData(gp, gp_r, gp_s, gp_t); // this sets unit[] to standard values
-	GradShapeFunction(dshapefct, unit);
-	for (i = 0; i < nnodes; i++)
+	// GetGaussData(gp, gp_r, gp_s, gp_t); // this sets unit[] to standard values
+	// Already computed. WW //GradShapeFunction(dshapefct, unit);
+
+	// Avoid warnings for unused variables.
+	(void)gp;
+	(void)gp_r;
+	(void)gp_s;
+	(void)gp_t;
+
+	for (int i = 0; i < nnodes; i++)
 	{
 		summand[i] = 0.0;
 		for (size_t k = 0; k < dim; k++)

--- a/FEM/fem_ele_std.cpp
+++ b/FEM/fem_ele_std.cpp
@@ -5326,6 +5326,7 @@ void CFiniteElementStd::CalcAdvectionMCF()
 	int gp_r = 0, gp_s = 0, gp_t = 0, i, j, in, jn, nDF = pcs->dof, Index = MeshElement->GetIndex();
 	double fkt, vel[3];
 	ElementValue* gp_ele = ele_gp_value[Index];
+	getShapeFunctionCentroid();
 	CalCoefAdvectionMCF();
 	for (gp = 0; gp < nGaussPoints; gp++)
 	{
@@ -5369,6 +5370,7 @@ void CFiniteElementStd::CalcContentMCF()
 {
 	int gp_r = 0, gp_s = 0, gp_t = 0, in, i, j, nDF = pcs->dof;
 	double fkt;
+	getShapeFunctionCentroid();
 	CalCoefContentMCF();
 	for (gp = 0; gp < nGaussPoints; gp++)
 	{
@@ -5403,7 +5405,6 @@ void CFiniteElementStd::CalCoefContentMCF()
 		ContentMatrixElements[in] = 0.0;
 	if (FluidProp->cmpN > 0)
 	{
-	getShapefunctValues(gp, 1);       // Linear interpolation N....var shapefct
 	for(in = 0; in < nDF; in++) arg_PV[in] = interpolate(NodalValue[in]);
 	rho = FluidProp->Density(arg_PV);
 	poro = MediaProp->Porosity(Index, pcs->m_num->ls_theta);

--- a/FEM/fem_ele_std.cpp
+++ b/FEM/fem_ele_std.cpp
@@ -9405,7 +9405,11 @@ void CFiniteElementStd::ExtropolateGauss(CRFProcess* m_pcs, const int idof)
 	}
 	// For strain and stress extrapolation all element types
 	// Number of elements associated to nodes
-	for (i = 0; i < nnodes; i++)
+	nnodes = MeshElement->nnodes;
+	// Node indices
+	for(int i = 0; i < nnodes; i++)
+		nodes[i] = MeshElement->nodes[i]->GetIndex();
+	for(i = 0; i < nnodes; i++)
 		dbuff[i] = (double)MeshElement->nodes[i]->getConnectedElementIDs().size();
 	//
 	gp_r = gp_s = gp_t = gp = 0;
@@ -9523,7 +9527,11 @@ void CFiniteElementStd::ExtrapolateGauss_ReactRate_TNEQ_TES(CRFProcess* m_pcs)
 	MshElemType::type ElementType = MeshElement->GetElementType();
 
 	// Number of elements associated to nodes
-	for (i = 0; i < nnodes; i++)
+	nnodes = MeshElement->nnodes;
+	// Node indices
+	for(int i = 0; i < nnodes; i++)
+		nodes[i] = MeshElement->nodes[i]->GetIndex();
+	for(i=0; i<nnodes; i++)
 		dbuff[i] = (double)MeshElement->nodes[i]->getConnectedElementIDs().size();
 
 	gp_r = gp_s = gp_t = gp = 0;
@@ -9753,6 +9761,12 @@ void CFiniteElementStd::CalcNodeMatParatemer()
 	setOrder(1);
 	// Set material
 	SetMaterial();
+
+	nnodes = MeshElement->nnodes;
+	// Node indices
+	for(int i = 0; i < nnodes; i++)
+		nodes[i] = MeshElement->nodes[i]->GetIndex();
+
 	//----------------------------------------------------------------------
 	// Node value of the previous time step
 	int idx11 = idx1;

--- a/FEM/fem_ele_std.cpp
+++ b/FEM/fem_ele_std.cpp
@@ -6209,11 +6209,6 @@ void CFiniteElementStd::CalcSolidDensityRate()
 	// Find out material group - TN
 	// const long group = MeshElement->GetPatchIndex();
 
-	// Get room in the memory for local matrices
-	SetMemory();
-	// Set material
-	SetMaterial();
-
 	ElementValue* gp_ele = ele_gp_value[Index];
 
 	// loop over all Gauss points
@@ -6338,11 +6333,6 @@ void CFiniteElementStd::Cal_Velocity()
 		dof_n = 3;
 	//
 	gp_t = 0;
-
-	// Get room in the memory for local matrices
-	SetMemory();
-	// Set material
-	SetMaterial();
 
 	ElementValue* gp_ele = ele_gp_value[Index];
 
@@ -6619,8 +6609,6 @@ void CFiniteElementStd::Cal_VelocityMCF()
 	double arg_PV[6], gravity_vector[3], rho;
 	int gp_r = 0, gp_s = 0, gp_t;
 	gp_t = 0;
-	SetMemory();
-	SetMaterial();
 	ElementValue* gp_ele = ele_gp_value[Index];
 	for (size_t k = 0; k < dim; k++)
 		gravity_vector[k] = 0.0;
@@ -6922,11 +6910,6 @@ void CFiniteElementStd::Cal_Velocity_2()
 	if (PcsType == EPT_MULTIPHASE_FLOW)
 		dof_n = 2;
 	//
-
-	// Get room in the memory for local matrices
-	SetMemory();
-	// Set material
-	SetMaterial();
 
 	ElementValue* gp_ele = ele_gp_value[Index];
 
@@ -9422,7 +9405,8 @@ void CFiniteElementStd::ExtropolateGauss(MeshLib::CElem& elem, CRFProcess* m_pcs
 	double EV, EV1 = 0.0, varx = 0.0;
 	gp_r = gp_s = gp_t = gp = 0;
 	//
-	for (gp = 0; gp < nGaussPoints; gp++)
+	SetIntegrationPointNumber(ElementType);
+	for(gp = 0; gp < nGaussPoints; gp++)
 	{
 		int i = gp;
 		SetGaussPoint(gp, gp_r, gp_s, gp_t);
@@ -9441,8 +9425,7 @@ void CFiniteElementStd::ExtropolateGauss(MeshLib::CElem& elem, CRFProcess* m_pcs
 			NodalVal2[i] = gp_ele->Velocity_g(idof, gp) * time_unit_factor;
 	}
 
-	if (ElementType == MshElemType::QUAD || ElementType == MshElemType::HEXAHEDRON)
-		Xi_p = CalcXi_p();
+	CalcXi_p();
 
 	//
 	i_s = 0;
@@ -9547,7 +9530,8 @@ void CFiniteElementStd::ExtrapolateGauss_ReactRate_TNEQ_TES
 	ElementValue* gp_ele = ele_gp_value[MeshElement->GetIndex()];
 
 	// loop over all gauss points
-	for (gp = 0; gp < nGaussPoints; gp++)
+	SetIntegrationPointNumber(ElementType);
+	for(gp=0; gp<nGaussPoints; gp++)
 	{
 		SetGaussPoint(gp, gp_r, gp_s, gp_t);
 		if(ElementType==MshElemType::QUAD||ElementType==MshElemType::HEXAHEDRON)
@@ -9564,8 +9548,7 @@ void CFiniteElementStd::ExtrapolateGauss_ReactRate_TNEQ_TES
 		NodalVal5[i] = gp_ele->rho_s_curr[gp] * time_unit_factor;
 	}
 
-	if (ElementType == MshElemType::QUAD || ElementType == MshElemType::HEXAHEDRON)
-		Xi_p = CalcXi_p();
+	CalcXi_p();
 
 	i_s = 0;
 	i_e = nnodes;
@@ -9675,6 +9658,7 @@ void CFiniteElementStd::CalcSatuation(MeshLib::CElem& elem)
 	// for PG = interpolate(NodalVal0);
 	const MshElemType::type ElementType = MeshElement->GetElementType();
 	getShapeFunctionPtr(ElementType);
+	SetIntegrationPointNumber(ElementType);
 	for(gp = 0; gp < nGaussPoints; gp++)
 	{
 		SetGaussPoint(gp, gp_r, gp_s, gp_t);
@@ -9697,8 +9681,7 @@ void CFiniteElementStd::CalcSatuation(MeshLib::CElem& elem)
 		NodalVal_Sat[i] = MediaProp->SaturationCapillaryPressureFunction(PG);
 	}
 
-	if (ElementType == MshElemType::QUAD || ElementType == MshElemType::HEXAHEDRON)
-		Xi_p = CalcXi_p();
+	CalcXi_p();
 
 	//
 	int i_s, i_e, ish;
@@ -9735,6 +9718,7 @@ void CFiniteElementStd::CalcSatuation(MeshLib::CElem& elem)
 		}
 		else if (this->GetExtrapoMethod() == ExtrapolationMethod::EXTRAPO_AVERAGE)
 			eS = avgSat;
+
 		// Average value of the contribution of ell neighbor elements
 		eS /= dbuff[i];
 		eS += pcs->GetNodeValue(nodes[i], idx_S);
@@ -9818,6 +9802,7 @@ void CFiniteElementStd::CalcNodeMatParatemer(MeshLib::CElem& elem)
 	gp_r = gp_s = gp_t = gp = 0;
 	// for PG = interpolate(NodalVal0);
 	getShapeFunctionPtr(MeshElement->GetElementType());
+	SetIntegrationPointNumber(ElementType);
 	for(gp = 0; gp < nGaussPoints; gp++)
 	{
 		SetGaussPoint(gp, gp_r, gp_s, gp_t);
@@ -9861,8 +9846,7 @@ void CFiniteElementStd::CalcNodeMatParatemer(MeshLib::CElem& elem)
 			NodalVal0[i] = MediaProp->Porosity(MeshElement->index, 1.0);
 	}
 	//
-	if (ElementType == MshElemType::QUAD || ElementType == MshElemType::HEXAHEDRON)
-		Xi_p = CalcXi_p();
+	Xi_p = CalcXi_p();
 	//
 	i_s = 0;
 	i_e = nnodes;

--- a/FEM/fem_ele_std.cpp
+++ b/FEM/fem_ele_std.cpp
@@ -3196,7 +3196,7 @@ void CFiniteElementStd::UpwindUnitCoord(int p, int point, int ind)
 	{
 		v_rst[i] = 0.0;
 		for (size_t j = 0; j < ele_dim; j++)
-			v_rst[i] += Jacobian[i * dim + j] * v[j];
+			v_rst[i] += _Jacobian[i * dim + j] * v[j];
 	}
 	//
 
@@ -3992,7 +3992,7 @@ void CFiniteElementStd::UpwindAlphaMass(double* alpha)
 	{
 		v_rst[i] = 0.0;
 		for (size_t j = 0; j < ele_dim; j++)
-			v_rst[i] += Jacobian[i * dim + j] * v_tot[j];
+			v_rst[i] += _Jacobian[i * dim + j] * v_tot[j];
 	}
 
 	// Upwind-Factors
@@ -9526,7 +9526,7 @@ void CFiniteElementStd::ExtrapolateGauss_ReactRate_TNEQ_TES(MeshLib::CElem& elem
 /***********************************************************************
    27.03.2007 WW
 ***********************************************************************/
-void CFiniteElementStd::CalcSatuation(MeshLib::CElem& elem)
+void CFiniteElementStd::CalcSaturation(MeshLib::CElem& elem)
 {
 	MeshElement = &elem;
 	Index = MeshElement->GetIndex();

--- a/FEM/fem_ele_std.cpp
+++ b/FEM/fem_ele_std.cpp
@@ -917,8 +917,16 @@ void CFiniteElementStd::SetMaterial(int /*phase*/)
 	MediaProp->Fem_Ele_Std = this;
 	MeshElement->area = MediaProp->geo_area; // NW
 
-	if (MediaProp->storage_model == 7) // 29.11.2011. WW
-		SolidProp->Calculate_Lame_Constant();
+	if (ele_dim != 3)
+	{
+		for (gp = 0; gp < nGaussPoints; gp++)
+		{
+			_determinants_all[gp] *= MeshElement->area;
+		}
+	}
+
+    if(MediaProp->storage_model ==7 )   // 29.11.2011. WW
+       SolidProp->Calculate_Lame_Constant();
 
 	//----------------------------------------------------------------------
 	// MSP
@@ -6908,13 +6916,11 @@ void CFiniteElementStd::Cal_Velocity_2()
 	int k;
 	static double vel[3], vel_g[3];
 	// ---- Gauss integral
-	int gp_r = 0, gp_s = 0, gp_t;
 	double coef = 0.0;
 	int dof_n = 1;
 	if (PcsType == EPT_MULTIPHASE_FLOW)
 		dof_n = 2;
 	//
-	gp_t = 0;
 
 	// Get room in the memory for local matrices
 	SetMemory();

--- a/FEM/fem_ele_std.cpp
+++ b/FEM/fem_ele_std.cpp
@@ -13,7 +13,6 @@
 
 #include "fem_ele_std.h"
 
-
 // C++ STL
 #include <cfloat>
 //#include <iostream>
@@ -495,7 +494,7 @@ CFiniteElementStd::CFiniteElementStd(CRFProcess* Pcs, const int C_Sys_Flad, cons
 #endif
 	dof_index = 0;
 	drho_gw_dT = .0;
-	dSdp =.0;
+	dSdp = .0;
 	GasProp = NULL;
 	index = 0;
 	M_g = 0;
@@ -563,32 +562,32 @@ CFiniteElementStd::~CFiniteElementStd()
 	AuxMatrix = NULL;
 	AuxMatrix1 = NULL;
 	// 27.2.2007 WW
-	delete [] NodalVal;
-	delete [] NodalVal0;
-	delete [] NodalVal1;
-	delete [] NodalVal2;
-	delete [] NodalVal3;
-	delete [] NodalVal4;
-	delete [] NodalVal5;
-	delete [] NodalValC;
-	delete [] NodalValC1;
-	delete [] NodalVal_Sat;
-	delete [] NodalVal_SatNW;
-	delete [] NodalVal_p2;
-	delete [] mat;
-	delete [] NodalVal_p20;                     //AKS
-	delete [] NodalVal_t0;          //AKS/NB
-	delete [] NodalVal_t1;          //AKS/NB
-	delete [] NodalVal_t2_0;
-	delete [] NodalVal_t2_1;
-	delete [] NodalVal_X0;
-	delete [] NodalVal_X1;
-	if(idx_vel_disp)
-		delete [] idx_vel_disp;
-	delete [] idx_vel;              //AKS
-	//NW
-	if(weight_func)
-		delete [] weight_func;    // Remove bug. WW
+	delete[] NodalVal;
+	delete[] NodalVal0;
+	delete[] NodalVal1;
+	delete[] NodalVal2;
+	delete[] NodalVal3;
+	delete[] NodalVal4;
+	delete[] NodalVal5;
+	delete[] NodalValC;
+	delete[] NodalValC1;
+	delete[] NodalVal_Sat;
+	delete[] NodalVal_SatNW;
+	delete[] NodalVal_p2;
+	delete[] mat;
+	delete[] NodalVal_p20; // AKS
+	delete[] NodalVal_t0; // AKS/NB
+	delete[] NodalVal_t1; // AKS/NB
+	delete[] NodalVal_t2_0;
+	delete[] NodalVal_t2_1;
+	delete[] NodalVal_X0;
+	delete[] NodalVal_X1;
+	if (idx_vel_disp)
+		delete[] idx_vel_disp;
+	delete[] idx_vel; // AKS
+	// NW
+	if (weight_func)
+		delete[] weight_func; // Remove bug. WW
 	weight_func = NULL;
 }
 /**************************************************************************
@@ -925,8 +924,8 @@ void CFiniteElementStd::SetMaterial(int /*phase*/)
 		}
 	}
 
-    if(MediaProp->storage_model ==7 )   // 29.11.2011. WW
-       SolidProp->Calculate_Lame_Constant();
+	if (MediaProp->storage_model == 7) // 29.11.2011. WW
+		SolidProp->Calculate_Lame_Constant();
 
 	//----------------------------------------------------------------------
 	// MSP
@@ -1232,7 +1231,7 @@ void CFiniteElementStd::CalcOverlandCKWRatNodes(int i, int j, double* head, doub
 	else
 	{
 		if (MediaProp->channel == 1)
-			*ckwr = flow_depth * pow(flow_depth * width / (2 * flow_depth + width), depth_exp);
+			*ckwr = flow_depth* pow(flow_depth * width / (2 * flow_depth + width), depth_exp);
 		else
 			*ckwr = pow(flow_depth, depth_exp + 1);
 	}
@@ -1277,8 +1276,8 @@ void CFiniteElementStd::CalcOverlandUpwindedCoefficients(double** amat, double* 
    Programing:
    06/2007 JOD Implementation
 **************************************************************************/
-void CFiniteElementStd::CalcOverlandResidual(double* head, double* swval, double* swold, double ast, double* residual,
-                                             double** amat)
+void CFiniteElementStd::CalcOverlandResidual(
+    double* head, double* swval, double* swold, double ast, double* residual, double** amat)
 {
 	double sum;
 	double storinit[4], astor[4], rhs[4];
@@ -1315,8 +1314,8 @@ void CFiniteElementStd::CalcOverlandResidual(double* head, double* swval, double
    Programing:
    06/2007 JOD Implementation
 **************************************************************************/
-double CFiniteElementStd::CalcOverlandJacobiNodes(int i, int j, double* head, double* headKeep, double akrw, double axx,
-                                                  double ayy, double** amat, double* sumjac)
+double CFiniteElementStd::CalcOverlandJacobiNodes(
+    int i, int j, double* head, double* headKeep, double akrw, double axx, double ayy, double** amat, double* sumjac)
 {
 	double jacobi, gammaij, amatEps, amatKeep;
 
@@ -1378,8 +1377,8 @@ void CFiniteElementStd::CalcOverlandCoefficientsLine(double* head, double* axx, 
 	eslope = 1.0 / dhds;
 	eslope = pow(eslope, 1 - slope_exp);
 
-	*axx = eslope * fric * width / delt;
-	*ast = delt * width / (double)(nnodes * dt);
+	*axx = eslope* fric* width / delt;
+	*ast = delt* width / (double)(nnodes * dt);
 }
 /**************************************************************************
    FEMLib-Method:
@@ -1416,8 +1415,8 @@ void CFiniteElementStd::CalcOverlandCoefficientsQuad(double* head, double* axx, 
 	eslope = 1.0 / dhds;
 	eslope = pow(eslope, 1 - slope_exp);
 
-	*axx = eslope * fric * dy / dx; // ett/ell
-	*ayy = eslope * fric * dx / dy;
+	*axx = eslope* fric* dy / dx; // ett/ell
+	*ayy = eslope* fric* dx / dy;
 	*ast = delt / (double)(nnodes * dt);
 }
 /**************************************************************************
@@ -1468,8 +1467,8 @@ void CFiniteElementStd::CalcOverlandCoefficientsTri(double* head, double* axx, d
 	eslope = 1.0 / dhds;
 
 	eslope = pow(eslope, 1 - slope_exp);
-	*axx = eslope * fric * delt;
-	*ayy = eslope * fric * delt;
+	*axx = eslope* fric* delt;
+	*ayy = eslope* fric* delt;
 	*ast = delt / (double)(nnodes * dt);
 }
 
@@ -1495,9 +1494,7 @@ void CFiniteElementStd::CalNodalEnthalpy()
 	{
 		NodalVal_Sat[i] = pcs->GetNodeValue(nodes[i], idxS);
 		getShapeFunctionCentroid();
-		temp =  FluidProp->Density()
-		       * MediaProp->Porosity(Index,pcs->m_num->ls_theta)
-		       * NodalVal_Sat[i];
+		temp = FluidProp->Density() * MediaProp->Porosity(Index, pcs->m_num->ls_theta) * NodalVal_Sat[i];
 		// Enthalpy
 		dT = 0.0;
 		NodalVal2[i] = SolidProp->Enthalpy(NodalVal0[i], temp);
@@ -1532,51 +1529,15 @@ double CFiniteElementStd::CalCoefMass()
 	CompProperties* m_cp = NULL;
 	double drho_dp_rho = 0.0; // drho/dp * 1/rho
 
-	switch(PcsType)
+	switch (PcsType)
 	{
-	default:
-		std::cout << "Fatal error in CalCoefMass: No valid PCS type" << "\n";
-		break;
-	case EPT_LIQUID_FLOW:                               // Liquid flow
-		// Is this really needed?
-		val = MediaProp->StorageFunction(Index,unit,pcs->m_num->ls_theta);
-
-                 // get drho/dp/rho from material model or direct input
-		 if(FluidProp->compressibility_model_pressure>0)
-		 {
-
-                   rho_val = FluidProp->Density();
-     	           arg[0]=interpolate(NodalVal1);   //   p
-    	           arg[1]=interpolate(NodalValC1);  //   T
-    	           drho_dp_rho=FluidProp->drhodP(arg)/rho_val;
-                 }
-		 else
-		   drho_dp_rho=FluidProp->drho_dp;
-
-		// JT 2010, needed storage term and fluid compressibility...
-		// We derive here the storage at constant strain, or the inverse of Biot's "M" coefficient
-		// Assumptions are the most general possible::  Invarience under "pi" (Detournay & Cheng) loading.
-		// Se = 1/M = poro/Kf + (alpha-poro)/Ks    ::    Cf = 1/Kf = 1/rho * drho/dp    ::    alpha = 1 - K/Ks
-		// Second term (of Se) below vanishes for incompressible grains
-		//WW if(D_Flag > 0  && rho_val > MKleinsteZahl)
-		if(dm_pcs  && MediaProp->storage_model == 7) // Add MediaProp->storage_model.  29.09.2011. WW
-		{
-			biot_val = SolidProp->biot_const;
-			poro_val = MediaProp->Porosity(Index,pcs->m_num->ls_theta);
-			val = 0.;//WX:04.2013
-
-			//WW if(SolidProp->K == 0) //WX: if HM Partitioned, K still 0 here
-			if(fabs(SolidProp->K)<DBL_MIN) //WW 29.09.2011
-			{
-				if(SolidProp->Youngs_mode<10||SolidProp->Youngs_mode>13)//JM,WX: 2013
-				SolidProp->K = SolidProp->E / 3 / (1 - 2 * SolidProp->PoissonRatio);
-				else
-				{
-					double E_av;  // average Youngs modulus
-					double nu_av; // average Poisson ratio
-					double nu_ai; // Poisson ratio perpendicular to the plane of isotropie, due to strain in the plane of isotropie
-					double nu_ia; // Poisson ratio in the plane of isotropie, due to strain perpendicular to the plane of isotropie
-					double nu_i;  // Poisson ratio in the plane of isotropy
+		default:
+			std::cout << "Fatal error in CalCoefMass: No valid PCS type"
+			          << "\n";
+			break;
+		case EPT_LIQUID_FLOW: // Liquid flow
+			// Is this really needed?
+			val = MediaProp->StorageFunction(Index, unit, pcs->m_num->ls_theta);
 
 			// get drho/dp/rho from material model or direct input
 			if (FluidProp->compressibility_model_pressure > 0)
@@ -1611,16 +1572,16 @@ double CFiniteElementStd::CalCoefMass()
 						double E_av; // average Youngs modulus
 						double nu_av; // average Poisson ratio
 						double nu_ai; // Poisson ratio perpendicular to the plane of isotropie, due to strain in the
-						// plane of isotropie
+						              // plane of isotropie
 						double nu_ia; // Poisson ratio in the plane of isotropie, due to strain perpendicular to the
-						// plane of isotropie
+						              // plane of isotropie
 						double nu_i; // Poisson ratio in the plane of isotropy
 
 						E_av = 2. / 3. * (*SolidProp->data_Youngs)(0) + 1. / 3. * (*SolidProp->data_Youngs)(1);
 
 						nu_ia = (*SolidProp->data_Youngs)(2);
-						nu_ai
-						    = nu_ia * (*SolidProp->data_Youngs)(1) / (*SolidProp->data_Youngs)(0); //  nu_ai=nu_ia*Ea/Ei
+						nu_ai = nu_ia * (*SolidProp->data_Youngs)(1)
+						        / (*SolidProp->data_Youngs)(0); //  nu_ai=nu_ia*Ea/Ei
 
 						nu_i = SolidProp->Poisson_Ratio();
 						//           12     13    21   23   31    32
@@ -1650,13 +1611,28 @@ double CFiniteElementStd::CalCoefMass()
 				val *= storage_effstress;
 			}
 
-			// Will handle the dual porosity version later...
-		}
-		else
-		{
-			poro_val = MediaProp->Porosity(Index,pcs->m_num->ls_theta);
-			val += poro_val * drho_dp_rho;
-		}
+			val /= time_unit_factor;
+			break;
+		case EPT_UNCONFINED_FLOW: // Unconfined flow
+			break;
+		case EPT_GROUNDWATER_FLOW: // MB now Groundwater flow
+			if (MediaProp->unconfined_flow_group > 0) // OK
+				val = MediaProp->Porosity(Index, pcs->m_num->ls_theta);
+			else
+				val = MediaProp->StorageFunction(Index, unit, pcs->m_num->ls_theta);
+			break;
+		case EPT_TWOPHASE_FLOW: // Two-phase flow
+			// val = (1/rho*n*d_rho/d_p*S + Se*S )
+			if (pcs->pcs_type_number == 0)
+			{
+				// PCH cpl_pcs gives a funny process number.
+				// It is just the opposite of the phase. So, I get the value the other way around.
+				idxS = cpl_pcs->GetNodeValueIndex("SATURATION2");
+				for (int i = 0; i < nnodes; i++)
+					NodalVal_Sat[i] = cpl_pcs->GetNodeValue(nodes[i], idxS + 1);
+				Sw = 1.0 - interpolate(NodalVal_Sat);
+				// Is this really needed?
+				val = MediaProp->StorageFunction(Index, unit, pcs->m_num->ls_theta) * MMax(0., Sw);
 
 				// JT 2010, generalized poroelastic storage. See single phase version in case "L".
 				// Se = 1/M = poro/Kf + (alpha-poro)/Ks
@@ -1742,51 +1718,33 @@ double CFiniteElementStd::CalCoefMass()
 			else
 				drho_dp_rho = FluidProp->drho_dp;
 
-		if (PG<0.0) // JM skip to call these two functions in saturated case
-		{
-			Sw = MediaProp->SaturationCapillaryPressureFunction(-PG);
-			dSdp = -MediaProp->PressureSaturationDependency(Sw,true); // JT: dSdp now returns actual sign (i.e. <0)
-		}
+			// Storativity
+			val = MediaProp->StorageFunction(Index, unit, pcs->m_num->ls_theta) * Sw;
 
-		poro = MediaProp->Porosity(Index,pcs->m_num->ls_theta);
-		rhow = FluidProp->Density();
-
-		if(FluidProp->compressibility_model_pressure>0)
-		{  //drho_dp from rho-p-T relation
-			arg[0]=PG;
-			arg[1]=interpolate(NodalValC1);  // T
-			drho_dp_rho=FluidProp->drhodP(arg)/rhow;
-		}
-		else
-			drho_dp_rho=FluidProp->drho_dp;
-
-		// Storativity
-		val = MediaProp->StorageFunction(Index,unit,pcs->m_num->ls_theta) * Sw;
-
-		// Fluid compressibility
-		if(rhow > 0.0)
-			val += poro  * Sw * drho_dp_rho;
-		// Capillarity
-		if(PG<0.0) // dSdp gives always a value>0, even if p>0!
-		val += poro * dSdp;
-		//WW
-		if(MediaProp->heat_diffusion_model == 1)
-		{
-			//           PG = fabs(interpolate(NodalVal1));
-			TG = interpolate(NodalValC) + PhysicalConstant::CelsiusZeroInKelvin;
-			humi = exp(PG / (SpecificGasConstant::WaterVapour * TG * rhow));
-			rhov = humi * FluidProp->vaporDensity(TG);
-			//
-			val -= poro * rhov * dSdp / rhow;
-			val += (1.0 - Sw) * poro * rhov / (rhow * rhow * SpecificGasConstant::WaterVapour * TG);
-		}
-		break;
-	case EPT_FLUID_MOMENTUM:                               // Fluid Momentum
-		val = 1.0;
-		break;
-	case EPT_GAS_FLOW:                               // Air (gas) flow
-		val = MediaProp->Porosity(Index,pcs->m_num->ls_theta) / interpolate(NodalVal1);
-		break;
+			// Fluid compressibility
+			if (rhow > 0.0)
+				val += poro * Sw * drho_dp_rho;
+			// Capillarity
+			if (PG < 0.0) // dSdp gives always a value>0, even if p>0!
+				val += poro * dSdp;
+			// WW
+			if (MediaProp->heat_diffusion_model == 1)
+			{
+				//           PG = fabs(interpolate(NodalVal1));
+				TG = interpolate(NodalValC) + PhysicalConstant::CelsiusZeroInKelvin;
+				humi = exp(PG / (SpecificGasConstant::WaterVapour * TG * rhow));
+				rhov = humi * FluidProp->vaporDensity(TG);
+				//
+				val -= poro * rhov * dSdp / rhow;
+				val += (1.0 - Sw) * poro * rhov / (rhow * rhow * SpecificGasConstant::WaterVapour * TG);
+			}
+			break;
+		case EPT_FLUID_MOMENTUM: // Fluid Momentum
+			val = 1.0;
+			break;
+		case EPT_GAS_FLOW: // Air (gas) flow
+			val = MediaProp->Porosity(Index, pcs->m_num->ls_theta) / interpolate(NodalVal1);
+			break;
 	}
 	return val;
 }
@@ -1813,7 +1771,7 @@ double CFiniteElementStd::CalCoefMass2(int dof_index)
 	dens_arg[1] = 293.15;
 	//
 	// CB_merge_0513 in case of het K, store local K in permeability_tensor
-	double *tensor = NULL;
+	double* tensor = NULL;
 	tensor = MediaProp->PermeabilityTensor(Index);
 	MediaProp->local_permeability = tensor[0];
 
@@ -1980,33 +1938,9 @@ double CFiniteElementStd::CalCoefMassPSGLOBAL(int dof_index)
 	// WWif(MediaProp->heat_diffusion_model==273&&cpl_pcs)
 	// WW  diffusion = true;
 	//
-	switch(dof_index)
+	switch (dof_index)
 	{
-	case 0:
-
-		// compressibility also for the wetting phase NB
-		poro = MediaProp->Porosity(Index,pcs->m_num->ls_theta);
-		Sw = 1.0 - interpolate(NodalVal_SatNW); //Sw = 1-Snw
-		P  = interpolate(NodalVal1); //Pw
-		T = interpolate(NodalValC1);
-		variables[0]=P;
-		variables[1]=T;
-		val = poro * (Sw) * FluidProp->drhodP(variables) / FluidProp->Density();
-		//		cout << FluidProp->fluid_name << " Pressure: " << P << " Temp: " << ": drhodP: " << FluidProp->drhodP(P,T) << " density: " << FluidProp->Density() << "\n";
-		break;
-	case 1:                               // Snw in the wetting equation
-		poro = MediaProp->Porosity(Index,pcs->m_num->ls_theta);
-		val = -poro;
-		break;
-	case 2:                               // Pw in the non-wetting equation
-		Sw = 1.0 - interpolate(NodalVal_SatNW); //Sw = 1 - Snw
-		                                        // Pnw = Pw + Pc(Sw)
-		P = interpolate(NodalVal1) + MediaProp->CapillaryPressureFunction(Sw);
-		//      P = interpolate(NodalVal1);  // Pw
-		T = interpolate(NodalValC1);
-		variables[0]=P;
-		variables[1]=T;
-		val = poro * (1. - Sw) * GasProp->drhodP(variables) / GasProp->Density();
+		case 0:
 
 			// compressibility also for the wetting phase NB
 			poro = MediaProp->Porosity(Index, pcs->m_num->ls_theta);
@@ -2017,7 +1951,7 @@ double CFiniteElementStd::CalCoefMassPSGLOBAL(int dof_index)
 			variables[1] = T;
 			val = poro * (Sw)*FluidProp->drhodP(variables) / FluidProp->Density();
 			//		cout << FluidProp->fluid_name << " Pressure: " << P << " Temp: " << ": drhodP: " <<
-			// FluidProp->drhodP(P,T) << " density: " << FluidProp->Density() << "\n";
+			//FluidProp->drhodP(P,T) << " density: " << FluidProp->Density() << "\n";
 			break;
 		case 1: // Snw in the wetting equation
 			poro = MediaProp->Porosity(Index, pcs->m_num->ls_theta);
@@ -2215,11 +2149,11 @@ void CFiniteElementStd::CalCoefLaplace(bool Gravity, int ip)
 	int nidx1;
 	int Index = MeshElement->GetIndex();
 	double k_rel;
-	double variables[3];                  //OK4709
-	int tr_phase = 0;                     // SB, BG
-	double perm_effstress=1.;//AS:08.2012
-	//WX:12.2012 perm depends on p or strain, same as CalCoefLaplace2
-	CFiniteElementStd *h_fem;
+	double variables[3]; // OK4709
+	int tr_phase = 0; // SB, BG
+	double perm_effstress = 1.; // AS:08.2012
+	// WX:12.2012 perm depends on p or strain, same as CalCoefLaplace2
+	CFiniteElementStd* h_fem;
 	h_fem = this;
 	double fac_perm = 1.0;
 
@@ -2346,8 +2280,8 @@ void CFiniteElementStd::CalCoefLaplace(bool Gravity, int ip)
 					double* pressureHead;
 					pressureHead = new double[8];
 					for (int i = 0; i < nnodes; i++)
-						pressureHead[i]
-						    = pcs->GetNodeValue(nodes[i], 1) - pcs->m_msh->nod_vector[nodes[i]]->getData()[2];
+						pressureHead[i] = pcs->GetNodeValue(nodes[i], 1)
+						                  - pcs->m_msh->nod_vector[nodes[i]]->getData()[2];
 					PG = interpolate(pressureHead);
 					delete[] pressureHead;
 
@@ -2512,7 +2446,7 @@ void CFiniteElementStd::CalCoefLaplace(bool Gravity, int ip)
 			break;
 		case EPT_MASS_TRANSPORT: // Mass transport
 			mat_fac = 1.0; // MediaProp->Porosity(Index,pcs->m_num->ls_theta); // porosity now included in
-			// MassDispersionTensorNew()
+			               // MassDispersionTensorNew()
 			// Get transport phase of component, to obtain correct velocities in dispersion tensor
 			tr_phase = cp_vec[this->pcs->pcs_component_number]->transport_phase;
 			// SB, BG
@@ -2602,42 +2536,26 @@ void CFiniteElementStd::CalCoefLaplace(bool Gravity, int ip)
 					tensor[i * dim + i] *= w[i];
 			}
 			//
-			Dpv = MediaProp->base_heat_diffusion_coefficient * tort * (1 - Sw) * poro
-				  * pow(TG / PhysicalConstant::CelsiusZeroInKelvin, 1.8);
-			Dpv *= time_unit_factor * FluidProp->vaporDensity(TG) * humi /
-			       (SpecificGasConstant::WaterVapour * rhow * TG);
-			for(size_t i = 0; i < dim; i++)
-				mat[i * dim + i] += Dpv / rhow;
-		}
-		break;
-	//------------------------------------------------------------------
-	case EPT_GAS_FLOW:                               // Air flow
-		dens_arg[0] = interpolate(NodalVal1);
-		dens_arg[1] = interpolate(NodalValC1) + PhysicalConstant::CelsiusZeroInKelvin;
-		dens_arg[2] = Index;
-		double vis = FluidProp->Viscosity(dens_arg);
-		mat_fac = vis;
-		tensor = MediaProp->PermeabilityTensor(Index);
-		k_rel = 1.0;
-		if (MediaProp->flowlinearity_model>0)
-			k_rel = MediaProp->NonlinearFlowFunction(index, gp, pcs->m_num->ls_theta, this); //NW
+			for (size_t i = 0; i < dim * dim; i++)
+				mat[i] = tensor[i] * mat_fac * fac_perm; // WX:12.2012
 
-		//WX:09.2011
-		fac_perm=1.;
-		if(MediaProp->permeability_pressure_model>0)
-		{
-			fac_perm = MediaProp->PermeabilityFunctionPressure(Index, dens_arg[0]);
-			mat_fac /= fac_perm;
-		}
-		if(MediaProp->permeability_strain_model>0)
-		{
-			fac_perm = MediaProp->PermeabilityFunctionStrain(Index,nnodes,h_fem);
-			mat_fac /= fac_perm;
-		}
-
-		for(size_t i = 0; i < dim * dim; i++)
-		mat[i] = tensor[i]/mat_fac*k_rel;
-		break;
+			if (MediaProp->heat_diffusion_model == 1 && !Gravity)
+			{
+				rhow = FluidProp->Density();
+				// PG = fabs(interpolate(NodalVal1));
+				TG = interpolate(NodalValC) + PhysicalConstant::CelsiusZeroInKelvin;
+				poro = MediaProp->Porosity(Index, pcs->m_num->ls_theta);
+				tort = MediaProp->TortuosityFunction(Index, unit, pcs->m_num->ls_theta);
+				humi = exp(PG / (SpecificGasConstant::WaterVapour * TG * rhow));
+				//
+				Dpv = MediaProp->base_heat_diffusion_coefficient * tort * (1 - Sw) * poro
+				      * pow(TG / PhysicalConstant::CelsiusZeroInKelvin, 1.8);
+				Dpv *= time_unit_factor * FluidProp->vaporDensity(TG) * humi
+				       / (SpecificGasConstant::WaterVapour * rhow * TG);
+				for (size_t i = 0; i < dim; i++)
+					mat[i * dim + i] += Dpv / rhow;
+			}
+			break;
 		//------------------------------------------------------------------
 		case EPT_GAS_FLOW: // Air flow
 			dens_arg[0] = interpolate(NodalVal1);
@@ -2766,6 +2684,7 @@ void CFiniteElementStd::CalCoefLaplace2(bool Gravity, int dof_index)
 	tensor = MediaProp->PermeabilityTensor(Index);
 	MediaProp->local_permeability = tensor[0];
 	//
+
 	// WX: 11.05.2010
 	PG = interpolate(NodalVal1);
 	PG2 = interpolate(NodalVal_p2);
@@ -2933,8 +2852,9 @@ void CFiniteElementStd::CalCoefLaplaceMCF(int ip)
 	double* tensor = NULL;
 	double arg_PV[6];
 	poro = MediaProp->Porosity(Index, pcs->m_num->ls_theta);
-	assert(nDF<=6);
-	for(int i = 0; i<nDF; i++) arg_PV[i] = interpolate(NodalValue[i]);
+	assert(nDF <= 6);
+	for (int i = 0; i < nDF; i++)
+		arg_PV[i] = interpolate(NodalValue[i]);
 	const double rho = FluidProp->Density(arg_PV);
 
 	for (int in = 0; in < nDF * nDF; in++)
@@ -2992,47 +2912,47 @@ void CFiniteElementStd::CalCoefLaplacePSGLOBAL(bool Gravity, int dof_index)
 		mat[i] = 0.0;
 	switch (dof_index)
 	{
-	case 0:
-		tensor = MediaProp->PermeabilityTensor(Index);
-		if(pcs->m_num->ele_upwinding == 1)
-		{
-			// Doing Upwind elements for saturation by divergent of pressure.
-			// Pw upwind
-			int WhichNode = UpwindElement((int)(pcs->m_num->ele_upwind_method), 0);
-			Sw = 1.0 - NodalVal_SatNW[WhichNode];
-		}
-		else
-			Sw = 1.0 - interpolate(NodalVal_SatNW);
-		k_rel = MediaProp->PermeabilitySaturationFunction(Sw,0);
+		case 0:
+			tensor = MediaProp->PermeabilityTensor(Index);
+			if (pcs->m_num->ele_upwinding == 1)
+			{
+				// Doing Upwind elements for saturation by divergent of pressure.
+				// Pw upwind
+				int WhichNode = UpwindElement((int)(pcs->m_num->ele_upwind_method), 0);
+				Sw = 1.0 - NodalVal_SatNW[WhichNode];
+			}
+			else
+				Sw = 1.0 - interpolate(NodalVal_SatNW);
+			k_rel = MediaProp->PermeabilitySaturationFunction(Sw, 0);
 
-		// CB_merge_0513
-		variables[0] = interpolate(NodalVal1); // pressure
-		variables[1] = interpolate(NodalValC); // temperature
+			// CB_merge_0513
+			variables[0] = interpolate(NodalVal1); // pressure
+			variables[1] = interpolate(NodalValC); // temperature
 
-		mat_fac = k_rel / FluidProp->Viscosity(variables);
-		//mat_fac = k_rel / FluidProp->Viscosity();
-		// Since gravity for water phase is handled directly in Assemble_Gravity,
-		// no need of any code for water phase here.
-		for(size_t i = 0; i < dim * dim; i++)
-			mat[i] = tensor[i] * mat_fac * time_unit_factor;
-		break;
-	case 1:
-		tensor = MediaProp->PermeabilityTensor(Index);
-		mat_fac = 0.0;            // Snw has no laplace term
-		for(size_t i = 0; i < dim * dim; i++)
-			mat[i] = tensor[i] * mat_fac * time_unit_factor;
-		break;
-	case 2:
-		tensor = MediaProp->PermeabilityTensor(Index);
-		if(pcs->m_num->ele_upwinding == 1)
-		{
-			// Doing Upwind elements for saturation by divergent of pressure.
-			// Pnw upwind
-			int WhichNode = UpwindElement((int)(pcs->m_num->ele_upwind_method), 0);
-			Sw = 1.0 - NodalVal_SatNW[WhichNode];
-		}
-		else
-			Sw = 1.0 - interpolate(NodalVal_SatNW);
+			mat_fac = k_rel / FluidProp->Viscosity(variables);
+			// mat_fac = k_rel / FluidProp->Viscosity();
+			// Since gravity for water phase is handled directly in Assemble_Gravity,
+			// no need of any code for water phase here.
+			for (size_t i = 0; i < dim * dim; i++)
+				mat[i] = tensor[i] * mat_fac * time_unit_factor;
+			break;
+		case 1:
+			tensor = MediaProp->PermeabilityTensor(Index);
+			mat_fac = 0.0; // Snw has no laplace term
+			for (size_t i = 0; i < dim * dim; i++)
+				mat[i] = tensor[i] * mat_fac * time_unit_factor;
+			break;
+		case 2:
+			tensor = MediaProp->PermeabilityTensor(Index);
+			if (pcs->m_num->ele_upwinding == 1)
+			{
+				// Doing Upwind elements for saturation by divergent of pressure.
+				// Pnw upwind
+				int WhichNode = UpwindElement((int)(pcs->m_num->ele_upwind_method), 0);
+				Sw = 1.0 - NodalVal_SatNW[WhichNode];
+			}
+			else
+				Sw = 1.0 - interpolate(NodalVal_SatNW);
 
 			k_rel = MediaProp->PermeabilitySaturationFunction(Sw, 1);
 			// Pnw = Pw + Pc(Sw) //TODO: could cause errors in some cases
@@ -3060,9 +2980,8 @@ void CFiniteElementStd::CalCoefLaplacePSGLOBAL(bool Gravity, int dof_index)
 				//			{
 				// Doing Upwind elements for saturation by divergent of pressure.
 				// Pnw upwind
-				//				int WhichNode = UpwindElement((int)(pcs->m_num->ele_upwind_method), 1); // TF: set, but
-				// never
-				// used
+				//				int WhichNode = UpwindElement((int)(pcs->m_num->ele_upwind_method), 1); // TF: set, but never
+				//used
 				//				Snw = NodalVal_SatNW[WhichNode]; // TF: set, but never used
 				//			}
 				//			else
@@ -3098,7 +3017,7 @@ void CFiniteElementStd::CalCoefLaplacePSGLOBAL(bool Gravity, int dof_index)
 			// Doing Upwind elements for saturation by divergent of pressure.
 			// Pnw upwind
 			//			int WhichNode = UpwindElement((int)(pcs->m_num->ele_upwind_method), 1); // TF: set, but never
-			// used
+			//used
 			//			Snw = NodalVal_SatNW[WhichNode]; // TF: set, but never used
 			//		}
 			//		else
@@ -3425,8 +3344,8 @@ void CFiniteElementStd::UpwindUnitCoord(int p, int point, int ind)
 					scale = MMin(scale, (1. - fabs(ur)) / fabs(alpha[0]));
 				if (fabs(us + alpha[1]) > 1.)
 					scale = MMin(scale, (1. - fabs(us)) / fabs(alpha[1]));
-				*rupw = ur + scale * alpha[0];
-				*supw = us + scale * alpha[1];
+				*rupw = ur + scale* alpha[0];
+				*supw = us + scale* alpha[1];
 			}
 			else if (upwind_meth == 2)
 			{
@@ -3485,9 +3404,9 @@ void CFiniteElementStd::UpwindUnitCoord(int p, int point, int ind)
 					scale = MMin(scale, (1. - fabs(us)) / fabs(alpha[1]));
 				if (fabs(ut + alpha[2]) > 1.)
 					scale = MMin(scale, (1. - fabs(ut)) / fabs(alpha[2]));
-				*rupw = ur + scale * alpha[0]; // ist die reihenfolge hier richtig?
-				*supw = us + scale * alpha[1]; // scale h?gt hier ja nur von dem letzten if ab..
-				*tupw = ut + scale * alpha[2];
+				*rupw = ur + scale* alpha[0]; // ist die reihenfolge hier richtig?
+				*supw = us + scale* alpha[1]; // scale h?gt hier ja nur von dem letzten if ab..
+				*tupw = ut + scale* alpha[2];
 			}
 			else if (upwind_meth == 2)
 			{
@@ -3584,9 +3503,11 @@ double CFiniteElementStd::CalCoefAdvection()
 void CFiniteElementStd::CalCoefAdvectionMCF()
 {
 	int i, nDF = pcs->dof;
-    double arg_PV[6], rho;
-    for(i = 0; i < nDF*nDF; i++) AdvectionMatrixElements[i] = 0.0;
-	for(i = 0; i<nDF; i++) arg_PV[i] = interpolate(NodalValue[i]);
+	double arg_PV[6], rho;
+	for (i = 0; i < nDF * nDF; i++)
+		AdvectionMatrixElements[i] = 0.0;
+	for (i = 0; i < nDF; i++)
+		arg_PV[i] = interpolate(NodalValue[i]);
 	rho = FluidProp->Density(arg_PV);
 	// Advection Matrix Elements value---start
 	if (FluidProp->mu_JT == "ON")
@@ -3682,8 +3603,8 @@ void CFiniteElementStd::CalcMass()
 		{
 			// CB 11/07 this is to provide the velocity at the element center of gravity
 			// call to his function here is also required for upwinding in CalcCoefLaplace
-			getShapeFunctionCentroid();               // Linear interpolation function
-			getGradShapeFunctionCentroid();           //
+			getShapeFunctionCentroid(); // Linear interpolation function
+			getGradShapeFunctionCentroid(); //
 			Cal_Velocity_2();
 			UpwindAlphaMass(alpha); // CB 160507
 		}
@@ -3707,9 +3628,9 @@ void CFiniteElementStd::CalcMass()
 		//  if((upwind_method == 1) || (upwind_method == 2))
 		//      UpwindUnitCoord(phase, gp, indice); // phase 0
 		//}
-		getShapefunctValues(gp, 1);       // Linear interpolation function
-		if (pcs->m_num->ele_supg_method > 0) //NW
-			getGradShapefunctValues(gp, 1);  // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
+		if (pcs->m_num->ele_supg_method > 0) // NW
+			getGradShapefunctValues(gp, 1); // Linear interpolation function
 
 		// Material
 		mat_fac = CalCoefMass();
@@ -4064,7 +3985,7 @@ void CFiniteElementStd::UpwindAlphaMass(double* alpha)
 	// SetGaussPoint(point, gp_r, gp_s, gp_t);
 	// velocity transformation a,b,c -> r,s,t
 	const bool inverse = false;
-	computeJacobian(0, 1, inverse);                   // order 1
+	computeJacobian(0, 1, inverse); // order 1
 	// multiply velocity vector with Jacobian matrix
 	// Jacobi*v-->v_rst
 	for (size_t i = 0; i < ele_dim; i++)
@@ -4155,7 +4076,7 @@ void CFiniteElementStd::UpwindAlphaMass(double* alpha)
 		case 3: // Hexahedra
 		{
 			/* Elementgeometriedaten */
-			static double *invjac, jacobi[9], detjac;
+			static double* invjac, jacobi[9], detjac;
 			/* Elementdaten */
 			// static double v_rst[3];
 
@@ -4256,22 +4177,22 @@ void CFiniteElementStd::UpwindSummandMass(const int gp, int& gp_r, int& gp_s, in
 			u2 = MXPGaussPkt(nGauss, gp_s);
 			u3 = MXPGaussPkt(nGauss, gp_t);
 			// derived from MPhi3D_SUPG
-			summand[0]
-			    = +alpha[0] * (1 + u2) * (1 + u3) + alpha[1] * (1 + u1) * (1 + u3) + alpha[2] * (1 + u1) * (1 + u2);
-			summand[1]
-			    = -alpha[0] * (1 + u2) * (1 + u3) + alpha[1] * (1 - u1) * (1 + u3) + alpha[2] * (1 - u1) * (1 + u2);
-			summand[2]
-			    = -alpha[0] * (1 - u2) * (1 + u3) - alpha[1] * (1 - u1) * (1 + u3) + alpha[2] * (1 - u1) * (1 - u2);
-			summand[3]
-			    = +alpha[0] * (1 - u2) * (1 + u3) - alpha[1] * (1 + u1) * (1 + u3) + alpha[2] * (1 + u1) * (1 - u2);
-			summand[4]
-			    = +alpha[0] * (1 + u2) * (1 - u3) + alpha[1] * (1 + u1) * (1 - u3) - alpha[2] * (1 + u1) * (1 + u2);
-			summand[5]
-			    = -alpha[0] * (1 + u2) * (1 - u3) + alpha[1] * (1 - u1) * (1 - u3) - alpha[2] * (1 - u1) * (1 + u2);
-			summand[6]
-			    = -alpha[0] * (1 - u2) * (1 - u3) - alpha[1] * (1 - u1) * (1 - u3) - alpha[2] * (1 - u1) * (1 - u2);
-			summand[7]
-			    = +alpha[0] * (1 - u2) * (1 - u3) - alpha[1] * (1 + u1) * (1 - u3) - alpha[2] * (1 + u1) * (1 - u2);
+			summand[0] = +alpha[0] * (1 + u2) * (1 + u3) + alpha[1] * (1 + u1) * (1 + u3)
+			             + alpha[2] * (1 + u1) * (1 + u2);
+			summand[1] = -alpha[0] * (1 + u2) * (1 + u3) + alpha[1] * (1 - u1) * (1 + u3)
+			             + alpha[2] * (1 - u1) * (1 + u2);
+			summand[2] = -alpha[0] * (1 - u2) * (1 + u3) - alpha[1] * (1 - u1) * (1 + u3)
+			             + alpha[2] * (1 - u1) * (1 - u2);
+			summand[3] = +alpha[0] * (1 - u2) * (1 + u3) - alpha[1] * (1 + u1) * (1 + u3)
+			             + alpha[2] * (1 + u1) * (1 - u2);
+			summand[4] = +alpha[0] * (1 + u2) * (1 - u3) + alpha[1] * (1 + u1) * (1 - u3)
+			             - alpha[2] * (1 + u1) * (1 + u2);
+			summand[5] = -alpha[0] * (1 + u2) * (1 - u3) + alpha[1] * (1 - u1) * (1 - u3)
+			             - alpha[2] * (1 - u1) * (1 + u2);
+			summand[6] = -alpha[0] * (1 - u2) * (1 - u3) - alpha[1] * (1 - u1) * (1 - u3)
+			             - alpha[2] * (1 - u1) * (1 - u2);
+			summand[7] = +alpha[0] * (1 - u2) * (1 - u3) - alpha[1] * (1 + u1) * (1 - u3)
+			             - alpha[2] * (1 + u1) * (1 - u2);
 			for (i = 0; i < 8; i++)
 				summand[i] *= 0.125;
 		}
@@ -4326,8 +4247,8 @@ void CFiniteElementStd::CalcMass2()
 		//---------------------------------------------------------
 		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		// Compute geometry
-		getShapefunctValues(gp, 1);       // Linear interpolation function
-		for(in = 0; in < dof_n; in++)
+		getShapefunctValues(gp, 1); // Linear interpolation function
+		for (in = 0; in < dof_n; in++)
 		{
 			for (jn = 0; jn < dof_n; jn++)
 			{
@@ -4373,18 +4294,19 @@ void CFiniteElementStd::CalcMassMCF()
 	CalCoefMassMCF(); // Calculate mass matrix
 	for (gp = 0; gp < nGaussPoints; gp++)
 	{
-		fkt = GetGaussData(gp, gp_r, gp_s, gp_t); //Compute Jacobian matrix and its determinate
+		fkt = GetGaussData(gp, gp_r, gp_s, gp_t); // Compute Jacobian matrix and its determinate
 		getShapefunctValues(gp, 1);
-		for(in = 0; in < nDF; in++)
+		for (in = 0; in < nDF; in++)
 		{
 			const int ish = in * nnodes;
-			for(jn = 0; jn < nDF; jn++)
+			for (jn = 0; jn < nDF; jn++)
 			{
 				const int jsh = jn * nnodes;
 				for (i = 0; i < nnodes; i++)
 				{
 					for (j = 0; j < nnodes; j++)
-						(*Mass2)(i + ish, j + jsh) +=  fkt*MassMatrixElements[in*nDF + jn]*shapefct[i] *shapefct[j];
+						(*Mass2)(i + ish, j + jsh) += fkt * MassMatrixElements[in * nDF + jn] * shapefct[i]
+						                              * shapefct[j];
 				}
 			}
 		}
@@ -4399,33 +4321,33 @@ void CFiniteElementStd::CalcMassMCF()
  **************************************************************************/
 void CFiniteElementStd::CalcMassPSGLOBAL()
 {
-  int i, j,in,jn;
-  // ---- Gauss integral
-  int gp_r = 0,gp_s = 0,gp_t = 0;
-  double fkt,mat_fac;
-  // Material
-  int dof_n = 2;
-  mat_fac = 1.0;
-  //----------------------------------------------------------------------
-  //======================================================================
-  // Loop over Gauss points
-  for (gp = 0; gp < nGaussPoints; gp++)
-  {
-      //---------------------------------------------------------
-      //  Get local coordinates and weights
-      //  Compute Jacobian matrix and its determinate
-      //---------------------------------------------------------
-      fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
-      // Compute geometry
-      getShapefunctValues(gp, 1);       // Linear interpolation function
-      for(in = 0; in < dof_n; in++)
-      {
-         for(jn = 0; jn < dof_n; jn++)
-         {
-             // Material
-             mat_fac = CalCoefMassPSGLOBAL(in * dof_n + jn);
-             mat_fac *= fkt;
-             // Calculate mass matrix
+	int i, j, in, jn;
+	// ---- Gauss integral
+	int gp_r = 0, gp_s = 0, gp_t = 0;
+	double fkt, mat_fac;
+	// Material
+	int dof_n = 2;
+	mat_fac = 1.0;
+	//----------------------------------------------------------------------
+	//======================================================================
+	// Loop over Gauss points
+	for (gp = 0; gp < nGaussPoints; gp++)
+	{
+		//---------------------------------------------------------
+		//  Get local coordinates and weights
+		//  Compute Jacobian matrix and its determinate
+		//---------------------------------------------------------
+		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
+		// Compute geometry
+		getShapefunctValues(gp, 1); // Linear interpolation function
+		for (in = 0; in < dof_n; in++)
+		{
+			for (jn = 0; jn < dof_n; jn++)
+			{
+				// Material
+				mat_fac = CalCoefMassPSGLOBAL(in * dof_n + jn);
+				mat_fac *= fkt;
+// Calculate mass matrix
 #if defined(USE_PETSC) // || defined(other parallel libs)//03~04.3012. WW
 				for (i = 0; i < act_nodes; i++)
 				{
@@ -4557,17 +4479,17 @@ void CFiniteElementStd::CalcLumpedMass2()
 	(*Mass2) = 0.0;
 	// Center of the reference element
 	getShapeFunctionCentroid();
-	for(in = 0; in < dof_n; in++)
-	  {
-	    const int ish = in * nnodes;
-	    for(jn = 0; jn < dof_n; jn++)
-	      {
-		// Factor
-		factor = CalCoefMass2(in * dof_n + jn);
-		pcs->timebuffer = factor; // Tim Control "Neumann"
-		// Volume
-		factor *= vol / (double)nnodes;
-		const int jsh = jn * nnodes; //WW
+	for (in = 0; in < dof_n; in++)
+	{
+		const int ish = in * nnodes;
+		for (jn = 0; jn < dof_n; jn++)
+		{
+			// Factor
+			factor = CalCoefMass2(in * dof_n + jn);
+			pcs->timebuffer = factor; // Tim Control "Neumann"
+			// Volume
+			factor *= vol / (double)nnodes;
+			const int jsh = jn * nnodes; // WW
 #if defined(USE_PETSC) // || defined(other parallel libs)//03~04.3012. WW
 			for (i = 0; i < act_nodes; i++)
 			{
@@ -4667,17 +4589,17 @@ void CFiniteElementStd::CalcLumpedMassPSGLOBAL()
 	(*Mass2) = 0.0;
 	// Center of the reference element
 	getShapeFunctionCentroid();
-	for(in = 0; in < dof_n; in++)
-	  {
-	    const int ish = in * nnodes; //WW
-	    for(jn = 0; jn < dof_n; jn++)
-	      {
-		// Factor
-		factor = CalCoefMassPSGLOBAL(in * dof_n + jn);
-		pcs->timebuffer = factor; // Tim Control "Neumann"
-		// Volume
-		factor *= vol / (double)nnodes;
-		const int jsh = jn * nnodes; //WW
+	for (in = 0; in < dof_n; in++)
+	{
+		const int ish = in * nnodes; // WW
+		for (jn = 0; jn < dof_n; jn++)
+		{
+			// Factor
+			factor = CalCoefMassPSGLOBAL(in * dof_n + jn);
+			pcs->timebuffer = factor; // Tim Control "Neumann"
+			// Volume
+			factor *= vol / (double)nnodes;
+			const int jsh = jn * nnodes; // WW
 #if defined(USE_PETSC) // || defined(other parallel libs)//03~04.3012. WW
 			for (i = 0; i < act_nodes; i++)
 			{
@@ -4723,7 +4645,7 @@ void CFiniteElementStd::CalcStorage()
 		//---------------------------------------------------------
 		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		// Compute geometry
-		getShapefunctValues(gp, 1);       // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
 		// Material
 		mat_fac = CalCoefStorage();
 		// GEO factor
@@ -4777,7 +4699,7 @@ void CFiniteElementStd::CalcContent()
 		//---------------------------------------------------------
 		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		// Compute geometry
-		getShapefunctValues(gp, 1);       // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
 		// Material
 		mat_fac = CalCoefContent();
 		// GEO factor
@@ -4895,8 +4817,8 @@ void CFiniteElementStd::CalcLaplace()
 							const int km = dim * k;
 							for (std::size_t l = 0; l < dim; l++)
 							{
-								(*Laplace)(iish, jjsh)
-								    += fkt * dshapefct[ksh] * mat[km + l] * dshapefct[l * nnodes + j];
+								(*Laplace)(iish, jjsh) += fkt * dshapefct[ksh] * mat[km + l]
+								                          * dshapefct[l * nnodes + j];
 							}
 						}
 					} // j: nodes
@@ -4916,8 +4838,8 @@ void CFiniteElementStd::CalcLaplace()
 							const int km = dim * k;
 							for (size_t l = 0; l < dim; l++)
 							{
-								(*Laplace)(iish, jjsh)
-								    += fkt * dshapefct[ksh] * mat[km + l] * dshapefct[l * nnodes + j];
+								(*Laplace)(iish, jjsh) += fkt * dshapefct[ksh] * mat[km + l]
+								                          * dshapefct[l * nnodes + j];
 							}
 						}
 					} // j: nodes
@@ -4942,24 +4864,25 @@ void CFiniteElementStd::CalcLaplaceMCF()
 	double fkt;
 	for (gp = 0; gp < nGaussPoints; gp++)
 	{
-	fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
-	getGradShapefunctValues(gp, 1);
-	getShapefunctValues(gp, 1); // For thoese used in the material parameter caculation
-	CalCoefLaplaceMCF(gp);
-	for(in = 0; in < nDF; in++)
-	{
-	const int ish = in * nnodes;
-	for(i = 0; i < nnodes; i++)
-	{
-	for(j = 0;  j< nnodes; j++)
-	{
-	for(size_t k = 0; k < dim; k++)
-	{
-	(*Laplace)(i + ish, j + ish) += fkt*LaplaceMatrixElements[in*nDF + in][dim*k + k] *dshapefct[k*nnodes + i]*dshapefct[k*nnodes + j];
-	}
-	}
-	}
-	}
+		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
+		getGradShapefunctValues(gp, 1);
+		getShapefunctValues(gp, 1); // For thoese used in the material parameter caculation
+		CalCoefLaplaceMCF(gp);
+		for (in = 0; in < nDF; in++)
+		{
+			const int ish = in * nnodes;
+			for (i = 0; i < nnodes; i++)
+			{
+				for (j = 0; j < nnodes; j++)
+				{
+					for (size_t k = 0; k < dim; k++)
+					{
+						(*Laplace)(i + ish, j + ish) += fkt * LaplaceMatrixElements[in * nDF + in][dim * k + k]
+						                                * dshapefct[k * nnodes + i] * dshapefct[k * nnodes + j];
+					}
+				}
+			}
+		}
 	}
 	// TEST OUTPUT
 	// Laplace->Write();
@@ -5004,9 +4927,9 @@ void CFiniteElementStd::Assemble_DualTransfer()
 		//---------------------------------------------------------
 		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		// Material
-		getShapefunctValues(gp, 1);       // Moved here by NW 25.10.2011
-        	mat_fac = CalcCoefDualTransfer();
-        	mat_fac *= fkt;
+		getShapefunctValues(gp, 1); // Moved here by NW 25.10.2011
+		mat_fac = CalcCoefDualTransfer();
+		mat_fac *= fkt;
 		// Calculate mass matrix
 		for (i = 0; i < nnodes; i++)
 			for (j = 0; j < nnodes; j++)
@@ -5220,8 +5143,8 @@ void CFiniteElementStd::CalcAdvection()
 		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		//---------------------------------------------------------
 		// Compute geometry
-		getGradShapefunctValues(gp, 1);   // Linear interpolation function....dNJ-1....var dshapefct
-		getShapefunctValues(gp, 1);       // Linear interpolation N....var shapefct
+		getGradShapefunctValues(gp, 1); // Linear interpolation function....dNJ-1....var dshapefct
+		getShapefunctValues(gp, 1); // Linear interpolation N....var shapefct
 		//---------------------------------------------------------
 		mat_factor = CalCoefAdvection(); // this should be called after calculating shape functions. NW
 		// Velocity
@@ -5331,8 +5254,8 @@ void CFiniteElementStd::CalcAdvectionMCF()
 	for (gp = 0; gp < nGaussPoints; gp++)
 	{
 		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
-		getGradShapefunctValues(gp, 1);   // Linear interpolation function....dNJ-1....var dshapefct
-		getShapefunctValues(gp, 1);       // Linear interpolation N....var shapefct
+		getGradShapefunctValues(gp, 1); // Linear interpolation function....dNJ-1....var dshapefct
+		getShapefunctValues(gp, 1); // Linear interpolation N....var shapefct
 		vel[0] = gp_ele->Velocity(0, gp);
 		vel[1] = gp_ele->Velocity(1, gp);
 		vel[2] = gp_ele->Velocity(2, gp);
@@ -5374,20 +5297,21 @@ void CFiniteElementStd::CalcContentMCF()
 	CalCoefContentMCF();
 	for (gp = 0; gp < nGaussPoints; gp++)
 	{
-	fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
-	getShapefunctValues(gp, 1);       // Linear interpolation N....var shapefct
+		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
+		getShapefunctValues(gp, 1); // Linear interpolation N....var shapefct
 
-	for (in = 0; in < nDF; in++)
-	{
-	const int ish = in * nnodes;
-	for (i = 0; i< nnodes; i++)
-	{
-	for (j = 0; j< nnodes; j++)
-	{
-	(*Content)(i + ish, j + ish) += fkt*ContentMatrixElements[in*nDF + in]*shapefct[i]*shapefct[j];
-	}
-	}
-	}
+		for (in = 0; in < nDF; in++)
+		{
+			const int ish = in * nnodes;
+			for (i = 0; i < nnodes; i++)
+			{
+				for (j = 0; j < nnodes; j++)
+				{
+					(*Content)(i + ish, j + ish) += fkt * ContentMatrixElements[in * nDF + in] * shapefct[i]
+					                                * shapefct[j];
+				}
+			}
+		}
 	}
 }
 /**************************************************************************
@@ -5405,12 +5329,15 @@ void CFiniteElementStd::CalCoefContentMCF()
 		ContentMatrixElements[in] = 0.0;
 	if (FluidProp->cmpN > 0)
 	{
-	for(in = 0; in < nDF; in++) arg_PV[in] = interpolate(NodalValue[in]);
-	rho = FluidProp->Density(arg_PV);
-	poro = MediaProp->Porosity(Index, pcs->m_num->ls_theta);
-	for(in = 0; in<nDF-2; in++) retardation_factore[in] = 1.0 + (1.0 - poro)*SolidProp->Density(0)*FluidProp->Kd[in]*pow(poro, -1.0);
-	for(in = 2; in < nDF; in++)
-	ContentMatrixElements[(nDF + 1)*in] = poro*rho*retardation_factore[in - 2]*FluidProp->lambda[in-2];
+		for (in = 0; in < nDF; in++)
+			arg_PV[in] = interpolate(NodalValue[in]);
+		rho = FluidProp->Density(arg_PV);
+		poro = MediaProp->Porosity(Index, pcs->m_num->ls_theta);
+		for (in = 0; in < nDF - 2; in++)
+			retardation_factore[in] = 1.0 + (1.0 - poro) * SolidProp->Density(0) * FluidProp->Kd[in] * pow(poro, -1.0);
+		for (in = 2; in < nDF; in++)
+			ContentMatrixElements[(nDF + 1) * in] = poro * rho * retardation_factore[in - 2]
+			                                        * FluidProp->lambda[in - 2];
 	}
 }
 /***************************************************************************
@@ -5455,7 +5382,7 @@ void CFiniteElementStd::CalcRHS_by_ThermalDiffusion()
 
 		//---------------------------------------------------------
 		// Compute geometry
-		getGradShapefunctValues(gp, 1);   // Linear interpolation function
+		getGradShapefunctValues(gp, 1); // Linear interpolation function
 		//---------------------------------------------------------
 		getShapefunctValues(gp, 1);
 		double rhow = FluidProp->Density();
@@ -5471,8 +5398,7 @@ void CFiniteElementStd::CalcRHS_by_ThermalDiffusion()
 		     * pow(TG / PhysicalConstant::CelsiusZeroInKelvin, 1.8);
 		rhov = humi * FluidProp->vaporDensity(TG);
 		drdT = (FluidProp->vaporDensity_derivative(TG) * humi
-		        - rhov * PG / (SpecificGasConstant::WaterVapour * rhow * TG * TG))
-		       / rhow;
+		        - rhov * PG / (SpecificGasConstant::WaterVapour * rhow * TG * TG)) / rhow;
 		Dtv = time_unit_factor * Dv * drdT;
 
 		//    }
@@ -5606,30 +5532,29 @@ void CFiniteElementStd::CalcStrainCoupling(int phase)
 	{
 		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 
-			getGradShapefunctValues(gp, 2);
-			getShapefunctValues(gp, 1);
-			getShapefunctValues(gp, 2);
+		getGradShapefunctValues(gp, 2);
+		getShapefunctValues(gp, 1);
+		getShapefunctValues(gp, 2);
 
-			if (axisymmetry)
-			{
-				Radius = 0.0;
-				for(int i = 0; i < nnodes; i++)
-					Radius += shapefct[i] * X[i];
-			}
-			//
-			fkt *= CalCoefStrainCouping(phase);
-			for(size_t i = 0; i < dim; i++ )
-			{
-				for (int k = 0; k < nnodes; k++)
-					for (int l = 0; l < nnodesHQ; l++)
-					{
-						kl = nnodesHQ * i + l;
-						du  = dshapefctHQ[kl];
-						if(i == 0 && axisymmetry)
-							du += shapefctHQ[l] / Radius;
-						(*StrainCoupling)(k, kl) += shapefct[k] * du * fkt;
-					}
-			}
+		if (axisymmetry)
+		{
+			Radius = 0.0;
+			for (int i = 0; i < nnodes; i++)
+				Radius += shapefct[i] * X[i];
+		}
+		//
+		fkt *= CalCoefStrainCouping(phase);
+		for (size_t i = 0; i < dim; i++)
+		{
+			for (int k = 0; k < nnodes; k++)
+				for (int l = 0; l < nnodesHQ; l++)
+				{
+					kl = nnodesHQ * i + l;
+					du = dshapefctHQ[kl];
+					if (i == 0 && axisymmetry)
+						du += shapefctHQ[l] / Radius;
+					(*StrainCoupling)(k, kl) += shapefct[k] * du * fkt;
+				}
 		}
 	}
 	setOrder(1);
@@ -5659,8 +5584,8 @@ void CFiniteElementStd::CalcStrainCoupling(int phase)
 // Local assembly
 void CFiniteElementStd::Assemble_Gravity()
 {
-	//int Index = MeshElement->GetIndex();
-	if((coordinate_system) % 10 != 2)     //NW: exclude (!axisymmetry)
+	// int Index = MeshElement->GetIndex();
+	if ((coordinate_system) % 10 != 2) // NW: exclude (!axisymmetry)
 
 		// 27.2.2007 WW (*GravityMatrix) = 0.0;
 		return;
@@ -5710,8 +5635,8 @@ void CFiniteElementStd::Assemble_Gravity()
 		//---------------------------------------------------------
 		// Compute geometry
 		//---------------------------------------------------------
-		getGradShapefunctValues(gp, 1);   // Linear interpolation function
-		getShapefunctValues(gp, 1);       // Moved from CalCoefLaplace(). 12.3.2007 WW
+		getGradShapefunctValues(gp, 1); // Linear interpolation function
+		getShapefunctValues(gp, 1); // Moved from CalCoefLaplace(). 12.3.2007 WW
 		// Material
 		if (PcsType == EPT_THERMAL_NONEQUILIBRIUM || PcsType == EPT_TES)
 		{
@@ -5838,30 +5763,33 @@ void CFiniteElementStd::Assemble_GravityMCF()
 		}
 	}
 	getShapeFunctionCentroid();
-	for(in = 0; in < nDF; in++) arg_PV[in] = interpolate(NodalValue[in]);
+	for (in = 0; in < nDF; in++)
+		arg_PV[in] = interpolate(NodalValue[in]);
 	mat_fac = FluidProp->Density(arg_PV);
 	// Loop over Gauss points
 	for (gp = 0; gp < nGaussPoints; gp++)
 	{
-	fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
-	//---------------------------------------------------------
-	getGradShapefunctValues(gp, 1);   // Linear interpolation function
-	getShapefunctValues(gp, 1);       // Moved from CalCoefLaplace(). 12.3.2007 WW
-	tensor = MediaProp->DispersionTensorMCF(gp, 0,  0, arg_PV);
-	for (j = 0; j < nnodes; j++)
-	{
-	for(in = 0; in <nDF; in++) arg_PV[in] = pcs->GetNodeValue(nodes[j], idxMCF[in + nDF]);//current PV
-	//
-	rho = FluidProp->Density(arg_PV);
-	//
-	for (i = 0; i < nnodes; i++)
-	{
-	for (size_t k = 0; k < dim; k++)
-	{
-	NodalVal[i] -= fkt*mat_fac*tensor[dim*k + dim - 1]*dshapefct[k* nnodes + i]*shapefct[j]*rho*gravity_vector[k];
-	}
-	}
-	}
+		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
+		//---------------------------------------------------------
+		getGradShapefunctValues(gp, 1); // Linear interpolation function
+		getShapefunctValues(gp, 1); // Moved from CalCoefLaplace(). 12.3.2007 WW
+		tensor = MediaProp->DispersionTensorMCF(gp, 0, 0, arg_PV);
+		for (j = 0; j < nnodes; j++)
+		{
+			for (in = 0; in < nDF; in++)
+				arg_PV[in] = pcs->GetNodeValue(nodes[j], idxMCF[in + nDF]); // current PV
+			//
+			rho = FluidProp->Density(arg_PV);
+			//
+			for (i = 0; i < nnodes; i++)
+			{
+				for (size_t k = 0; k < dim; k++)
+				{
+					NodalVal[i] -= fkt * mat_fac * tensor[dim * k + dim - 1] * dshapefct[k * nnodes + i] * shapefct[j]
+					               * rho * gravity_vector[k];
+				}
+			}
+		}
 	}
 	cshift += NodeShift[problem_dimension_dm];
 	cshift += NodeShift[0];
@@ -5930,8 +5858,8 @@ void CFiniteElementStd::Assemble_Gravity_Multiphase()
 		//---------------------------------------------------------
 		// Compute geometry
 		//---------------------------------------------------------
-		getGradShapefunctValues(gp, 1);   // Linear interpolation function
-		getShapefunctValues(gp, 1);       // Moved from CalCoefLaplace(). 12.3.2016 WW
+		getGradShapefunctValues(gp, 1); // Linear interpolation function
+		getShapefunctValues(gp, 1); // Moved from CalCoefLaplace(). 12.3.2016 WW
 		// Material
 		// PCH
 		// Pressure equation is the sum of all pressures for all the phases
@@ -6223,7 +6151,7 @@ void CFiniteElementStd::CalcSolidDensityRate()
 		// Compute geometry
 		//---------------------------------------------------------
 		// ComputeGradShapefct(1);                  // Linear interpolation function
-		getShapefunctValues(gp, 1); //3.2016 WW
+		getShapefunctValues(gp, 1); // 3.2016 WW
 
 		// get interpolated primary variable values
 		const double p_g = time_interpolate(NodalVal0, NodalVal1, theta, this);
@@ -6259,8 +6187,8 @@ void CFiniteElementStd::CalcSolidDensityRate()
 				const double rhoSR0 = 1.0;
 				const double rhoTil = 0.1;
 				const double omega = 2.0 * 3.1416;
-				gp_ele->rho_s_curr[gp]
-				    = rhoSR0 + rhoTil * sin(omega * aktuelle_zeit) / (1.0 - poro); // TN Test mass transfer
+				gp_ele->rho_s_curr[gp] = rhoSR0
+				                         + rhoTil * sin(omega * aktuelle_zeit) / (1.0 - poro); // TN Test mass transfer
 				gp_ele->q_R[gp] = rhoTil * omega * cos(omega * aktuelle_zeit) / (1.0 - poro); // TN Test mass transfer
 			}
 			else
@@ -6402,10 +6330,10 @@ void CFiniteElementStd::Cal_Velocity()
 		//---------------------------------------------------------
 		// Compute geometry
 		//---------------------------------------------------------
-		getGradShapefunctValues(gp, 1);   // Linear interpolation function
-		getShapefunctValues(gp, 1);       // Moved from CalCoefLaplace(). 12.3.2007 WW
-		                          //WW/CB
-		if((PcsType == EPT_TWOPHASE_FLOW) && (pcs->pcs_type_number == 1))
+		getGradShapefunctValues(gp, 1); // Linear interpolation function
+		getShapefunctValues(gp, 1); // Moved from CalCoefLaplace(). 12.3.2007 WW
+		// WW/CB
+		if ((PcsType == EPT_TWOPHASE_FLOW) && (pcs->pcs_type_number == 1))
 			flag_cpl_pcs = true;
 		// Material
 		if (dof_n == 1)
@@ -6468,7 +6396,7 @@ void CFiniteElementStd::Cal_Velocity()
 				if (dim == 3 && ele_dim == 2)
 				{
 					vel[dim - 1] += coef; // NW local permeability tensor is already transformed to global one in
-					// CalCoefLaplace()
+					                      // CalCoefLaplace()
 					if (PcsType == EPT_MULTIPHASE_FLOW || PcsType == EPT_PSGLOBAL)
 					{
 						for (size_t i = 0; i < dim; i++)
@@ -6536,8 +6464,8 @@ void CFiniteElementStd::Cal_Velocity()
 
 					if (GasMassForm)
 					{ // TN otherwise wrong velocity
-						tmp_gp_velocity(i, gp)
-						    -= mat[dim * i + j] / FluidProp->Density(eos_arg) * vel[j] / time_unit_factor;
+						tmp_gp_velocity(i, gp) -= mat[dim * i + j] / FluidProp->Density(eos_arg) * vel[j]
+						                          / time_unit_factor;
 					}
 					else
 					{
@@ -6624,13 +6552,14 @@ void CFiniteElementStd::Cal_VelocityMCF()
 		}
 	}
 	getShapeFunctionCentroid();
-	for(in = 0; in < nDF; in++) arg_PV[in] = interpolate(NodalValue[in]);
+	for (in = 0; in < nDF; in++)
+		arg_PV[in] = interpolate(NodalValue[in]);
 	gp_ele->Velocity = 0.0;
 	for (gp = 0; gp < nGaussPoints; gp++)
 	{
 		GetGaussData(gp, gp_r, gp_s, gp_t);
-		ComputeGradShapefct(1);
-		ComputeShapefct(1);
+		getGradShapefunctValues(gp, 1); // Linear interpolation function
+		getShapefunctValues(gp, 1); // 03.2016 WW
 		tensor = MediaProp->DispersionTensorMCF(gp, 0, 0, arg_PV);
 		for (j = 0; j < nnodes; j++)
 		{
@@ -6641,34 +6570,20 @@ void CFiniteElementStd::Cal_VelocityMCF()
 			//
 			for (size_t k = 0; k < dim; k++)
 			{
-				gp_ele->Velocity(k, gp)
-				    -= tensor[dim * k + k] * (dshapefct[k * nnodes + j] * pcs->GetNodeValue(nodes[j], idxMCF[0 + nDF])
+				gp_ele->Velocity(k, gp) -= tensor[dim * k + k]
+				                           * (dshapefct[k * nnodes + j] * pcs->GetNodeValue(nodes[j], idxMCF[0 + nDF])
 				                              + shapefct[j] * rho * gravity_vector[k]);
 			}
 		}
 
-	GetGaussData(gp, gp_r, gp_s, gp_t);
-	getGradShapefunctValues(gp, 1);   // Linear interpolation function
-	getShapefunctValues(gp, 1);       // 03.2016 WW
-	tensor = MediaProp->DispersionTensorMCF(gp, 0, 0, arg_PV);
-	for(j = 0; j<nnodes; j++)
-	{
-	for(in = 0; in<nDF; in++) arg_PV[in] = pcs->GetNodeValue(nodes[j], idxMCF[in + nDF]);
-	//
-	rho = FluidProp->Density(arg_PV);
-	//
-	for (size_t k = 0; k<dim; k++)
-	{
-	gp_ele->Velocity(k, gp) -= tensor[dim*k + k]*(dshapefct[k*nnodes + j]*pcs->GetNodeValue(nodes[j], idxMCF[0 + nDF]) + shapefct[j]*rho*gravity_vector[k]);
-	}
-	}
-
-	//
-	if(pcs->Write_Matrix)
-	{
-	(*pcs->matrix_file) << "### Element: " << Index << endl;
-	(*pcs->matrix_file) << "---Velocity of fluid " << endl;
-	gp_ele->Velocity.Write(*pcs->matrix_file);
+		//
+		if (pcs->Write_Matrix)
+		{
+			(*pcs->matrix_file) << "### Element: " << Index << endl;
+			(*pcs->matrix_file) << "---Velocity of fluid " << endl;
+			gp_ele->Velocity.Write(*pcs->matrix_file);
+		}
+		// gp_ele->Velocity.Write();
 	}
 }
 
@@ -6958,13 +6873,13 @@ void CFiniteElementStd::Cal_Velocity_2()
 	//  Compute Jacobian matrix and its determination
 	//---------------------------------------------------------
 
-	//GetGaussData(gp, gp_r, gp_s, gp_t);
+	// GetGaussData(gp, gp_r, gp_s, gp_t);
 	// calculate the velocity at the element center of gravity
 
 	//---------------------------------------------------------
 	// Compute geometry
 	//---------------------------------------------------------
-	if((PcsType == EPT_TWOPHASE_FLOW) && (pcs->pcs_type_number == 1)) //WW/CB
+	if ((PcsType == EPT_TWOPHASE_FLOW) && (pcs->pcs_type_number == 1)) // WW/CB
 		flag_cpl_pcs = true;
 	// Material
 	if (dof_n == 1)
@@ -7154,7 +7069,7 @@ string CFiniteElementStd::Cal_GP_Velocity_ECLIPSE(string tempstring, bool output
 		// GetGaussData(gp, gp_r, gp_s, gp_t);
 		// WW fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		// Compute the shape function for interpolation within element
-		getShapefunctValues(gp, 1);       // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
 
 		// Save former gp velocity for test use only
 		for (size_t i_dim = 0; i_dim < dim; i_dim++)
@@ -7308,8 +7223,8 @@ void CFiniteElementStd::AssembleRHS(int dimension)
 		//---------------------------------------------------------
 		// Compute geometry
 		//---------------------------------------------------------
-		getGradShapefunctValues(gp, 1);   // Linear interpolation function
-		getShapefunctValues(gp, 1);       // Linear interpolation function
+		getGradShapefunctValues(gp, 1); // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
 
 		// Material
 		CalCoefLaplace(true);
@@ -7328,9 +7243,8 @@ void CFiniteElementStd::AssembleRHS(int dimension)
 			rho = 1.0;
 		else
 			rho *= gravity_constant;
-		//			rho *= gravity_constant/FluidProp->Viscosity();		// This seems to divide viscosity two times.
-		// Thus,
-		// wrong.
+		//			rho *= gravity_constant/FluidProp->Viscosity();		// This seems to divide viscosity two times. Thus,
+		//wrong.
 
 		fktG *= rho;
 		for (int i = 0; i < nnodes; i++)
@@ -7917,7 +7831,7 @@ void CFiniteElementStd::add2GlobalMatrixII()
 // TEST
 #ifdef assmb_petsc_test
 	{
-		os_t << "\n------------------" << act_nodes * dof << "\n";
+		os_t << "\n------------------" << act_nodes* dof << "\n";
 		StiffMatrix->Write(os_t);
 		RHS->Write(os_t);
 
@@ -8461,8 +8375,7 @@ void CFiniteElementStd::AssembleParabolicEquationNewton()
 		for (int j = 0; j < nnodes; j++)
 #if defined(NEW_EQS) // WW
 			(*pcs->eqs_new->A)(NodeShift[problem_dimension_dm] + eqs_number[i],
-			                   NodeShift[problem_dimension_dm] + eqs_number[j])
-			    += jacobian[i][j]; // WW
+			                   NodeShift[problem_dimension_dm] + eqs_number[j]) += jacobian[i][j]; // WW
 #else
 			MXInc(NodeShift[problem_dimension_dm] + eqs_number[i], NodeShift[problem_dimension_dm] + eqs_number[j],
 			      jacobian[i][j]);
@@ -8653,8 +8566,7 @@ void CFiniteElementStd::Assemble_strainCPL(const int phase)
 		for (i = 0; i < nnodes; i++)
 		{
 #if !defined(USE_PETSC) // && !defined(other parallel libs)//03~04.3012. WW
-			eqs_rhs[NodeShift[shift_index] + eqs_number[i]]
-			        += NodalVal[i];
+			eqs_rhs[NodeShift[shift_index] + eqs_number[i]] += NodalVal[i];
 #endif
 			(*RHS)[i + LocalShift] += NodalVal[i];
 		}
@@ -8751,7 +8663,7 @@ void CFiniteElementStd::AssembleMassMatrix(int option)
 		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 
 		// Compute geometry
-		getShapefunctValues(gp, 1);       // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
 
 		if (option == 0) // The consistent method
 
@@ -9004,7 +8916,7 @@ void CFiniteElementStd::Config()
 **************************************************************************/
 void CFiniteElementStd::Assembly()
 {
-	Config();                             //26.08.2008
+	Config(); // 26.08.2008
 
 	// If output matrices and vectors. 07.2011. WW
 	if (pcs->Write_Matrix)
@@ -9052,28 +8964,31 @@ void CFiniteElementStd::Assembly()
 				// Turn off the partial-pressure-based model for Snw equation
 				pcs->PartialPS = 0;
 
-			AssembleRHSVector();
-			Assemble_Gravity_Multiphase();
-		}
-		add2GlobalMatrixII();
-		break;
-	//....................................................................
-	case EPT_COMPONENTAL_FLOW:                               // Componental flow
-		for(int i = 0; i < nnodes; i++)
-			NodalVal_Sat[i] = pcs->GetNodeValue(nodes[i], idxS);
-		break;
-	//....................................................................
-	case EPT_HEAT_TRANSPORT:                               // Heat transport
-		heat_phase_change = false; // ?2WW
-		//  if(SolidProp->GetCapacityModel()==2) // Boiling model
-		//    CalNodalEnthalpy();
-		//CMCD4213
-		AssembleMixedHyperbolicParabolicEquation();
-		if(FluidProp->density_model == 14 && MediaProp->heat_diffusion_model == 1 &&
-		   cpl_pcs )
-			Assemble_RHS_HEAT_TRANSPORT();  // This include when need pressure terms n dp/dt + nv.Nabla p//AKS
-		if(MediaProp->evaporation == 647)
-			Assemble_RHS_HEAT_TRANSPORT2();  //AKS
+				pcs->ML_Cap = 0;
+				AssembleParabolicEquation();
+				pcs->ML_Cap = 0;
+
+				AssembleRHSVector();
+				Assemble_Gravity_Multiphase();
+			}
+			add2GlobalMatrixII();
+			break;
+		//....................................................................
+		case EPT_COMPONENTAL_FLOW: // Componental flow
+			for (int i = 0; i < nnodes; i++)
+				NodalVal_Sat[i] = pcs->GetNodeValue(nodes[i], idxS);
+			break;
+		//....................................................................
+		case EPT_HEAT_TRANSPORT: // Heat transport
+			heat_phase_change = false; // ?2WW
+			//  if(SolidProp->GetCapacityModel()==2) // Boiling model
+			//    CalNodalEnthalpy();
+			// CMCD4213
+			AssembleMixedHyperbolicParabolicEquation();
+			if (FluidProp->density_model == 14 && MediaProp->heat_diffusion_model == 1 && cpl_pcs)
+				Assemble_RHS_HEAT_TRANSPORT(); // This include when need pressure terms n dp/dt + nv.Nabla p//AKS
+			if (MediaProp->evaporation == 647)
+				Assemble_RHS_HEAT_TRANSPORT2(); // AKS
 
 #if defined(USE_PETSC) // || defined(other parallel libs)//03~04.3012. WW
 			add2GlobalMatrixII();
@@ -9373,7 +9288,7 @@ void CFiniteElementStd::ExtropolateGauss(MeshLib::CElem& elem, CRFProcess* m_pcs
 
 	// Multi-phase flow 03.2009 PCH
 	int idx_v2 = 0;
-	if(m_pcs->type == 1212 || m_pcs->type == 1313 || m_pcs->type == 42)
+	if (m_pcs->type == 1212 || m_pcs->type == 1313 || m_pcs->type == 42)
 	{
 		switch (idof)
 		{
@@ -9392,7 +9307,7 @@ void CFiniteElementStd::ExtropolateGauss(MeshLib::CElem& elem, CRFProcess* m_pcs
 	// Number of elements associated to nodes
 	nnodes = MeshElement->nnodes;
 	// Node indices
-	for(int i = 0; i < nnodes; i++)
+	for (int i = 0; i < nnodes; i++)
 	{
 		nodes[i] = MeshElement->nodes[i]->GetIndex();
 		dbuff[i] = (double)MeshElement->nodes[i]->getConnectedElementIDs().size();
@@ -9406,11 +9321,11 @@ void CFiniteElementStd::ExtropolateGauss(MeshLib::CElem& elem, CRFProcess* m_pcs
 	gp_r = gp_s = gp_t = gp = 0;
 	//
 	SetIntegrationPointNumber(ElementType);
-	for(gp = 0; gp < nGaussPoints; gp++)
+	for (gp = 0; gp < nGaussPoints; gp++)
 	{
 		int i = gp;
 		SetGaussPoint(gp, gp_r, gp_s, gp_t);
-		if(ElementType == MshElemType::QUAD || ElementType == MshElemType::HEXAHEDRON)
+		if (ElementType == MshElemType::QUAD || ElementType == MshElemType::HEXAHEDRON)
 		{
 			i = GetLocalIndex(gp_r, gp_s, gp_t);
 			if (i == -1)
@@ -9452,7 +9367,7 @@ void CFiniteElementStd::ExtropolateGauss(MeshLib::CElem& elem, CRFProcess* m_pcs
 	}
 
 	ConfigShapefunction(ElementType);
-	for(int i = 0; i < nnodes; i++)
+	for (int i = 0; i < nnodes; i++)
 	{
 		EV = EV1 = varx = 0.0;
 
@@ -9462,7 +9377,7 @@ void CFiniteElementStd::ExtropolateGauss(MeshLib::CElem& elem, CRFProcess* m_pcs
 			SetExtropoGaussPoints(i);
 			//
 			ComputeShapefct(1, dbuff0); // Linear interpolation function
-			for(int j = i_s; j < i_e; j++)
+			for (int j = i_s; j < i_e; j++)
 				EV += NodalVal1[j] * dbuff0[j - ish];
 		}
 		else if (this->GetExtrapoMethod() == ExtrapolationMethod::EXTRAPO_AVERAGE)
@@ -9481,7 +9396,7 @@ void CFiniteElementStd::ExtropolateGauss(MeshLib::CElem& elem, CRFProcess* m_pcs
 		{
 			// Calculate values at nodes
 			if (this->GetExtrapoMethod() == ExtrapolationMethod::EXTRAPO_LINEAR)
-				for(int j = i_s; j < i_e; j++)
+				for (int j = i_s; j < i_e; j++)
 					EV1 += NodalVal2[j] * dbuff0[j - ish];
 			else if (this->GetExtrapoMethod() == ExtrapolationMethod::EXTRAPO_AVERAGE)
 				// average
@@ -9501,8 +9416,7 @@ void CFiniteElementStd::ExtropolateGauss(MeshLib::CElem& elem, CRFProcess* m_pcs
 This function is needed to extrapolate the nodal reaction rate values,
 using the gauss point calculated reaction rates.
 ***********************************************************************/
-void CFiniteElementStd::ExtrapolateGauss_ReactRate_TNEQ_TES
-			(MeshLib::CElem& elem, CRFProcess *m_pcs)
+void CFiniteElementStd::ExtrapolateGauss_ReactRate_TNEQ_TES(MeshLib::CElem& elem, CRFProcess* m_pcs)
 {
 	int i, j, gp, gp_r, gp_s, gp_t;
 	int i_s, i_e, ish;
@@ -9520,21 +9434,21 @@ void CFiniteElementStd::ExtrapolateGauss_ReactRate_TNEQ_TES
 	// Number of elements associated to nodes
 	nnodes = MeshElement->nnodes;
 	// Node indices
-	for(int i = 0; i < nnodes; i++)
+	for (int i = 0; i < nnodes; i++)
 	{
 		nodes[i] = MeshElement->nodes[i]->GetIndex();
 		dbuff[i] = (double)MeshElement->nodes[i]->getConnectedElementIDs().size();
 	}
 
-	gp_r=gp_s=gp_t=gp=0;
+	gp_r = gp_s = gp_t = gp = 0;
 	ElementValue* gp_ele = ele_gp_value[MeshElement->GetIndex()];
 
 	// loop over all gauss points
 	SetIntegrationPointNumber(ElementType);
-	for(gp=0; gp<nGaussPoints; gp++)
+	for (gp = 0; gp < nGaussPoints; gp++)
 	{
 		SetGaussPoint(gp, gp_r, gp_s, gp_t);
-		if(ElementType==MshElemType::QUAD||ElementType==MshElemType::HEXAHEDRON)
+		if (ElementType == MshElemType::QUAD || ElementType == MshElemType::HEXAHEDRON)
 		{
 			i = GetLocalIndex(gp_r, gp_s, gp_t);
 			if (i == -1)
@@ -9571,7 +9485,7 @@ void CFiniteElementStd::ExtrapolateGauss_ReactRate_TNEQ_TES
 	}
 
 	ConfigShapefunction(ElementType);
-	for(i=0; i<nnodes; i++)
+	for (i = 0; i < nnodes; i++)
 	{
 		EV = EV1 = varx = rhoEV = rhoEV1 = 0.0;
 
@@ -9581,9 +9495,10 @@ void CFiniteElementStd::ExtrapolateGauss_ReactRate_TNEQ_TES
 			SetExtropoGaussPoints(i);
 			//
 			ComputeShapefct(1, dbuff0); // Linear interpolation function
-			for(j=i_s; j<i_e; j++) {
-				EV    += NodalVal4[j]*dbuff0[j-ish];
-				rhoEV += NodalVal5[j]*dbuff0[j-ish];
+			for (j = i_s; j < i_e; j++)
+			{
+				EV += NodalVal4[j] * dbuff0[j - ish];
+				rhoEV += NodalVal5[j] * dbuff0[j - ish];
 			}
 		}
 		else if (this->GetExtrapoMethod() == ExtrapolationMethod::EXTRAPO_AVERAGE)
@@ -9626,7 +9541,7 @@ void CFiniteElementStd::CalcSatuation(MeshLib::CElem& elem)
 	MediaProp = mmp_vector[mmp_index];
 	MediaProp->m_pcs = pcs;
 	MediaProp->Fem_Ele_Std = this;
-    // CB_merge_0513
+	// CB_merge_0513
 	double* tens = MediaProp->PermeabilityTensor(Index);
 	//
 	int idx_cp, idx_S;
@@ -9639,11 +9554,11 @@ void CFiniteElementStd::CalcSatuation(MeshLib::CElem& elem)
 		idx_S = pcs->GetNodeValueIndex("SATURATION2") + 1;
 	}
 	double sign = -1.0;
-	if(pcs->type == 1212 || pcs->type == 42)
+	if (pcs->type == 1212 || pcs->type == 42)
 		sign = 1.0;
 	//
 	nnodes = MeshElement->nnodes;
-	for(int i = 0; i < nnodes; i++)
+	for (int i = 0; i < nnodes; i++)
 	{
 		nodes[i] = MeshElement->nodes[i]->GetIndex();
 		// Number of elements associated to nodes
@@ -9659,11 +9574,11 @@ void CFiniteElementStd::CalcSatuation(MeshLib::CElem& elem)
 	const MshElemType::type ElementType = MeshElement->GetElementType();
 	getShapeFunctionPtr(ElementType);
 	SetIntegrationPointNumber(ElementType);
-	for(gp = 0; gp < nGaussPoints; gp++)
+	for (gp = 0; gp < nGaussPoints; gp++)
 	{
 		SetGaussPoint(gp, gp_r, gp_s, gp_t);
 		int i = gp;
-		if(ElementType == MshElemType::QUAD || ElementType == MshElemType::HEXAHEDRON)
+		if (ElementType == MshElemType::QUAD || ElementType == MshElemType::HEXAHEDRON)
 		{
 			i = GetLocalIndex(gp_r, gp_s, gp_t);
 			if (i == -1)
@@ -9676,7 +9591,7 @@ void CFiniteElementStd::CalcSatuation(MeshLib::CElem& elem)
 		getShapefunctValues(gp, 1);
 		//
 		// CB_merge_0513 in case of het K, store local K
-		MediaProp->local_permeability  = tens[0];
+		MediaProp->local_permeability = tens[0];
 		PG = interpolate(NodalVal0);
 		NodalVal_Sat[i] = MediaProp->SaturationCapillaryPressureFunction(PG);
 	}
@@ -9704,7 +9619,7 @@ void CFiniteElementStd::CalcSatuation(MeshLib::CElem& elem)
 		avgSat = CalcAverageGaussPointValues(NodalVal_Sat);
 
 	ConfigShapefunction(ElementType);
-	for(int i = 0; i < nnodes; i++)
+	for (int i = 0; i < nnodes; i++)
 	{
 		double eS = 0.0;
 		// Calculate values at nodes
@@ -9713,7 +9628,7 @@ void CFiniteElementStd::CalcSatuation(MeshLib::CElem& elem)
 			SetExtropoGaussPoints(i);
 			//
 			ComputeShapefct(1, dbuff0); // Linear interpolation function
-			for(int j = i_s; j < i_e; j++)
+			for (int j = i_s; j < i_e; j++)
 				eS += NodalVal_Sat[j] * dbuff0[j - ish];
 		}
 		else if (this->GetExtrapoMethod() == ExtrapolationMethod::EXTRAPO_AVERAGE)
@@ -9727,7 +9642,7 @@ void CFiniteElementStd::CalcSatuation(MeshLib::CElem& elem)
 			eS = 1.0;
 		if (MediaProp->permeability_saturation_model[0] == 10
 		    && eS < MediaProp->capillary_pressure_values[1]) // MW: limit to non-negative saturation for stability in
-			// unconfined gw
+		                                                     // unconfined gw
 			eS = MediaProp->capillary_pressure_values[1];
 		//
 		pcs->SetNodeValue(nodes[i], idx_S, eS);
@@ -9758,7 +9673,7 @@ void CFiniteElementStd::CalcNodeMatParatemer(MeshLib::CElem& elem)
 
 	nnodes = MeshElement->nnodes;
 	// Node indices
-	for(int i = 0; i < nnodes; i++)
+	for (int i = 0; i < nnodes; i++)
 		nodes[i] = MeshElement->nodes[i]->GetIndex();
 
 	//----------------------------------------------------------------------
@@ -9803,7 +9718,7 @@ void CFiniteElementStd::CalcNodeMatParatemer(MeshLib::CElem& elem)
 	// for PG = interpolate(NodalVal0);
 	getShapeFunctionPtr(MeshElement->GetElementType());
 	SetIntegrationPointNumber(ElementType);
-	for(gp = 0; gp < nGaussPoints; gp++)
+	for (gp = 0; gp < nGaussPoints; gp++)
 	{
 		SetGaussPoint(gp, gp_r, gp_s, gp_t);
 		if (ElementType == MshElemType::QUAD || ElementType == MshElemType::HEXAHEDRON)
@@ -9877,7 +9792,7 @@ void CFiniteElementStd::CalcNodeMatParatemer(MeshLib::CElem& elem)
 	}
 
 	ConfigShapefunction(ElementType);
-	for(i = 0; i < nnodes; i++)
+	for (i = 0; i < nnodes; i++)
 	{
 		// Calculate values at nodes
 		if (this->GetExtrapoMethod() == ExtrapolationMethod::EXTRAPO_LINEAR)
@@ -9894,7 +9809,7 @@ void CFiniteElementStd::CalcNodeMatParatemer(MeshLib::CElem& elem)
 				{
 					w[0] += NodalVal2[j] * dbuff0[j - ish];
 					w[1] += NodalVal3[j] * dbuff0[j - ish];
-					if(dim == 3)
+					if (dim == 3)
 						w[2] += NodalVal4[j] * dbuff0[j - ish];
 				}
 			else if (this->GetExtrapoMethod() == ExtrapolationMethod::EXTRAPO_AVERAGE)
@@ -10266,7 +10181,7 @@ void CFiniteElementStd::CalCoef_RHS_Pc(int dof_index)
 **************************************************************************/
 double CFiniteElementStd::CalCoef_RHS_PSGLOBAL(int dof_index)
 {
-	for(size_t i = 0; i < dim * dim; i++)
+	for (size_t i = 0; i < dim * dim; i++)
 		mat[i] = 0.0;
 
 	switch (dof_index)
@@ -10381,9 +10296,9 @@ void CFiniteElementStd::Assemble_RHS_T_MPhaseFlow()
 		//---------------------------------------------------------
 		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		// Compute geometry
-		getGradShapefunctValues(gp, 1);   // Linear interpolation function
-		getShapefunctValues(gp, 1);       // Linear interpolation function
-		for(ii = 0; ii < dof_n; ii++)
+		getGradShapefunctValues(gp, 1); // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
+		for (ii = 0; ii < dof_n; ii++)
 		{
 			// Material
 			fac = fkt * CalCoef_RHS_T_MPhase(ii) / dt;
@@ -10466,8 +10381,8 @@ void CFiniteElementStd::Assemble_RHS_T_PSGlobal()
 		//---------------------------------------------------------
 		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		// Compute geometry
-		getGradShapefunctValues(gp, 1);   // Linear interpolation function
-		getShapefunctValues(gp, 1);       // Linear interpolation function
+		getGradShapefunctValues(gp, 1); // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
 
 		for (ii = 0; ii < dof_n; ii++)
 		{
@@ -10541,8 +10456,8 @@ void CFiniteElementStd::Assemble_RHS_Pc()
 		//---------------------------------------------------------
 		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		// Compute geometry
-		getGradShapefunctValues(gp, 1);   // Linear interpolation function
-		getShapefunctValues(gp, 1);       // Linear interpolation function
+		getGradShapefunctValues(gp, 1); // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
 		// grad Pc
 		for (ii = 0; ii < dof_n; ii++)
 		{
@@ -10592,44 +10507,48 @@ void CFiniteElementStd::Assemble_RHS_Pc()
  **************************************************************************/
 void CFiniteElementStd::Assemble_RHS_LIQUIDFLOW()
 {
-    if (!isTemperatureCoupling()) return;
-       if ((FluidProp->drho_dT == .0 && (FluidProp->density_model<8 || FluidProp->density_model>14))&& SolidProp->Thermal_Expansion()==.0) return;
+	if (!isTemperatureCoupling())
+		return;
+	if ((FluidProp->drho_dT == .0 && (FluidProp->density_model < 8 || FluidProp->density_model > 14))
+	    && SolidProp->Thermal_Expansion() == .0)
+		return;
 
-    //----------------------------------------------------------------------
-    for (int i = 0; i < nnodes; i++)
-        NodalVal[i] = 0.0;
-    //======================================================================
-    // Loop over Gauss points
-    int gp_r = 0,gp_s = 0,gp_t = 0;
-    for (gp = 0; gp < nGaussPoints; gp++)
-    {
-        //---------------------------------------------------------
-        //  Get local coordinates and weights
-        //  Compute Jacobian matrix and its determinate
-        //---------------------------------------------------------
-        const double gp_fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
-        //---------------------------------------------------------
-        // Compute geometry
-        //---------------------------------------------------------
-        getShapefunctValues(gp, 1);       // Linear interpolation function
-        //---------------------------------------------------------
-        //  Evaluate variables
-        //---------------------------------------------------------
-        const double T_n = interpolate(NodalValC);
-        const double T_n1 = interpolate(NodalValC1);
-        const double dT = T_n1 -T_n;
-        //---------------------------------------------------------
-        //  Evaluate material property
-        //---------------------------------------------------------
-        const double poro = MediaProp->Porosity(Index, pcs->m_num->ls_theta);
-        double alpha_T_s = 3.*SolidProp->Thermal_Expansion(); // multiply 3 for volumetrix expression
-        Sw = 1.0;
-        double alpha_T_l;
-		if (FluidProp->density_model>7 && FluidProp->density_model<15){
-            double arg[2];
-				   arg[0]=interpolate(NodalVal1);  // p
-				   arg[1]=interpolate(NodalValC1); // T
-			alpha_T_l = - FluidProp->drhodT(arg)/FluidProp->Density();
+	//----------------------------------------------------------------------
+	for (int i = 0; i < nnodes; i++)
+		NodalVal[i] = 0.0;
+	//======================================================================
+	// Loop over Gauss points
+	int gp_r = 0, gp_s = 0, gp_t = 0;
+	for (gp = 0; gp < nGaussPoints; gp++)
+	{
+		//---------------------------------------------------------
+		//  Get local coordinates and weights
+		//  Compute Jacobian matrix and its determinate
+		//---------------------------------------------------------
+		const double gp_fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
+		//---------------------------------------------------------
+		// Compute geometry
+		//---------------------------------------------------------
+		getShapefunctValues(gp, 1); // Linear interpolation function
+		//---------------------------------------------------------
+		//  Evaluate variables
+		//---------------------------------------------------------
+		const double T_n = interpolate(NodalValC);
+		const double T_n1 = interpolate(NodalValC1);
+		const double dT = T_n1 - T_n;
+		//---------------------------------------------------------
+		//  Evaluate material property
+		//---------------------------------------------------------
+		const double poro = MediaProp->Porosity(Index, pcs->m_num->ls_theta);
+		double alpha_T_s = 3. * SolidProp->Thermal_Expansion(); // multiply 3 for volumetrix expression
+		Sw = 1.0;
+		double alpha_T_l;
+		if (FluidProp->density_model > 7 && FluidProp->density_model < 15)
+		{
+			double arg[2];
+			arg[0] = interpolate(NodalVal1); // p
+			arg[1] = interpolate(NodalValC1); // T
+			alpha_T_l = -FluidProp->drhodT(arg) / FluidProp->Density();
 		}
 		else
 			alpha_T_l = -FluidProp->drho_dT; // negative sign is required due to OGS input
@@ -10727,7 +10646,7 @@ void CFiniteElementStd::Assemble_RHS_M()
 		//---------------------------------------------------------
 		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		// Compute geometry
-		getShapefunctValues(gp, 1);       // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
 
 		getGradShapefunctValues(gp, 2);
 		grad_du = 0.0;
@@ -10818,8 +10737,8 @@ void CFiniteElementStd::Assemble_RHS_AIR_FLOW()
 		//---------------------------------------------------------
 		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		// Compute geometry
-		getGradShapefunctValues(gp, 1);   // Linear interpolation function
-		getShapefunctValues(gp, 1);       // Linear interpolation function
+		getGradShapefunctValues(gp, 1); // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
 		ElementValue* gp_ele = ele_gp_value[Index];
 
 		for (ii = 0; ii < dof_n; ii++)
@@ -10910,8 +10829,8 @@ void CFiniteElementStd::Assemble_RHS_HEAT_TRANSPORT()
 		//---------------------------------------------------------
 		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		// Compute geometry
-		getGradShapefunctValues(gp, 1);   // Linear interpolation function
-		getShapefunctValues(gp, 1);       // Linear interpolation function
+		getGradShapefunctValues(gp, 1); // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
 		ElementValue* gp_ele = ele_gp_value[Index];
 
 		for (ii = 0; ii < dof_n; ii++)
@@ -10936,8 +10855,8 @@ void CFiniteElementStd::Assemble_RHS_HEAT_TRANSPORT()
 			for (i = 0; i < nnodes; i++)
 				for (j = 0; j < nnodes; j++)
 					for (size_t k = 0; k < dim; k++)
-						NodalVal[i + ii * nnodes]
-						    += fkt * vel[k] * shapefct[i] * dshapefct[k * nnodes + j] * NodalValC1[j];
+						NodalVal[i + ii * nnodes] += fkt * vel[k] * shapefct[i] * dshapefct[k * nnodes + j]
+						                             * NodalValC1[j];
 		}
 	}
 	for (ii = 0; ii < pcs->dof; ii++)
@@ -10969,7 +10888,7 @@ double CFiniteElementStd::CalCoef_RHS_HEAT_TRANSPORT2(int dof_index)
 	double val = 0.0, mat_fac;
 	// TF unused variable - comment fix compile warning
 	//      double Tc=647.096;
-	double H_vap = 0.0,dens_arg[3];
+	double H_vap = 0.0, dens_arg[3];
 	PG = interpolate(NodalValC1);
 	PG2 = interpolate(NodalVal_p2);
 	TG = interpolate(NodalVal1) + PhysicalConstant::CelsiusZeroInKelvin;
@@ -10983,7 +10902,7 @@ double CFiniteElementStd::CalCoef_RHS_HEAT_TRANSPORT2(int dof_index)
 	poro = MediaProp->Porosity(Index, pcs->m_num->ls_theta);
 	if (MediaProp->evaporation == 647)
 		H_vap = -2257000; // pow((Tc - TG),0.38)*2.5397E+5;//It is specific you can change thi value as you chaning
-	// fluid from water
+		                  // fluid from water
 	for (size_t i = 0; i < dim * dim; i++)
 		mat[i] = 0.0;
 	switch (dof_index)
@@ -11050,8 +10969,8 @@ void CFiniteElementStd::Assemble_RHS_HEAT_TRANSPORT2()
 		//---------------------------------------------------------
 		fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		// Compute geometry
-		getGradShapefunctValues(gp, 1);   // Linear interpolation function
-		getShapefunctValues(gp, 1);       // Linear interpolation function
+		getGradShapefunctValues(gp, 1); // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
 		// TF unused variable - comment fix compile warning
 		//         ElementValue* gp_ele = ele_gp_value[Index];
 		int dof_n = 2;
@@ -11612,7 +11531,7 @@ void CFiniteElementStd::CalcEnergyNorm_Dual(double& err_norm0, double& err_normn
 		mat_fac = CalcCoefDualTransfer();
 		mat_fac *= fkt;
 		// Material
-		getShapefunctValues(gp, 1);       // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
 		// Calculate mass matrix
 		for (i = 0; i < nnodes; i++)
 			for (j = 0; j < nnodes; j++)
@@ -11652,8 +11571,7 @@ void CFiniteElementStd::CalcEnergyNorm_Dual(double& err_norm0, double& err_normn
 	AuxMatrix1->multi(NodalVal0, NodalVal);
 	for (i = 0; i < nnodes; i++)
 		err_normn += (fm * (atol + rtol * max(NodalVal3[i], x_n[nodes[i]]))
-		              - ff * (atol + rtol * max(NodalVal4[i], x_n[nodes[i] + cshift])))
-		             * NodalVal[i];
+		              - ff * (atol + rtol * max(NodalVal4[i], x_n[nodes[i] + cshift]))) * NodalVal[i];
 	//
 	//
 }

--- a/FEM/fem_ele_std.h
+++ b/FEM/fem_ele_std.h
@@ -135,8 +135,10 @@ public:
 	void CalcStorage();
 	// 9. Content matrix
 	void CalcContent();
-	void CalcContentTNEQ(); // NW
-	void CalcContentTES(); // NW
+	void CalcContentTNEQ(); //NW
+	void CalcContentTES(); //NW
+	//
+	void CalcSatuation();                  //WW
 	//
 	void CalcSatution(); // WW
 //

--- a/FEM/fem_ele_std.h
+++ b/FEM/fem_ele_std.h
@@ -214,7 +214,7 @@ public:
 	void ExtrapolateGauss_ReactRate_TNEQ_TES(MeshLib::CElem& elem, CRFProcess* m_pcs);
 	// Calulate satutation at intehration points
 	// and extrapolate them to nodes.
-	void CalcSatuation(MeshLib::CElem& elem); // WW
+	void CalcSaturation(MeshLib::CElem& elem); // WW
 	// Extrapolate material parameters
 	void CalcNodeMatParatemer(MeshLib::CElem& elem); // WW
 
@@ -235,7 +235,8 @@ private:
 	int comp; // Component
 	int LocalShift; // For RHS
 	// Danymic
-	int* idx_vel_disp, idx_pres;
+	int* idx_vel_disp;
+	int idx_pres;
 	// Velocity
 	int* idx_vel; // WW
 	// Material properties
@@ -471,7 +472,8 @@ public:
 
 	// HS Thermal Storage parameters---------------
 	// Array of parameters on each Gauss point
-	double* rho_s_prev, *rho_s_curr;
+	double* rho_s_prev;
+	double* rho_s_curr;
 	double* q_R;
 // End of Thermal Storage parameters---------------
 #ifdef USE_TRANSPORT_FLUX

--- a/FEM/fem_ele_std.h
+++ b/FEM/fem_ele_std.h
@@ -137,11 +137,6 @@ public:
 	void CalcContent();
 	void CalcContentTNEQ(); //NW
 	void CalcContentTES(); //NW
-	//
-	void CalcSatuation();                  //WW
-	//
-	void CalcSatution(); // WW
-//
 #ifdef E_NORM
 	// 25.08.2008. WW
 	void CalcEnergyNorm(double& err_norm0, double& err_normn);
@@ -149,7 +144,6 @@ public:
 	void CalcEnergyNorm_Dual(double& err_norm0, double& err_normn);
 //
 #endif
-	void CalcNodeMatParatemer(); // WW
 	// Assembly
 	void Assembly();
 	void Assembly(int option, int dimension); // PCH for Fluid Momentum
@@ -213,11 +207,18 @@ public:
 	void CalcSUPGWeightingFunction(double* vel, int ip, double& tau, double* v_dN);
 	// NW
 	double CalcSUPGEffectiveElemenetLength(double* vel);
+
 	// Gauss value
-	void ExtropolateGauss(CRFProcess* m_pcs, const int idof);
+	void ExtropolateGauss(MeshLib::CElem& elem, CRFProcess* m_pcs, const int idof);
 	// Extrapolate reaction rates on TNEQ flow
-	void ExtrapolateGauss_ReactRate_TNEQ_TES(CRFProcess* m_pcs);
-	void UpdateSolidDensity(size_t elem_idx); // HS
+	void ExtrapolateGauss_ReactRate_TNEQ_TES(MeshLib::CElem& elem, CRFProcess *m_pcs);
+	// Calulate satutation at intehration points
+	// and extrapolate them to nodes.
+	void CalcSatuation(MeshLib::CElem& elem);                  //WW
+	// Extrapolate material parameters
+	void CalcNodeMatParatemer(MeshLib::CElem& elem);          //WW
+
+	void UpdateSolidDensity(size_t elem_idx);       // HS
 	// CB _ctx_ CB_merge_0513
 	// void Set_ctx_(long ele_index, double val, int gaussp, int i_dim);
 	// double Get_ctx_(long ele_index, int gaussp, int i_dim);

--- a/FEM/fem_ele_std.h
+++ b/FEM/fem_ele_std.h
@@ -135,8 +135,8 @@ public:
 	void CalcStorage();
 	// 9. Content matrix
 	void CalcContent();
-	void CalcContentTNEQ(); //NW
-	void CalcContentTES(); //NW
+	void CalcContentTNEQ(); // NW
+	void CalcContentTES(); // NW
 #ifdef E_NORM
 	// 25.08.2008. WW
 	void CalcEnergyNorm(double& err_norm0, double& err_normn);
@@ -211,14 +211,14 @@ public:
 	// Gauss value
 	void ExtropolateGauss(MeshLib::CElem& elem, CRFProcess* m_pcs, const int idof);
 	// Extrapolate reaction rates on TNEQ flow
-	void ExtrapolateGauss_ReactRate_TNEQ_TES(MeshLib::CElem& elem, CRFProcess *m_pcs);
+	void ExtrapolateGauss_ReactRate_TNEQ_TES(MeshLib::CElem& elem, CRFProcess* m_pcs);
 	// Calulate satutation at intehration points
 	// and extrapolate them to nodes.
-	void CalcSatuation(MeshLib::CElem& elem);                  //WW
+	void CalcSatuation(MeshLib::CElem& elem); // WW
 	// Extrapolate material parameters
-	void CalcNodeMatParatemer(MeshLib::CElem& elem);          //WW
+	void CalcNodeMatParatemer(MeshLib::CElem& elem); // WW
 
-	void UpdateSolidDensity(size_t elem_idx);       // HS
+	void UpdateSolidDensity(size_t elem_idx); // HS
 	// CB _ctx_ CB_merge_0513
 	// void Set_ctx_(long ele_index, double val, int gaussp, int i_dim);
 	// double Get_ctx_(long ele_index, int gaussp, int i_dim);
@@ -235,7 +235,7 @@ private:
 	int comp; // Component
 	int LocalShift; // For RHS
 	// Danymic
-	int *idx_vel_disp, idx_pres;
+	int* idx_vel_disp, idx_pres;
 	// Velocity
 	int* idx_vel; // WW
 	// Material properties
@@ -471,7 +471,7 @@ public:
 
 	// HS Thermal Storage parameters---------------
 	// Array of parameters on each Gauss point
-	double *rho_s_prev, *rho_s_curr;
+	double* rho_s_prev, *rho_s_curr;
 	double* q_R;
 // End of Thermal Storage parameters---------------
 #ifdef USE_TRANSPORT_FLUX

--- a/FEM/fem_ele_std1.cpp
+++ b/FEM/fem_ele_std1.cpp
@@ -82,8 +82,8 @@ void CFiniteElementStd::ComputeAdditionalJacobi_H2()
 		//  Compute Jacobian matrix and its determinate
 		//---------------------------------------------------------
 		fkt = relax * GetGaussData(gp, gp_r, gp_s, gp_t);
-		getShapefunctValues(gp, 1);       // Linear interpolation function
-		getGradShapefunctValues(gp, 1);   // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
+		getGradShapefunctValues(gp, 1); // Linear interpolation function
 
 		// poro = MediaProp->Porosity(Index,pcs->m_num->ls_theta);
 		tensor = MediaProp->PermeabilityTensor(Index);
@@ -120,12 +120,10 @@ void CFiniteElementStd::ComputeAdditionalJacobi_H2()
 			gradPg[dim - 1] += g_constant * rho_ga;
 		}
 
-		dkdp1 = dSdp
-		        * (MediaProp->PermeabilitySaturationFunction(S1, 0) - MediaProp->PermeabilitySaturationFunction(Sw, 0))
-		        / perturb;
-		dkdp2 = dSdp
-		        * (MediaProp->PermeabilitySaturationFunction(S1, 1) - MediaProp->PermeabilitySaturationFunction(Sw, 1))
-		        / perturb;
+		dkdp1 = dSdp * (MediaProp->PermeabilitySaturationFunction(S1, 0)
+		                - MediaProp->PermeabilitySaturationFunction(Sw, 0)) / perturb;
+		dkdp2 = dSdp * (MediaProp->PermeabilitySaturationFunction(S1, 1)
+		                - MediaProp->PermeabilitySaturationFunction(Sw, 1)) / perturb;
 
 		for (size_t i = 0; i < dim && i < 3; i++)
 		{
@@ -268,8 +266,8 @@ void CFiniteElementStd::ComputeAdditionalJacobi_Richards()
 		//  Compute Jacobian matrix and its determinate
 		//---------------------------------------------------------
 		fkt = relax * GetGaussData(gp, gp_r, gp_s, gp_t);
-		getShapefunctValues(gp, 1);       // Linear interpolation function
-		getGradShapefunctValues(gp, 1);   // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
+		getGradShapefunctValues(gp, 1); // Linear interpolation function
 
 		tensor = MediaProp->PermeabilityTensor(Index);
 		PG = -interpolate(NodalVal1);
@@ -292,9 +290,8 @@ void CFiniteElementStd::ComputeAdditionalJacobi_Richards()
 		if ((coordinate_system) % 10 == 2)
 			gradPw[dim - 1] += g_constant * rhow;
 
-		dkdp1 = dSdp
-		        * (MediaProp->PermeabilitySaturationFunction(S1, 0) - MediaProp->PermeabilitySaturationFunction(Sw, 0))
-		        / perturb;
+		dkdp1 = dSdp * (MediaProp->PermeabilitySaturationFunction(S1, 0)
+		                - MediaProp->PermeabilitySaturationFunction(Sw, 0)) / perturb;
 
 		for (size_t i = 0; i < dim && i < 3; i++)
 		{

--- a/FEM/fem_ele_std1.cpp
+++ b/FEM/fem_ele_std1.cpp
@@ -82,8 +82,8 @@ void CFiniteElementStd::ComputeAdditionalJacobi_H2()
 		//  Compute Jacobian matrix and its determinate
 		//---------------------------------------------------------
 		fkt = relax * GetGaussData(gp, gp_r, gp_s, gp_t);
-		ComputeShapefct(1); // Linear interpolation function
-		ComputeGradShapefct(1); // Linear interpolation function
+		getShapefunctValues(gp, 1);       // Linear interpolation function
+		getGradShapefunctValues(gp, 1);   // Linear interpolation function
 
 		// poro = MediaProp->Porosity(Index,pcs->m_num->ls_theta);
 		tensor = MediaProp->PermeabilityTensor(Index);
@@ -187,7 +187,7 @@ void CFiniteElementStd::ComputeAdditionalJacobi_H2()
 		{
 			// setOrder(2);
 			// GetGaussData(gp, gp_r, gp_s, gp_t);
-			// ComputeGradShapefct(2);
+			getGradShapefunctValues(gp, 2);
 			// setOrder(1);
 
 			/// if deformation is coupled
@@ -268,8 +268,8 @@ void CFiniteElementStd::ComputeAdditionalJacobi_Richards()
 		//  Compute Jacobian matrix and its determinate
 		//---------------------------------------------------------
 		fkt = relax * GetGaussData(gp, gp_r, gp_s, gp_t);
-		ComputeShapefct(1); // Linear interpolation function
-		ComputeGradShapefct(1); // Linear interpolation function
+		getShapefunctValues(gp, 1);       // Linear interpolation function
+		getGradShapefunctValues(gp, 1);   // Linear interpolation function
 
 		tensor = MediaProp->PermeabilityTensor(Index);
 		PG = -interpolate(NodalVal1);
@@ -319,7 +319,7 @@ void CFiniteElementStd::ComputeAdditionalJacobi_Richards()
 		{
 			// setOrder(2);
 			// GetGaussData(gp, gp_r, gp_s, gp_t);
-			// ComputeGradShapefct(2);
+			getGradShapefunctValues(gp, 2);
 			// setOrder(1);
 
 			/// if deformation is coupled

--- a/FEM/fem_ele_std_tes.cpp
+++ b/FEM/fem_ele_std_tes.cpp
@@ -57,7 +57,7 @@ void CFiniteElementStd::CalcMassTES()
 		// Compute Jacobian matrix and its determinate
 		double fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		// Compute geometry
-		ComputeShapefct(1); // Linear interpolation function
+		getShapefunctValues(gp, 1);       // Linear interpolation function
 
 		for (int in = 0; in < pcs->dof; in++)
 		{
@@ -122,9 +122,9 @@ void CFiniteElementStd::CalcLumpedMassTES()
 	// Initialize
 	(*Mass2) = 0.0;
 	// Center of the reference element
-	SetCenterGP();
-	ComputeShapefct(1);
-	for (int in = 0; in < nDF; in++)
+	getShapeFunctionCentroid();               // Linear interpolation function
+
+	for(int in = 0; in < nDF; in++)
 	{
 		const int ish = in * nnodes;
 		for (int jn = 0; jn < nDF; jn++)
@@ -387,8 +387,8 @@ void CFiniteElementStd::CalcAdvectionTES()
 	for (gp = 0; gp < nGaussPoints; gp++)
 	{
 		double fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
-		ComputeGradShapefct(1);
-		ComputeShapefct(1);
+		getShapefunctValues(gp, 1);
+		getGradShapefunctValues(gp, 1);
 
 		// Velocity
 		// TODO [CL] vel includes porosity? cf. \tilde w
@@ -513,7 +513,7 @@ void CFiniteElementStd::CalcContentTES()
 	for (gp = 0; gp < nGaussPoints; gp++)
 	{
 		double fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
-		ComputeShapefct(1);
+		getShapefunctValues(gp, 1);
 
 		for (int in = 0; in < pcs->dof; in++)
 		{
@@ -605,7 +605,7 @@ void CFiniteElementStd::Assemble_RHS_TES()
 		double fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 
 		// Compute geometry
-		ComputeShapefct(1);
+		getShapefunctValues(gp, 1);
 
 		for (int ii = 0; ii < pcs->dof; ii++)
 		{

--- a/FEM/fem_ele_std_tes.cpp
+++ b/FEM/fem_ele_std_tes.cpp
@@ -57,7 +57,7 @@ void CFiniteElementStd::CalcMassTES()
 		// Compute Jacobian matrix and its determinate
 		double fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		// Compute geometry
-		getShapefunctValues(gp, 1);       // Linear interpolation function
+		getShapefunctValues(gp, 1); // Linear interpolation function
 
 		for (int in = 0; in < pcs->dof; in++)
 		{
@@ -122,9 +122,9 @@ void CFiniteElementStd::CalcLumpedMassTES()
 	// Initialize
 	(*Mass2) = 0.0;
 	// Center of the reference element
-	getShapeFunctionCentroid();               // Linear interpolation function
+	getShapeFunctionCentroid(); // Linear interpolation function
 
-	for(int in = 0; in < nDF; in++)
+	for (int in = 0; in < nDF; in++)
 	{
 		const int ish = in * nnodes;
 		for (int jn = 0; jn < nDF; jn++)

--- a/FEM/fem_ele_std_tneq.cpp
+++ b/FEM/fem_ele_std_tneq.cpp
@@ -57,7 +57,7 @@ void CFiniteElementStd::CalcMassTNEQ()
 		// Compute Jacobian matrix and its determinate
 		double fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 		// Compute geometry
-		ComputeShapefct(1); // Linear interpolation function
+		getShapefunctValues(gp, 1);
 
 		for (int in = 0; in < pcs->dof; in++)
 		{
@@ -388,8 +388,8 @@ void CFiniteElementStd::CalcAdvectionTNEQ()
 	for (gp = 0; gp < nGaussPoints; gp++)
 	{
 		double fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
-		ComputeGradShapefct(1);
-		ComputeShapefct(1);
+		getShapefunctValues(gp, 1);
+		getGradShapefunctValues(gp, 1);
 
 		// Velocity
 		double vel[] = {gp_ele->Velocity(0, gp), gp_ele->Velocity(1, gp), gp_ele->Velocity(2, gp)};
@@ -540,7 +540,7 @@ void CFiniteElementStd::CalcContentTNEQ()
 	for (gp = 0; gp < nGaussPoints; gp++)
 	{
 		double fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
-		ComputeShapefct(1);
+		getShapefunctValues(gp, 1);
 
 		for (int in = 0; in < pcs->dof; in++)
 		{
@@ -661,8 +661,8 @@ void CFiniteElementStd::Assemble_RHS_TNEQ()
 		const double fkt = GetGaussData(gp, gp_r, gp_s, gp_t);
 
 		// Compute geometry
-		ComputeShapefct(1);
-		ComputeGradShapefct(1); // this is needed for CalCoef_RHS_TNEQ() !!
+		getShapefunctValues(gp, 1);
+		getGradShapefunctValues(gp, 1);
 
 		for (int ii = 0; ii < pcs->dof; ii++)
 		{

--- a/FEM/fem_ele_std_tneq.cpp
+++ b/FEM/fem_ele_std_tneq.cpp
@@ -782,8 +782,8 @@ double CFiniteElementStd::CalCoef_RHS_TNEQ(const int dof_index)
 					grad_pg[i] = 0.0; // clear to zero;
 					for (int j = 0; j < nnodes; j++) // loop over all connecting nodes
 					{
-						double pg_tmp
-						    = (1.0 - theta) * NodalVal0[j] + theta * NodalVal1[j]; // tmp value of gas pressure;
+						double pg_tmp = (1.0 - theta) * NodalVal0[j]
+						                + theta * NodalVal1[j]; // tmp value of gas pressure;
 						int index_tmp = i * nnodes + j;
 						grad_pg[i] += dshapefct[index_tmp] * pg_tmp;
 					}

--- a/FEM/fem_ele_vec.cpp
+++ b/FEM/fem_ele_vec.cpp
@@ -2680,6 +2680,11 @@ void CFiniteElementVec::ExtropolateGuassStrain()
 					dbuff[i] = 1;
 			}
 		}
+	}
+
+	// l1=l2=l3=l4=0;
+	MshElemType::type ElementType = MeshElement->GetElementType();
+	CalcXi_p();
 
 	//
 	int i_s, i_e, ish;
@@ -2805,6 +2810,7 @@ void CFiniteElementVec::ExtropolateGuassStress()
 		idx_pls =  pcs->GetNodeValueIndex("STRAIN_PLS");
 	//
 	MshElemType::type ElementType = MeshElement->GetElementType();
+	SetIntegrationPointNumber(ElementType);
 	for(gp = 0; gp < nGaussPoints; gp++)
 	{
 		int gp_r, gp_s, gp_t;
@@ -2854,8 +2860,7 @@ void CFiniteElementVec::ExtropolateGuassStress()
 		}
 	}
 	//
-	if (ElementType == MshElemType::QUAD || ElementType == MshElemType::HEXAHEDRON)
-		Xi_p = CalcXi_p();
+	CalcXi_p();
 
 	//
 	int i_s, i_e, ish;

--- a/FEM/fem_ele_vec.h
+++ b/FEM/fem_ele_vec.h
@@ -106,7 +106,7 @@ public:
 	bool GlobalAssembly();
 
 	// Compute strains
-	void ComputeStrain();
+	void ComputeStrain(const int ip);
 
 	// Set material data
 	void SetMaterial();

--- a/FEM/fem_ele_vec.h
+++ b/FEM/fem_ele_vec.h
@@ -60,6 +60,7 @@ public:
 	void Read_BIN(std::fstream& is);
 	void ReadElementStressASCI(std::fstream& is);
 	double MeanStress(const int gp) { return (*Stress)(0, gp) + (*Stress)(1, gp) + (*Stress)(2, gp); }
+
 private:
 	// Friend class
 	friend class SolidProp::CSolidProperties;
@@ -113,6 +114,7 @@ public:
 
 	// Get strain
 	double* GetStrain() const { return dstrain; }
+
 	//----------- Enhanced element -----------------------
 	// Geometry related
 	bool LocalAssembly_CheckLocalization(CElem* MElement);
@@ -185,7 +187,7 @@ private:
 	double* Disp;
 
 	// Temperatures of nodes
-	double *Temp, Tem;
+	double* Temp, Tem;
 	double* T1;
 	double S_Water;
 
@@ -219,9 +221,9 @@ private:
 	void ComputeMatrix_RHS(const double fkt, const Matrix* p_D);
 
 	// Temporarily used variables
-	double *Sxx, *Syy, *Szz, *Sxy, *Sxz, *Syz, *pstr;
+	double* Sxx, *Syy, *Szz, *Sxy, *Sxz, *Syz, *pstr;
 	// 2. For enhanced strain approach
-	Matrix *BDG, *PDB, *DtD, *PeDe; // For enhanced strain element
+	Matrix* BDG, *PDB, *DtD, *PeDe; // For enhanced strain element
 
 	/// Extropolation
 	bool RecordGuassStrain(const int gp, const int gp_r, const int gp_s, int gp_t);

--- a/FEM/mathlib.cpp
+++ b/FEM/mathlib.cpp
@@ -3442,7 +3442,7 @@ int MMultVecMat(double* vec, long gv, double* mat, long m, long n, double* veco,
 **************************************************************************/
 
 int MMultMatVec(/* Matrix */
-                double* mat, long m, long n,
+                const double* mat, long m, long n,
                 /* Veltor fuer das Produkt */
                 double* vec, long g,
                 /* Vektor fuer das Ergebnis */

--- a/FEM/mathlib.h
+++ b/FEM/mathlib.h
@@ -229,7 +229,7 @@ extern int MMultVecVec(double* vec1, long gv1, double* vec2, long gv2, double* m
 /*   MMultVecMat           - Multiplikation Vektor mit Matrix */
 extern int MMultVecMat(double* vec, long gv, double* mat, long m, long n, double* veco, long go);
 /*   MMultMatVec           - Multiplikation Matrix mit Vektor */
-extern int MMultMatVec(double* mat, long m, long n, double* vec, long g, double* veco, long r);
+extern int MMultMatVec(const double* mat, long m, long n, double* vec, long g, double* veco, long r);
 /*   MMultMatMat           - Multiplikation Matrix mit Matrix */
 extern int MMultMatMat(double* mat1, long m1, long n1, double* mat2, long m2, long n2, double* mato, long mo, long no);
 /*##########################################################################

--- a/FEM/pcs_dm.cpp
+++ b/FEM/pcs_dm.cpp
@@ -2741,7 +2741,7 @@ void CRFProcessDeformation::GlobalAssembly_DM()
 			continue;
 
 		elem->SetOrder(true);
-		fem_dm->ConfigElement(elem, m_num->ele_gauss_points);
+		fem_dm->ConfigElement(elem);
 		fem_dm->LocalAssembly(0);
 	}
 }

--- a/FEM/pcs_dm.cpp
+++ b/FEM/pcs_dm.cpp
@@ -1873,7 +1873,7 @@ double CRFProcessDeformation::CaclMaxiumLoadRatio(void)
 	double PRatio = 0.0;
 	const double MaxR = 20.0;
 
-	//gp_t = 0;
+	// gp_t = 0;
 
 	for (std::size_t i = 0; i < m_msh->ele_vector.size(); i++)
 	{
@@ -1923,9 +1923,7 @@ double CRFProcessDeformation::CaclMaxiumLoadRatio(void)
 				if (!(    elem->GetElementType() == MshElemType::TRIANGLE
 				       || elem->GetElementType() == MshElemType::QUAD) )
 				{
-					std::cerr <<
-					"CRFProcessDeformation::CaclMaxiumLoadRatio MshElemType not handled"
-					          << std::endl;
+					std::cerr << "CRFProcessDeformation::CaclMaxiumLoadRatio MshElemType not handled" << std::endl;
 				}
 				fem_dm->getGradShapefunctValues(gp, 2);
 				fem_dm->ComputeStrain(gp);
@@ -1947,8 +1945,8 @@ double CRFProcessDeformation::CaclMaxiumLoadRatio(void)
 				}
 
 				// Stress of the previous time step
-				for(int j = 0; j < fem_dm->ns; j++)
-					fem_dm->dstress[j] = (*eleV_DM->Stress)(j,gp);
+				for (int j = 0; j < fem_dm->ns; j++)
+					fem_dm->dstress[j] = (*eleV_DM->Stress)(j, gp);
 
 				// Compute try stress, stress incremental:
 				fem_dm->De->multi(dstrain, fem_dm->dstress);
@@ -1975,8 +1973,8 @@ double CRFProcessDeformation::CaclMaxiumLoadRatio(void)
 						p0 *= 3.0;
 						EffS
 						    = sqrt(II * pow(1.0 + (*Mat)(5) * III / pow(II, 1.5), (*Mat)(6)) + 0.5 * (*Mat)(0) * p0 * p0
-						           + (*Mat)(2) * (*Mat)(2) * p0 * p0 * p0 * p0)
-						      + (*Mat)(1) * p0 + (*Mat)(3) * p0 * p0;
+						           + (*Mat)(2) * (*Mat)(2) * p0 * p0 * p0 * p0) + (*Mat)(1) * p0
+						      + (*Mat)(3) * p0* p0;
 
 						if (EffS > (*Mat)(4))
 						{
@@ -2282,7 +2280,7 @@ void CRFProcessDeformation::Trace_Discontinuity()
 			}
 
 			fem_dm->ConfigElement(elem);
-			//2D
+			// 2D
 			elem->GetElementFaceNodes(bFaces, FNodes0);
 			if (elem->GetElementType() == MshElemType::QUAD || elem->GetElementType() == MshElemType::TRIANGLE)
 				nPathNodes = 2;
@@ -3584,6 +3582,8 @@ bool CRFProcessDeformation::CalcBC_or_SecondaryVariable_Dynamics(bool BC)
 }
 
 bool CRFProcessDeformation::isDynamic() const
-{return fem_dm->dynamic;}
+{
+	return fem_dm->dynamic;
+}
 
-}                                                 // end namespace
+} // end namespace

--- a/FEM/pcs_dm.cpp
+++ b/FEM/pcs_dm.cpp
@@ -1022,7 +1022,6 @@ void CRFProcessDeformation::InitGauss(void)
 	size_t i;
 	int j, k, gp, NGS, MatGroup, n_dom;
 	int PModel = 1;
-	int gp_r = 0, gp_s = 0, gp_t = 0;
 	//  double z=0.0;
 	double xyz[3];
 	static double Strs[6];

--- a/FEM/pcs_dm.cpp
+++ b/FEM/pcs_dm.cpp
@@ -2697,8 +2697,8 @@ void CRFProcessDeformation::GlobalAssembly()
 			else
 				CalcBC_or_SecondaryVariable_Dynamics(true);
 		}
-//  {        MXDumpGLS("rf_pcs1.txt",1,eqs->b,eqs->x);  //abort();}
-//
+		//  {  		MXDumpGLS("rf_pcs1.txt",1,eqs->b,eqs->x);  //abort();}
+		//
 
 #define atest_dump
 #ifdef test_dump

--- a/FEM/pcs_dm.cpp
+++ b/FEM/pcs_dm.cpp
@@ -1129,15 +1129,11 @@ void CRFProcessDeformation::InitGauss(void)
 				 */
 			}
 
-			fem_dm->setElement(elem);
+			fem_dm->ConfigElement(elem);
 			fem_dm->setOrder(2);
 			fem_dm->SetIntegrationPointNumber(elem->GetElementType());
 			NGS = fem_dm->GetNumGaussPoints();
 			//
-			if (ccounter > 0)
-			{
-				fem_dm->getShapeFunctionPtr(elem->GetElementType());
-			}
 
 			for (gp = 0; gp < NGS; gp++)
 			{

--- a/FEM/pcs_dm.h
+++ b/FEM/pcs_dm.h
@@ -81,6 +81,9 @@ public:
 	double* GetAuxArray() const { return ARRAY; }
 	void ScalingNodeForce(const double SFactor);
 	void InitGauss();
+
+	bool isDynamic() const;
+
 	//
 	void SetInitialGuess_EQS_VEC();
 	void UpdateIterativeStep(const double damp, const int u_type);
@@ -117,8 +120,9 @@ public:
 	void ReadElementStress();
 
 	// Access members
-	CFiniteElementVec* GetFEM_Assembler() const { return fem_dm; }
-	// WX:07.2011
+	CFiniteElementVec* GetFEMAssembler() {return fem_dm; }
+
+	//WX:07.2011
 	void PostExcavation();
 	// WX:10.2011
 	void UpdateIniStateValue();

--- a/FEM/pcs_dm.h
+++ b/FEM/pcs_dm.h
@@ -79,6 +79,7 @@ public:
 
 	// Aux. Memory
 	double* GetAuxArray() const { return ARRAY; }
+
 	void ScalingNodeForce(const double SFactor);
 	void InitGauss();
 
@@ -120,9 +121,9 @@ public:
 	void ReadElementStress();
 
 	// Access members
-	CFiniteElementVec* GetFEMAssembler() {return fem_dm; }
+	CFiniteElementVec* GetFEMAssembler() { return fem_dm; }
 
-	//WX:07.2011
+	// WX:07.2011
 	void PostExcavation();
 	// WX:10.2011
 	void UpdateIniStateValue();

--- a/FEM/problem.cpp
+++ b/FEM/problem.cpp
@@ -4302,6 +4302,10 @@ void Problem::createShapeFunctionPool()
 	for (std::size_t i = 0; i < pcs_vector.size(); i++)
 	{
 		CRFProcess* pcs = pcs_vector[i];
+		if (   pcs->getProcessType() == FiniteElement::FLUID_MOMENTUM
+			|| pcs->getProcessType() == FiniteElement::RANDOM_WALK)
+			 continue;
+
 		if (   pcs->getProcessType() == FiniteElement::DEFORMATION
 			|| pcs->getProcessType() == FiniteElement::DEFORMATION_DYNAMIC
 			|| pcs->getProcessType() == FiniteElement::DEFORMATION_FLOW
@@ -4414,6 +4418,10 @@ void Problem::createShapeFunctionPool()
 	for (std::size_t i = 0; i < pcs_vector.size(); i++)
 	{
 		CRFProcess* pcs = pcs_vector[i];
+		if (   pcs->getProcessType() == FiniteElement::FLUID_MOMENTUM
+			|| pcs->getProcessType() == FiniteElement::RANDOM_WALK)
+			 continue;
+
 		if ( pcs->getProcessType() == FiniteElement::DEFORMATION )
 		{
 			CRFProcessDeformation* dm_pcs = dynamic_cast<CRFProcessDeformation*>(pcs);

--- a/FEM/problem.cpp
+++ b/FEM/problem.cpp
@@ -4339,9 +4339,9 @@ void Problem::createShapeFunctionPool()
 
 	// Check element types of meshes
 	std::vector<MshElemType::type> elem_types;
-	elem_types.reserve(MshElemType::LAST);
+	elem_types.reserve(MshElemType::NUM_ELEM_TYPES);
 
-	for (std::size_t i = 0; i < static_cast<std::size_t>(MshElemType::LAST); i++)
+	for (std::size_t i = 0; i < static_cast<std::size_t>(MshElemType::NUM_ELEM_TYPES); i++)
 	{
 		elem_types.push_back(MshElemType::INVALID);
 	}

--- a/FEM/problem.cpp
+++ b/FEM/problem.cpp
@@ -114,7 +114,7 @@ using process::CRFProcessDeformation;
  ***************************************************************************/
 Problem::Problem (char* filename) :
 	dt0(0.), print_result(true),
-	_line_shapefunction_pool(NULL), _quadr_shapefunction_pool(NULL),
+	_linear_shapefunction_pool(NULL), _quadr_shapefunction_pool(NULL),
 	_geo_obj (new GEOLIB::GEOObjects), _geo_name (filename),
 	mrank(0), msize(0)
 {
@@ -618,19 +618,14 @@ Problem::~Problem()
 	delete m_vec_BRNS;
 #endif
 
-	if (_line_shapefunction_pool)
+	if (_linear_shapefunction_pool)
 	{
-		if (_line_shapefunction_pool == _quadr_shapefunction_pool)
+		if (_linear_shapefunction_pool == _quadr_shapefunction_pool)
 		{
-			delete _line_shapefunction_pool;
-			_line_shapefunction_pool = NULL;
 			_quadr_shapefunction_pool = NULL;
 		}
-		else
-		{
-			delete _line_shapefunction_pool;
-			_line_shapefunction_pool = NULL;
-		}
+		delete _linear_shapefunction_pool;
+		_linear_shapefunction_pool = NULL;
 	}
 	if (_quadr_shapefunction_pool)
 		delete _quadr_shapefunction_pool;
@@ -4391,16 +4386,16 @@ void Problem::createShapeFunctionPool()
 
 	const int num_gauss_sample_pnts = num_vector[0]->getNumIntegrationSamplePoints();
 	if (lin_fem_assembler)
-		_line_shapefunction_pool
+		_linear_shapefunction_pool
 		    = new FiniteElement::ShapeFunctionPool(elem_types, *lin_fem_assembler, num_gauss_sample_pnts);
 	if (fem_assembler)
 	{
 		_quadr_shapefunction_pool
 		    = new FiniteElement::ShapeFunctionPool(elem_types, *fem_assembler, num_gauss_sample_pnts);
-		if (!_line_shapefunction_pool)
+		if (!_linear_shapefunction_pool)
 		{
 			fem_assembler->setOrder(1);
-			_line_shapefunction_pool
+			_linear_shapefunction_pool
 			    = new FiniteElement::ShapeFunctionPool(elem_types, *fem_assembler, num_gauss_sample_pnts);
 			fem_assembler->setOrder(2);
 		}
@@ -4418,7 +4413,7 @@ void Problem::createShapeFunctionPool()
 		{
 			CRFProcessDeformation* dm_pcs = dynamic_cast<CRFProcessDeformation*>(pcs);
 			CFiniteElementVec* fem_assem_h = dm_pcs->GetFEMAssembler();
-			fem_assem_h->setShapeFunctionPool(_line_shapefunction_pool, _quadr_shapefunction_pool);
+			fem_assem_h->setShapeFunctionPool(_linear_shapefunction_pool, _quadr_shapefunction_pool);
 		}
 		else if (pcs->getProcessType() == FiniteElement::DEFORMATION_DYNAMIC
 		         || pcs->getProcessType() == FiniteElement::DEFORMATION_FLOW
@@ -4426,16 +4421,16 @@ void Problem::createShapeFunctionPool()
 		{
 			CRFProcessDeformation* dm_pcs = dynamic_cast<CRFProcessDeformation*>(pcs);
 			CFiniteElementVec* fem_assem_h = dm_pcs->GetFEMAssembler();
-			fem_assem_h->setShapeFunctionPool(_line_shapefunction_pool, _quadr_shapefunction_pool);
+			fem_assem_h->setShapeFunctionPool(_linear_shapefunction_pool, _quadr_shapefunction_pool);
 			CFiniteElementStd* fem_assem = dm_pcs->getLinearFEMAssembler();
-			fem_assem->setShapeFunctionPool(_line_shapefunction_pool, _quadr_shapefunction_pool);
+			fem_assem->setShapeFunctionPool(_linear_shapefunction_pool, _quadr_shapefunction_pool);
 		}
 		else
 		{
 			CFiniteElementStd* fem_assem = pcs->getLinearFEMAssembler();
 			if (!_quadr_shapefunction_pool)
-				_quadr_shapefunction_pool = _line_shapefunction_pool;
-			fem_assem->setShapeFunctionPool(_line_shapefunction_pool, _quadr_shapefunction_pool);
+				_quadr_shapefunction_pool = _linear_shapefunction_pool;
+			fem_assem->setShapeFunctionPool(_linear_shapefunction_pool, _quadr_shapefunction_pool);
 		}
 	}
 }

--- a/FEM/problem.cpp
+++ b/FEM/problem.cpp
@@ -70,7 +70,7 @@ extern int ReadData(char*, GEOLIB::GEOObjects& geo_obj, std::string& unique_name
 #include "Output.h"
 #include "fem_ele_std.h"
 #include "fem_ele_vec.h"
-#include "files0.h"                               // GetLineFromFile1
+#include "files0.h" // GetLineFromFile1
 #include "rf_bc_new.h"
 #include "rf_node.h"
 #include "rf_out_new.h"
@@ -222,22 +222,22 @@ Problem::Problem (char* filename) :
 	// OK if (!Check()) return; //OK
 	//----------------------------------------------------------------------
 	// REACTIONS
-	//CB before the first time step
-	if(REACTINT_vec.size()==0)
+	// CB before the first time step
+	if (REACTINT_vec.size() == 0)
 	{
-		for(size_t i=0; i<mmp_vector.size(); i++)
+		for (size_t i = 0; i < mmp_vector.size(); i++)
 		{
-			if(mmp_vector[i]->porosity_model==13)
+			if (mmp_vector[i]->porosity_model == 13)
 			{
 				std::cout << " Error in Model setup: Porosity model 13 is used, " << "\n";
 				std::cout << " but no reaction interface is defined! Exiting now..." << "\n";
 				exit(0);
- 			}
+			}
 		}
 	}
-	//if(MASS_TRANSPORT_Process) // if(MASS_TRANSPORT_Process&&NAPL_Dissolution) //CB Todo
+	// if(MASS_TRANSPORT_Process) // if(MASS_TRANSPORT_Process&&NAPL_Dissolution) //CB Todo
 	CreateClockTime(); // CB time
-	if(transport_processes.size() > 0)    //12.12.2008. WW
+	if (transport_processes.size() > 0) // 12.12.2008. WW
 	{
 		// set the id variable flow_pcs_type for Saturation and velocity calculation
 		// in mass transport element matrices
@@ -246,35 +246,36 @@ Problem::Problem (char* filename) :
 		KRConfig(*_geo_obj, _geo_name);
 
 		// initialyse the reaction interface if  not done yet
-		if(REACTINT_vec.size()>0)
+		if (REACTINT_vec.size() > 0)
 		{
-			if(REACTINT_vec[0]->unitconversion)
+			if (REACTINT_vec[0]->unitconversion)
 			{
 				CRFProcess* flow_pcs = NULL;
 				flow_pcs = PCSGetFlow();
-				if( flow_pcs->type==1212) // in case of mutlltiphase flow, sat water must be calculated here, required by pgc interface
+				if (flow_pcs->type == 1212) // in case of mutlltiphase flow, sat water must be calculated here, required
+				                            // by pgc interface
 					flow_pcs->CalcSecondaryVariables(true);
 			}
 			REACTINT_vec[0]->InitREACTINT();
 		}
-		//----------------------------------------------------------------------	
-		if(KinReactData_vector.size() > 0)
+		//----------------------------------------------------------------------
+		if (KinReactData_vector.size() > 0)
 		{
 			// Configure Data for Blobs (=>NAPL dissolution)
 			KBlobConfig(*_geo_obj, _geo_name);
 			KBlobCheck();
 			// in case of Twophaseflow before the first time step
-			if(total_processes[3] || total_processes[4])
-				if(KNaplDissCheck())  // 3: TWO_PHASE_FLOW. 12.12.2008. WW
-					KNaplCalcDensity();  //PCSCalcSecondaryVariables();
+			if (total_processes[3] || total_processes[4])
+				if (KNaplDissCheck()) // 3: TWO_PHASE_FLOW. 12.12.2008. WW
+					KNaplCalcDensity(); // PCSCalcSecondaryVariables();
 			// CB _drmc_ data for microbes
-			if(MicrobeData_vector.size()>0)
+			if (MicrobeData_vector.size() > 0)
 				MicrobeConfig();
 		}
 	}
-	//----------------------------------------------------------------------
-	// REACTIONS
-	// Initialization of REACT structure for rate exchange between MTM2 and Reactions
+//----------------------------------------------------------------------
+// REACTIONS
+// Initialization of REACT structure for rate exchange between MTM2 and Reactions
 
 //--------------------------------------------------
 // HB, for the GEM chemical reaction engine 05.2007
@@ -362,9 +363,9 @@ Problem::Problem (char* filename) :
 		}
 		//  delete rc;
 	}
-	//CB merge CAP 0311
+	// CB merge CAP 0311
 	// Initialize using ChemApp
-	if(REACT_CAP_vec.size() > 0) 
+	if (REACT_CAP_vec.size() > 0)
 	{
 		// SB 10/2009 do a first equilibrium calculation
 		REACT_CAP_vec[0]->ExecuteReactionsChemApp(0, -1); // DL/SB 11/2008 //DL 2011.11.24 comment for AGU
@@ -393,7 +394,7 @@ Problem::Problem (char* filename) :
 #endif
 	//  delete rc;
 
-	if(REACTINT_vec.size()>0)
+	if (REACTINT_vec.size() > 0)
 		REACTINT_vec[0]->ReactionPostProcessing(true);
 	//----------------------------------------------------------------------
 	// DDC
@@ -477,7 +478,7 @@ Problem::Problem (char* filename) :
 	// For time stepping. WW
 	CTimeDiscretization* m_tim = NULL;
 	start_time = 1.0e+25; // 1.e+8;  kg44 I need a really big time, as I have starting times bigger than 3.e+13 (1
-	// Million years!!!)
+	                      // Million years!!!)
 	end_time = 0.;
 	max_time_steps = 0;
 	bool time_ctr = false;
@@ -976,10 +977,10 @@ void Problem::PCSCreate()
 		pcs_vector[i]->Create();
 	}
 
-	createShapeFunctionPool(); //WW
+	createShapeFunctionPool(); // WW
 
 	for (size_t i = 0; i < no_processes; i++)
-	{//WW
+	{ // WW
 		CRFProcess* pcs = pcs_vector[i];
 		pcs->SetBoundaryConditionAndSourceTerm();
 
@@ -992,7 +993,6 @@ void Problem::PCSCreate()
 			dm_pcs->InitGauss();
 		}
 	}
-
 
 #if defined(USE_PETSC) // || defined(other solver libs)//03.3012. WW
 	CreateEQS_LinearSolver();
@@ -1470,7 +1470,7 @@ bool Problem::CouplingLoop()
 					loop_process_number = i;
 					if (a_pcs->first_coupling_iteration)
 						PreCouplingLoop(a_pcs);
-					//					 error = Call_Member_FN(this, active_processes[index])();
+					//					error = Call_Member_FN(this, active_processes[index])();
 					Call_Member_FN(this, active_processes[index])();
 					if (!a_pcs->TimeStepAccept())
 					{
@@ -1482,7 +1482,7 @@ bool Problem::CouplingLoop()
 					loop_process_number = i + 1;
 					if (b_pcs->first_coupling_iteration)
 						PreCouplingLoop(b_pcs);
-					//					 error = Call_Member_FN(this, active_processes[cpl_index])();
+					//					error = Call_Member_FN(this, active_processes[cpl_index])();
 					Call_Member_FN(this, active_processes[cpl_index])();
 					if (!b_pcs->TimeStepAccept())
 					{
@@ -1527,7 +1527,7 @@ bool Problem::CouplingLoop()
 				if (a_pcs->first_coupling_iteration)
 					PreCouplingLoop(a_pcs);
 				//				error = Call_Member_FN(this, active_processes[index])(); // TF: error set, but never
-				// used
+				//used
 				Call_Member_FN(this, active_processes[index])();
 				if (!a_pcs->TimeStepAccept())
 				{
@@ -1576,7 +1576,7 @@ if(has_constrained_bc > 0)
 		{
 			std::cout << "\n";
 			break;
-	    	}
+		}
 		//
 		if (cpl_overall_max_iterations > 1)
 		{
@@ -1730,9 +1730,9 @@ void Problem::PostCouplingLoop()
 			m_pcs->WriteSolution(); // WW
 #ifdef GEM_REACT
 			if (i == 0) // for GEM_REACT we also need information on porosity (node porosity internally stored in Gems
-				// process)!....do it only once and it does not matter for which process ! ....we assume that
-				// the first pcs process is the flow process...if reload not defined for every process,
-				// restarting with gems will not work in any case
+			            // process)!....do it only once and it does not matter for which process ! ....we assume that
+			            // the first pcs process is the flow process...if reload not defined for every process,
+			            // restarting with gems will not work in any case
 
 				if ((m_pcs->reload == 1 || m_pcs->reload == 3)
 				    && !((aktueller_zeitschritt % m_pcs->nwrite_restart) > 0))
@@ -2152,9 +2152,9 @@ void Problem::TestOutputDuMux(CRFProcess* m_pcs)
 		    = pcs_vector[m_pcs->DuMuxData->ProcessIndex_CO2inLiquid]->GetNodeValue(i, indexConcentration_CO2);
 
 		mass_CO2_gas = mass_CO2_gas + node_volume * saturation_CO2 * density_CO2;
-		mass_CO2_water
-		    = mass_CO2_water
-		      + node_volume * saturation_water * concentration_CO2_water * m_pcs->DuMuxData->Molweight_CO2 * 0.001;
+		mass_CO2_water = mass_CO2_water
+		                 + node_volume * saturation_water * concentration_CO2_water * m_pcs->DuMuxData->Molweight_CO2
+		                       * 0.001;
 		// cout << " Node: " << i << " saturation: " << saturation_water << " Density_CO2: " << density_CO2 << "
 		// node_volume: " << node_volume << "\n";
 	}
@@ -2268,9 +2268,9 @@ void Problem::TestOutputDuMux(CRFProcess* m_pcs)
 		                          / (m_pcs->DuMuxData->Molweight_CO2 * 1e-3);
 
 		mass_CO2_gas = mass_CO2_gas + node_volume * saturation_CO2 * density_CO2;
-		mass_CO2_water
-		    = mass_CO2_water
-		      + node_volume * saturation_water * concentration_CO2_water * m_pcs->DuMuxData->Molweight_CO2 * 0.001;
+		mass_CO2_water = mass_CO2_water
+		                 + node_volume * saturation_water * concentration_CO2_water * m_pcs->DuMuxData->Molweight_CO2
+		                       * 0.001;
 	}
 	mass_CO2 = mass_CO2_gas + mass_CO2_water;
 	// calculating time
@@ -2412,9 +2412,9 @@ void Problem::TestOutputEclipse(CRFProcess* m_pcs)
 		    = pcs_vector[m_pcs->EclipseData->ProcessIndex_CO2inLiquid]->GetNodeValue(i, indexConcentration_CO2);
 
 		mass_CO2_gas = mass_CO2_gas + node_volume * saturation_CO2 * density_CO2;
-		mass_CO2_water
-		    = mass_CO2_water
-		      + node_volume * saturation_water * concentration_CO2_water * m_pcs->EclipseData->Molweight_CO2 * 0.001;
+		mass_CO2_water = mass_CO2_water
+		                 + node_volume * saturation_water * concentration_CO2_water * m_pcs->EclipseData->Molweight_CO2
+		                       * 0.001;
 		// cout << " Node: " << i << " saturation: " << saturation_water << " Density_CO2: " << density_CO2 << "
 		// node_volume: " << node_volume << "\n";
 	}
@@ -2520,13 +2520,12 @@ void Problem::TestOutputEclipse(CRFProcess* m_pcs)
 		for (int j = 0; j < int(ele_nodes.Size()); j++)
 			concentration_CO2_water = concentration_CO2_water
 			                          + pcs_vector[m_pcs->EclipseData->ProcessIndex_CO2inLiquid]->GetNodeValue(
-			                                ele_nodes[j]->GetIndex(), indexConcentration_CO2)
-			                                / ele_nodes.Size();
+			                                ele_nodes[j]->GetIndex(), indexConcentration_CO2) / ele_nodes.Size();
 
 		mass_CO2_gas = mass_CO2_gas + element_volume * saturation_CO2 * density_CO2;
-		mass_CO2_water
-		    = mass_CO2_water
-		      + element_volume * saturation_water * concentration_CO2_water * m_pcs->EclipseData->Molweight_CO2 * 0.001;
+		mass_CO2_water = mass_CO2_water
+		                 + element_volume * saturation_water * concentration_CO2_water
+		                       * m_pcs->EclipseData->Molweight_CO2 * 0.001;
 	}
 	mass_CO2 = mass_CO2_gas + mass_CO2_water;
 	// calculating time
@@ -2668,8 +2667,7 @@ void Problem::OutputMassOfGasInModel(CRFProcess* m_pcs)
 	// +1: new timelevel
 	if (ProcessIndex_GasInLiquid > -1)
 		indexConcentration_Gas = pcs_vector[ProcessIndex_GasInLiquid]->GetNodeValueIndex(
-		                             pcs_vector[ProcessIndex_GasInLiquid]->pcs_primary_function_name[0])
-		                         + 1;
+		                             pcs_vector[ProcessIndex_GasInLiquid]->pcs_primary_function_name[0]) + 1;
 
 	for (long i = 0; i < (long)m_msh->nod_vector.size(); i++)
 	{
@@ -2720,8 +2718,8 @@ void Problem::OutputMassOfGasInModel(CRFProcess* m_pcs)
 		if (ProcessIndex_GasInLiquid > -1)
 		{
 			concentration_Gas_water = pcs_vector[ProcessIndex_GasInLiquid]->GetNodeValue(i, indexConcentration_Gas);
-			mass_Gas_water
-			    = mass_Gas_water + node_volume * saturation_water * concentration_Gas_water * Molweight_Gas * 0.001;
+			mass_Gas_water = mass_Gas_water
+			                 + node_volume * saturation_water * concentration_Gas_water * Molweight_Gas * 0.001;
 		}
 		else
 			mass_Gas_water = 0;
@@ -2889,9 +2887,8 @@ void Problem::OutputMassOfComponentInModel(std::vector<CRFProcess*> flow_pcs, CR
 		node_volume = 0;
 		if (mfp_vector[0]->density_model == 18)
 		{
-			//			variable_index = flow_pcs[0]->GetNodeValueIndex("DENSITY1"); // // 2012-08 TF, variable set but
-			// not
-			// used
+			//			variable_index = flow_pcs[0]->GetNodeValueIndex("DENSITY1"); // // 2012-08 TF, variable set but not
+			//used
 			//			density_water = flow_pcs[0]->GetNodeValue(i, variable_index); // 2012-08 TF, variable
 			//‘density_water’ set but not used [-Wunused-but-set-variable]
 		}
@@ -2908,8 +2905,8 @@ void Problem::OutputMassOfComponentInModel(std::vector<CRFProcess*> flow_pcs, CR
 			m_mat_mp = mmp_vector[group];
 			porosity
 			    = m_mat_mp->Porosity(m_ele->GetIndex(), 1); // CB Now provides also heterogeneous porosity, model 11
-			node_volume
-			    = node_volume + porosity * m_ele->GetVolume() * m_ele->GetFluxArea() / m_ele->GetNodesNumber(false);
+			node_volume = node_volume
+			              + porosity * m_ele->GetVolume() * m_ele->GetFluxArea() / m_ele->GetNodesNumber(false);
 			// cout << m_ele->GetNodesNumber(false) << " " << "\n";
 		}
 
@@ -2921,8 +2918,8 @@ void Problem::OutputMassOfComponentInModel(std::vector<CRFProcess*> flow_pcs, CR
 			int index = flow_pcs[0]->GetNodeValueIndex("SATURATION1") + 1; //+1... new time level
 			saturation_water = flow_pcs[0]->GetNodeValue(i, index);
 		}
-		indexComponentConcentration
-		    = transport_pcs->GetNodeValueIndex(transport_pcs->pcs_primary_function_name[0]) + 1; // +1: new timelevel
+		indexComponentConcentration = transport_pcs->GetNodeValueIndex(transport_pcs->pcs_primary_function_name[0])
+		                              + 1; // +1: new timelevel
 		ComponentConcentration = transport_pcs->GetNodeValue(i, indexComponentConcentration);
 
 		ComponentMass = ComponentMass + node_volume * saturation_water * ComponentConcentration;
@@ -3119,8 +3116,8 @@ inline double Problem::GroundWaterFlow()
 		idx_flux = neighb_pcs->GetNodeValueIndex("VELOCITY_Z1");
 
 		for (i = 0; i < neighb_grid->getBorderNodeNumber(); i++)
-			border_flux[local_indxs_this[i]]
-			    = neighb_pcs->GetNodeValue(local_indxs[i], idx_flux) / neighb_pcs->time_unit_factor;
+			border_flux[local_indxs_this[i]] = neighb_pcs->GetNodeValue(local_indxs[i], idx_flux)
+			                                   / neighb_pcs->time_unit_factor;
 
 		m_pcs->Integration(border_flux);
 
@@ -3682,7 +3679,7 @@ inline double Problem::Deformation()
 			m_pcs->cal_integration_point_value = true;
 			dm_pcs->CalIntegrationPointValue();
 		}
-		if(dm_pcs->type == 42) // H2M. 07.2011. WW
+		if (dm_pcs->type == 42) // H2M. 07.2011. WW
 			dm_pcs->CalcSecondaryVariablesUnsaturatedFlow();
 	}
 	return error;
@@ -3783,7 +3780,7 @@ inline void Problem::LOPExecuteRegionalRichardsFlow(CRFProcess* m_pcs_global, in
 		m_pcs_local->Create();
 
 		m_pcs_local->fem->setShapeFunctionPool(m_pcs_global->fem->getShapeFunctionPool(0),
-			                                   m_pcs_global->fem->getShapeFunctionPool(1));
+		                                       m_pcs_global->fem->getShapeFunctionPool(1));
 
 		m_pcs_local->SetBoundaryConditionAndSourceTerm();
 		//....................................................................
@@ -4302,14 +4299,14 @@ void Problem::createShapeFunctionPool()
 	for (std::size_t i = 0; i < pcs_vector.size(); i++)
 	{
 		CRFProcess* pcs = pcs_vector[i];
-		if (   pcs->getProcessType() == FiniteElement::FLUID_MOMENTUM
-			|| pcs->getProcessType() == FiniteElement::RANDOM_WALK)
-			 continue;
+		if (pcs->getProcessType() == FiniteElement::FLUID_MOMENTUM
+		    || pcs->getProcessType() == FiniteElement::RANDOM_WALK)
+			continue;
 
-		if (   pcs->getProcessType() == FiniteElement::DEFORMATION
-			|| pcs->getProcessType() == FiniteElement::DEFORMATION_DYNAMIC
-			|| pcs->getProcessType() == FiniteElement::DEFORMATION_FLOW
-			|| pcs->getProcessType() == FiniteElement::DEFORMATION_H2)
+		if (pcs->getProcessType() == FiniteElement::DEFORMATION
+		    || pcs->getProcessType() == FiniteElement::DEFORMATION_DYNAMIC
+		    || pcs->getProcessType() == FiniteElement::DEFORMATION_FLOW
+		    || pcs->getProcessType() == FiniteElement::DEFORMATION_H2)
 		{
 			pcs_1c_fem = pcs;
 		}
@@ -4331,7 +4328,7 @@ void Problem::createShapeFunctionPool()
 		if (!lin_fem_assembler)
 		{
 			lin_fem_assembler = pcs_1c_fem->getLinearFEMAssembler();
-			if(lin_fem_assembler)
+			if (lin_fem_assembler)
 				lin_fem_assembler->setOrder(1);
 		}
 
@@ -4343,73 +4340,68 @@ void Problem::createShapeFunctionPool()
 	// Check element types of meshes
 	std::vector<MshElemType::type> elem_types;
 	elem_types.reserve(MshElemType::LAST);
- 
-	for (std::size_t i=0; i<static_cast<std::size_t>(MshElemType::LAST); i++)
+
+	for (std::size_t i = 0; i < static_cast<std::size_t>(MshElemType::LAST); i++)
 	{
 		elem_types.push_back(MshElemType::INVALID);
 	}
 
-	for (std::size_t i=0; i<fem_msh_vector.size(); i++)
+	for (std::size_t i = 0; i < fem_msh_vector.size(); i++)
 	{
 		MeshLib::CFEMesh* mesh = fem_msh_vector[i];
 		if (mesh->getNumberOfLines() > 0)
-			elem_types[static_cast<int>(MshElemType::LINE)-1] = MshElemType::LINE;
+			elem_types[static_cast<int>(MshElemType::LINE) - 1] = MshElemType::LINE;
 		if (mesh->getNumberOfTris() > 0)
 		{
-			elem_types[static_cast<int>(MshElemType::TRIANGLE)-1] = MshElemType::TRIANGLE;
-			elem_types[static_cast<int>(MshElemType::LINE)-1] = MshElemType::LINE;
+			elem_types[static_cast<int>(MshElemType::TRIANGLE) - 1] = MshElemType::TRIANGLE;
+			elem_types[static_cast<int>(MshElemType::LINE) - 1] = MshElemType::LINE;
 		}
 		if (mesh->getNumberOfQuads() > 0)
 		{
-			elem_types[static_cast<int>(MshElemType::QUAD)-1] = MshElemType::QUAD;
-			elem_types[static_cast<int>(MshElemType::LINE)-1] = MshElemType::LINE;
+			elem_types[static_cast<int>(MshElemType::QUAD) - 1] = MshElemType::QUAD;
+			elem_types[static_cast<int>(MshElemType::LINE) - 1] = MshElemType::LINE;
 		}
 		if (mesh->getNumberOfHexs() > 0)
 		{
-			elem_types[static_cast<int>(MshElemType::HEXAHEDRON)-1] = MshElemType::HEXAHEDRON;
-			elem_types[static_cast<int>(MshElemType::QUAD8)-1] = MshElemType::QUAD8;
-			elem_types[static_cast<int>(MshElemType::LINE)-1] = MshElemType::LINE;
+			elem_types[static_cast<int>(MshElemType::HEXAHEDRON) - 1] = MshElemType::HEXAHEDRON;
+			elem_types[static_cast<int>(MshElemType::QUAD8) - 1] = MshElemType::QUAD8;
+			elem_types[static_cast<int>(MshElemType::LINE) - 1] = MshElemType::LINE;
 		}
 		if (mesh->getNumberOfTets() > 0)
 		{
-			elem_types[static_cast<int>(MshElemType::TETRAHEDRON)-1] = MshElemType::TETRAHEDRON;
-			elem_types[static_cast<int>(MshElemType::TRIANGLE)-1] = MshElemType::TRIANGLE;
-			elem_types[static_cast<int>(MshElemType::LINE)-1] = MshElemType::LINE;
+			elem_types[static_cast<int>(MshElemType::TETRAHEDRON) - 1] = MshElemType::TETRAHEDRON;
+			elem_types[static_cast<int>(MshElemType::TRIANGLE) - 1] = MshElemType::TRIANGLE;
+			elem_types[static_cast<int>(MshElemType::LINE) - 1] = MshElemType::LINE;
 		}
 		if (mesh->getNumberOfPrisms() > 0)
 		{
-			elem_types[static_cast<int>(MshElemType::PRISM)-1] = MshElemType::PRISM;
-			elem_types[static_cast<int>(MshElemType::QUAD8)-1] = MshElemType::QUAD8;
-			elem_types[static_cast<int>(MshElemType::TRIANGLE)-1] = MshElemType::TRIANGLE;
-			elem_types[static_cast<int>(MshElemType::LINE)-1] = MshElemType::LINE;
+			elem_types[static_cast<int>(MshElemType::PRISM) - 1] = MshElemType::PRISM;
+			elem_types[static_cast<int>(MshElemType::QUAD8) - 1] = MshElemType::QUAD8;
+			elem_types[static_cast<int>(MshElemType::TRIANGLE) - 1] = MshElemType::TRIANGLE;
+			elem_types[static_cast<int>(MshElemType::LINE) - 1] = MshElemType::LINE;
 		}
 		if (mesh->getNumberOfPyramids() > 0)
 		{
-			elem_types[static_cast<int>(MshElemType::PYRAMID)-1] = MshElemType::PYRAMID;
-			elem_types[static_cast<int>(MshElemType::QUAD8)-1] = MshElemType::QUAD8;
-			elem_types[static_cast<int>(MshElemType::TRIANGLE)-1] = MshElemType::TRIANGLE;
-			elem_types[static_cast<int>(MshElemType::LINE)-1] = MshElemType::LINE;
+			elem_types[static_cast<int>(MshElemType::PYRAMID) - 1] = MshElemType::PYRAMID;
+			elem_types[static_cast<int>(MshElemType::QUAD8) - 1] = MshElemType::QUAD8;
+			elem_types[static_cast<int>(MshElemType::TRIANGLE) - 1] = MshElemType::TRIANGLE;
+			elem_types[static_cast<int>(MshElemType::LINE) - 1] = MshElemType::LINE;
 		}
 	}
 
-
-	const int num_gauss_sample_pnts
-		     = num_vector[0]->getNumIntegrationSamplePoints();
+	const int num_gauss_sample_pnts = num_vector[0]->getNumIntegrationSamplePoints();
 	if (lin_fem_assembler)
-		_line_shapefunction_pool = 
-		new FiniteElement::ShapeFunctionPool(elem_types, *lin_fem_assembler,
-		                                     num_gauss_sample_pnts);
+		_line_shapefunction_pool
+		    = new FiniteElement::ShapeFunctionPool(elem_types, *lin_fem_assembler, num_gauss_sample_pnts);
 	if (fem_assembler)
 	{
-		_quadr_shapefunction_pool = 
-		new FiniteElement::ShapeFunctionPool(elem_types, *fem_assembler,
-		                                     num_gauss_sample_pnts);
+		_quadr_shapefunction_pool
+		    = new FiniteElement::ShapeFunctionPool(elem_types, *fem_assembler, num_gauss_sample_pnts);
 		if (!_line_shapefunction_pool)
 		{
 			fem_assembler->setOrder(1);
-			_line_shapefunction_pool = 
-			new FiniteElement::ShapeFunctionPool(elem_types, *fem_assembler,
-		                                     num_gauss_sample_pnts);
+			_line_shapefunction_pool
+			    = new FiniteElement::ShapeFunctionPool(elem_types, *fem_assembler, num_gauss_sample_pnts);
 			fem_assembler->setOrder(2);
 		}
 	}
@@ -4418,20 +4410,19 @@ void Problem::createShapeFunctionPool()
 	for (std::size_t i = 0; i < pcs_vector.size(); i++)
 	{
 		CRFProcess* pcs = pcs_vector[i];
-		if (   pcs->getProcessType() == FiniteElement::FLUID_MOMENTUM
-			|| pcs->getProcessType() == FiniteElement::RANDOM_WALK)
-			 continue;
+		if (pcs->getProcessType() == FiniteElement::FLUID_MOMENTUM
+		    || pcs->getProcessType() == FiniteElement::RANDOM_WALK)
+			continue;
 
-		if ( pcs->getProcessType() == FiniteElement::DEFORMATION )
+		if (pcs->getProcessType() == FiniteElement::DEFORMATION)
 		{
 			CRFProcessDeformation* dm_pcs = dynamic_cast<CRFProcessDeformation*>(pcs);
 			CFiniteElementVec* fem_assem_h = dm_pcs->GetFEMAssembler();
-			fem_assem_h->setShapeFunctionPool(_line_shapefunction_pool,
-				                              _quadr_shapefunction_pool);
+			fem_assem_h->setShapeFunctionPool(_line_shapefunction_pool, _quadr_shapefunction_pool);
 		}
-		else if (   pcs->getProcessType() == FiniteElement::DEFORMATION_DYNAMIC
-			|| pcs->getProcessType() == FiniteElement::DEFORMATION_FLOW
-			|| pcs->getProcessType() == FiniteElement::DEFORMATION_H2)
+		else if (pcs->getProcessType() == FiniteElement::DEFORMATION_DYNAMIC
+		         || pcs->getProcessType() == FiniteElement::DEFORMATION_FLOW
+		         || pcs->getProcessType() == FiniteElement::DEFORMATION_H2)
 		{
 			CRFProcessDeformation* dm_pcs = dynamic_cast<CRFProcessDeformation*>(pcs);
 			CFiniteElementVec* fem_assem_h = dm_pcs->GetFEMAssembler();
@@ -4444,8 +4435,7 @@ void Problem::createShapeFunctionPool()
 			CFiniteElementStd* fem_assem = pcs->getLinearFEMAssembler();
 			if (!_quadr_shapefunction_pool)
 				_quadr_shapefunction_pool = _line_shapefunction_pool;
-			fem_assem->setShapeFunctionPool(_line_shapefunction_pool,
-				                            _quadr_shapefunction_pool);
+			fem_assem->setShapeFunctionPool(_line_shapefunction_pool, _quadr_shapefunction_pool);
 		}
 	}
 }

--- a/FEM/problem.cpp
+++ b/FEM/problem.cpp
@@ -113,8 +113,10 @@ using process::CRFProcessDeformation;
    Modification:
  ***************************************************************************/
 Problem::Problem (char* filename) :
-	dt0(0.), print_result(true), _geo_obj (new GEOLIB::GEOObjects), _geo_name (filename),
-    _line_shapefunction_pool(NULL), _quadr_shapefunction_pool(NULL), mrank(0), msize(0)
+	dt0(0.), print_result(true),
+	_line_shapefunction_pool(NULL), _quadr_shapefunction_pool(NULL),
+	_geo_obj (new GEOLIB::GEOObjects), _geo_name (filename),
+	mrank(0), msize(0)
 {
 	if (filename != NULL)
 	{

--- a/FEM/problem.cpp
+++ b/FEM/problem.cpp
@@ -984,6 +984,7 @@ void Problem::PCSCreate()
 		pcs->SetBoundaryConditionAndSourceTerm();
 
 		if (   pcs->getProcessType() == FiniteElement::DEFORMATION_DYNAMIC
+			|| pcs->getProcessType() == FiniteElement::DEFORMATION
 			|| pcs->getProcessType() == FiniteElement::DEFORMATION_FLOW
 			|| pcs->getProcessType() == FiniteElement::DEFORMATION_H2)
 		{

--- a/FEM/problem.cpp
+++ b/FEM/problem.cpp
@@ -3781,6 +3781,11 @@ inline void Problem::LOPExecuteRegionalRichardsFlow(CRFProcess* m_pcs_global, in
 		//....................................................................
 		m_pcs_local->m_msh = m_msh_local;
 		m_pcs_local->Create();
+
+		m_pcs_local->fem->setShapeFunctionPool(m_pcs_global->fem->getShapeFunctionPool(0),
+			                                   m_pcs_global->fem->getShapeFunctionPool(1));
+
+		m_pcs_local->SetBoundaryConditionAndSourceTerm();
 		//....................................................................
 		// BC
 		//....................................................................

--- a/FEM/problem.h
+++ b/FEM/problem.h
@@ -112,15 +112,15 @@ private:
 	bool CalcVelocities;
 	bool conducted;
 
+	// Print flag
+	bool print_result;
+
 	/// Caches for shape functions and their derivatives with respect to
 	/// the local coordinates.
 	FiniteElement::ShapeFunctionPool* _line_shapefunction_pool;
 	FiniteElement::ShapeFunctionPool* _quadr_shapefunction_pool;
 
-	// Print flag
-	bool print_result;
 	// Processes
-
 	std::vector<CRFProcess*> total_processes;
 	std::vector<CRFProcess*> transport_processes;
 	std::vector<CRFProcess*> multiphase_processes;

--- a/FEM/problem.h
+++ b/FEM/problem.h
@@ -117,7 +117,7 @@ private:
 
 	/// Caches for shape functions and their derivatives with respect to
 	/// the local coordinates.
-	FiniteElement::ShapeFunctionPool* _line_shapefunction_pool;
+	FiniteElement::ShapeFunctionPool* _linear_shapefunction_pool;
 	FiniteElement::ShapeFunctionPool* _quadr_shapefunction_pool;
 
 	// Processes

--- a/FEM/problem.h
+++ b/FEM/problem.h
@@ -20,6 +20,17 @@ class CRFProcess;
 // GEOLIB
 #include "GEOObjects.h"
 
+
+namespace FiniteElement
+{
+class ShapeFunctionPool;
+}
+namespace FiniteElement
+{
+class CFiniteElementStd;
+class CFiniteElementVec;
+}
+
 //---------------------------------------------------------------------
 // Pointers to member functions
 class Problem;
@@ -101,6 +112,11 @@ private:
 	bool CalcVelocities;
 	bool conducted;
 
+	/// Caches for shape functions and their derivatives with respect to
+	/// the local coordinates.
+	FiniteElement::ShapeFunctionPool* _line_shapefunction_pool;
+	FiniteElement::ShapeFunctionPool* _quadr_shapefunction_pool;
+
 	// Print flag
 	bool print_result;
 	// Processes
@@ -146,6 +162,7 @@ private:
 	void OutputMassOfComponentInModel(std::vector<CRFProcess*> flow_pcs, CRFProcess* transport_pcs); // BG
 	void OutputMassOfGasInModel(CRFProcess* m_pcs); // BG
 
+	void createShapeFunctionPool();
 	/**
 	 * pointer to an instance of class GEOObjects,
 	 * that manages geometric entities

--- a/FEM/problem.h
+++ b/FEM/problem.h
@@ -20,7 +20,6 @@ class CRFProcess;
 // GEOLIB
 #include "GEOObjects.h"
 
-
 namespace FiniteElement
 {
 class ShapeFunctionPool;
@@ -61,10 +60,11 @@ public:
 			return buffer_array;
 	}
 	int GetCPLMaxIterations() { return cpl_overall_max_iterations; }
+
 	/**
-	   * get the geometric objects stored in GEOLIB::GEOObjects
-	   * @return a pointer to an instance of class GEOLIB::GEOObjects
-	   */
+	 * get the geometric objects stored in GEOLIB::GEOObjects
+	 * @return a pointer to an instance of class GEOLIB::GEOObjects
+	 */
 	const GEOLIB::GEOObjects* getGeoObj() const;
 	/**
 	 * Get the name of the project. The name is used by GEOLIB::GEOObjects

--- a/FEM/rf_fluid_momentum.cpp
+++ b/FEM/rf_fluid_momentum.cpp
@@ -123,27 +123,26 @@ double CFluidMomentum::Execute(int loop_process_number)
 	     << "\n";
 	cpl_max_relative_error = pcs_error;
 
-    bool isFlow = false;
-    CRFProcess *a_pcs = NULL;
-    // CRFProcess *f_pcs = NULL;
-    for(int k=0; k<no_processes; k++ )
-    {
-	   a_pcs = pcs_vector[k];
-       if(!a_pcs)
-         continue;
-       if(   a_pcs->getProcessType () == FiniteElement::RICHARDS_FLOW
-	        || a_pcs->getProcessType () == FiniteElement::LIQUID_FLOW
-	        || a_pcs->getProcessType () == FiniteElement::GROUNDWATER_FLOW
-	        || a_pcs->getProcessType () == FiniteElement::TWO_PHASE_FLOW
-	        || a_pcs->getProcessType () == FiniteElement::MULTI_PHASE_FLOW
-	     )
-       {
-         isFlow = true;
-         break;
-       }
-    }
+	bool isFlow = false;
+	CRFProcess* a_pcs = NULL;
+	// CRFProcess *f_pcs = NULL;
+	for (int k = 0; k < no_processes; k++)
+	{
+		a_pcs = pcs_vector[k];
+		if (!a_pcs)
+			continue;
+		if (a_pcs->getProcessType() == FiniteElement::RICHARDS_FLOW
+		    || a_pcs->getProcessType() == FiniteElement::LIQUID_FLOW
+		    || a_pcs->getProcessType() == FiniteElement::GROUNDWATER_FLOW
+		    || a_pcs->getProcessType() == FiniteElement::TWO_PHASE_FLOW
+		    || a_pcs->getProcessType() == FiniteElement::MULTI_PHASE_FLOW)
+		{
+			isFlow = true;
+			break;
+		}
+	}
 
-	for(int i = 0; i < no_processes; ++i)
+	for (int i = 0; i < no_processes; ++i)
 	{
 		m_pcs = pcs_vector[i];
 
@@ -158,11 +157,10 @@ double CFluidMomentum::Execute(int loop_process_number)
 		else if (m_pcs->getProcessType() == FiniteElement::GROUNDWATER_FLOW)
 			m_msh = FEMGet("GROUNDWATER_FLOW");
 
-
 		//		if(m_pcs->pcs_type_name.find("FLUID_MOMENTUM")!=string::npos) TF
-		if(m_pcs->getProcessType () == FiniteElement::FLUID_MOMENTUM)
+		if (m_pcs->getProcessType() == FiniteElement::FLUID_MOMENTUM)
 		{
-			if( isFlow )
+			if (isFlow)
 			{
 				fem = new CFiniteElementStd(m_pcs, m_msh->GetCoordinateFlag());
 				CFiniteElementStd* pcs_fem = a_pcs->getLinearFEMAssembler();
@@ -177,20 +175,20 @@ double CFluidMomentum::Execute(int loop_process_number)
 			else
 			{
 				m_msh = FEMGet("FLUID_MOMENTUM");
-				string vel_file = FileName+".vel";
+				string vel_file = FileName + ".vel";
 				ifstream ins(vel_file.c_str());
 				double vx, vy, vz;
 
-				int  nidx = m_pcs->GetNodeValueIndex("VELOCITY1_X")+1;
-				int  nidy = m_pcs->GetNodeValueIndex("VELOCITY1_Y")+1;
-				int  nidz = m_pcs->GetNodeValueIndex("VELOCITY1_Z")+1;
+				int nidx = m_pcs->GetNodeValueIndex("VELOCITY1_X") + 1;
+				int nidy = m_pcs->GetNodeValueIndex("VELOCITY1_Y") + 1;
+				int nidz = m_pcs->GetNodeValueIndex("VELOCITY1_Z") + 1;
 
 				for (size_t i = 0; i < m_pcs->m_msh->nod_vector.size(); i++)
 				{
-					ins>>vx>>vy>>vz>>ws;
-					m_pcs->SetNodeValue(i,nidx,vx);
-					m_pcs->SetNodeValue(i,nidy,vy);
-					m_pcs->SetNodeValue(i,nidz,vz);
+					ins >> vx >> vy >> vz >> ws;
+					m_pcs->SetNodeValue(i, nidx, vx);
+					m_pcs->SetNodeValue(i, nidy, vy);
+					m_pcs->SetNodeValue(i, nidz, vz);
 				}
 			}
 		}

--- a/FEM/rf_fluid_momentum.cpp
+++ b/FEM/rf_fluid_momentum.cpp
@@ -266,7 +266,7 @@ void CFluidMomentum::SolveDarcyVelocityOnNode()
 				elem = m_msh->ele_vector[i];
 				if (elem->GetMark()) // Marked for use
 				{
-					fem->ConfigElement(elem, m_num->ele_gauss_points);
+					fem->ConfigElement(elem);
 					fem->Assembly(0, d);
 				}
 			}

--- a/FEM/rf_fluid_momentum.cpp
+++ b/FEM/rf_fluid_momentum.cpp
@@ -123,25 +123,27 @@ double CFluidMomentum::Execute(int loop_process_number)
 	     << "\n";
 	cpl_max_relative_error = pcs_error;
 
-	bool isFlow = false;
-	CRFProcess* a_pcs = NULL;
-	// CRFProcess *f_pcs = NULL;
-	for (int k = 0; k < no_processes; k++)
-	{
-		a_pcs = pcs_vector[k];
-		if (!a_pcs)
-			continue;
-		if (a_pcs->getProcessType() == FiniteElement::RICHARDS_FLOW
-		    || a_pcs->getProcessType() == FiniteElement::LIQUID_FLOW
-		    || a_pcs->getProcessType() == FiniteElement::GROUNDWATER_FLOW
-		    || a_pcs->getProcessType() == FiniteElement::TWO_PHASE_FLOW
-		    || a_pcs->getProcessType() == FiniteElement::MULTI_PHASE_FLOW)
-		{
-			isFlow = true;
-			break;
-		}
-	}
-	for (int i = 0; i < no_processes; ++i)
+    bool isFlow = false;
+    CRFProcess *a_pcs = NULL;
+    // CRFProcess *f_pcs = NULL;
+    for(int k=0; k<no_processes; k++ )
+    {
+	   a_pcs = pcs_vector[k];
+       if(!a_pcs)
+         continue;
+       if(   a_pcs->getProcessType () == FiniteElement::RICHARDS_FLOW
+	        || a_pcs->getProcessType () == FiniteElement::LIQUID_FLOW
+	        || a_pcs->getProcessType () == FiniteElement::GROUNDWATER_FLOW
+	        || a_pcs->getProcessType () == FiniteElement::TWO_PHASE_FLOW
+	        || a_pcs->getProcessType () == FiniteElement::MULTI_PHASE_FLOW
+	     )
+       {
+         isFlow = true;
+         break;
+       }
+    }
+
+	for(int i = 0; i < no_processes; ++i)
 	{
 		m_pcs = pcs_vector[i];
 
@@ -156,28 +158,39 @@ double CFluidMomentum::Execute(int loop_process_number)
 		else if (m_pcs->getProcessType() == FiniteElement::GROUNDWATER_FLOW)
 			m_msh = FEMGet("GROUNDWATER_FLOW");
 
+
 		//		if(m_pcs->pcs_type_name.find("FLUID_MOMENTUM")!=string::npos) TF
-		if (m_pcs->getProcessType() == FiniteElement::FLUID_MOMENTUM)
+		if(m_pcs->getProcessType () == FiniteElement::FLUID_MOMENTUM)
 		{
-			if (isFlow)
+			if( isFlow )
+			{
+				fem = new CFiniteElementStd(m_pcs, m_msh->GetCoordinateFlag());
+				CFiniteElementStd* pcs_fem = a_pcs->getLinearFEMAssembler();
+
+				fem->setShapeFunctionPool(pcs_fem->getShapeFunctionPool(0),
+										  pcs_fem->getShapeFunctionPool(1));
+
 				SolveDarcyVelocityOnNode();
+				delete fem;
+				fem = NULL;
+			}
 			else
 			{
 				m_msh = FEMGet("FLUID_MOMENTUM");
-				string vel_file = FileName + ".vel";
+				string vel_file = FileName+".vel";
 				ifstream ins(vel_file.c_str());
 				double vx, vy, vz;
 
-				int nidx = m_pcs->GetNodeValueIndex("VELOCITY1_X") + 1;
-				int nidy = m_pcs->GetNodeValueIndex("VELOCITY1_Y") + 1;
-				int nidz = m_pcs->GetNodeValueIndex("VELOCITY1_Z") + 1;
+				int  nidx = m_pcs->GetNodeValueIndex("VELOCITY1_X")+1;
+				int  nidy = m_pcs->GetNodeValueIndex("VELOCITY1_Y")+1;
+				int  nidz = m_pcs->GetNodeValueIndex("VELOCITY1_Z")+1;
 
 				for (size_t i = 0; i < m_pcs->m_msh->nod_vector.size(); i++)
 				{
-					ins >> vx >> vy >> vz >> ws;
-					m_pcs->SetNodeValue(i, nidx, vx);
-					m_pcs->SetNodeValue(i, nidy, vy);
-					m_pcs->SetNodeValue(i, nidz, vz);
+					ins>>vx>>vy>>vz>>ws;
+					m_pcs->SetNodeValue(i,nidx,vx);
+					m_pcs->SetNodeValue(i,nidy,vy);
+					m_pcs->SetNodeValue(i,nidz,vz);
 				}
 			}
 		}
@@ -210,7 +223,6 @@ void CFluidMomentum::SolveDarcyVelocityOnNode()
 	MeshLib::CElem* elem = NULL;
 
 	CheckMarkedElement();
-	fem = new CFiniteElementStd(m_pcs, m_msh->GetCoordinateFlag());
 
 	// Checking the coordinateflag for proper solution.
 	int coordinateflag = m_msh->GetCoordinateFlag();
@@ -404,8 +416,6 @@ void CFluidMomentum::SolveDarcyVelocityOnNode()
 		}
 	}
 
-	// Release memroy
-	delete fem;
 #endif
 }
 

--- a/FEM/rf_fluid_momentum.cpp
+++ b/FEM/rf_fluid_momentum.cpp
@@ -167,6 +167,7 @@ double CFluidMomentum::Execute(int loop_process_number)
 
 				fem->setShapeFunctionPool(pcs_fem->getShapeFunctionPool(0),
 										  pcs_fem->getShapeFunctionPool(1));
+				fem->SetGaussPointNumber(pcs_fem->GetNumGaussSamples());
 
 				SolveDarcyVelocityOnNode();
 				delete fem;

--- a/FEM/rf_mmp_new.cpp
+++ b/FEM/rf_mmp_new.cpp
@@ -124,14 +124,14 @@ CMediumProperties::CMediumProperties() : geo_dimension(0), _mesh(NULL), _geo_typ
 	vol_bio_model = 0;
 	foc = 0.0;
 	alpha_t_model = -1;
-	graindiameter = 0; //CB Chiogna et al alpha-t model
+	graindiameter = 0; // CB Chiogna et al alpha-t model
 	hydraulicrad = 0;
 	betaexpo = 0;
-	ElementVolumeMultiplyer = 1.0; //SB / JOD 2014-11-10
+	ElementVolumeMultiplyer = 1.0; // SB / JOD 2014-11-10
 
-	permeability_pressure_model = -1; //01.09.2011. WW
-	permeability_strain_model = -1; //01.09.2011. WW
-	forchheimer_cf = 0.0; //NW
+	permeability_pressure_model = -1; // 01.09.2011. WW
+	permeability_strain_model = -1; // 01.09.2011. WW
+	forchheimer_cf = 0.0; // NW
 	forchheimer_De = .0;
 	forchheimer_a1 = .0;
 	forchheimer_a2 = .0;
@@ -770,7 +770,7 @@ std::ios::pos_type CMediumProperties::Read(std::ifstream* mmp_file)
 					pcs_name_vector.push_back("PRESSURE1");
 					break;
 				case 6: // Storativity is a function of normal effective stress defined by curve and distance from
-					// borehole, set up for KTB.
+				        // borehole, set up for KTB.
 					in >> storage_model_values[0]; // curve number
 					in >> storage_model_values[1]; // time collation
 					in >> storage_model_values[2]; // Default storage value for material groups > 0
@@ -974,7 +974,7 @@ std::ios::pos_type CMediumProperties::Read(std::ifstream* mmp_file)
 					in >> permeability_strain_model_value[1]; // d_fac/d_volStrain when vol. strain <= threshold
 					in >> permeability_strain_model_value[2]; // d_fac/d_volStrain when vol. strain > threshold
 					in >> permeability_strain_model_value[3]; // curve numer for dependenc between threshold and plas
-					// strain
+					                                          // strain
 					// if -1, threshold is constant
 					in >> permeability_strain_model_value[4]; // lower limit
 					in >> permeability_strain_model_value[5]; // uper limit
@@ -1029,7 +1029,7 @@ std::ios::pos_type CMediumProperties::Read(std::ifstream* mmp_file)
 					pcs_name_vector.push_back("PRESSURE1");
 					break;
 				case 6: // Normal effective stress calculated according to fracture orientation, related over a curve :
-					// KTB site
+				        // KTB site
 					in >> permeability_pressure_model_values[0];
 					in >> permeability_pressure_model_values[1];
 					in >> permeability_pressure_model_values[2];
@@ -1037,7 +1037,7 @@ std::ios::pos_type CMediumProperties::Read(std::ifstream* mmp_file)
 					pcs_name_vector.push_back("PRESSURE1");
 					break;
 				case 7: // Normal effective stress calculated according to fracture orientation, related over a curve :
-					// KTB site, and distance to the borehole.
+				        // KTB site, and distance to the borehole.
 					in >> permeability_pressure_model_values[0];
 					in >> permeability_pressure_model_values[1];
 					in >> permeability_pressure_model_values[2];
@@ -1140,7 +1140,7 @@ std::ios::pos_type CMediumProperties::Read(std::ifstream* mmp_file)
 						in >> residual_saturation[k]; // slr: residual saturation, this phase
 						in >> maximum_saturation[k]; // slm: maximum saturation, this phase
 						in >> saturation_exponent[k]; // exponent (always <= 1.0) --> (typical is 0.5) i.e. n = 1 / (1 -
-						// exponent) == 2.0
+						                              // exponent) == 2.0
 						in >> minimum_relative_permeability; // minimum relative permeability this phase
 						break;
 					//
@@ -1150,7 +1150,7 @@ std::ios::pos_type CMediumProperties::Read(std::ifstream* mmp_file)
 						in >> residual_saturation[k]; // sgr: residual saturation, this phase
 						in >> maximum_saturation[k]; // sgm: maximum saturation, this phase
 						in >> saturation_exponent[k]; // exponent (always <= 1.0) --> (typical is 0.5) i.e. n = 1 / (1 -
-						// exponent) == 2.0
+						                              // exponent) == 2.0
 						in >> minimum_relative_permeability; // minimum relative permeability this phase
 						break;
 					//
@@ -1554,7 +1554,7 @@ std::ios::pos_type CMediumProperties::Read(std::ifstream* mmp_file)
 					in >> capillary_pressure_values[1]; // Slr
 					in >> capillary_pressure_values[2]; // Slmax
 					in >> capillary_pressure_values[3]; // exponent (always <= 1.0) --> (typical is 0.5) i.e. n = 1 / (1
-					// - exponent) == 2.0
+					                                    // - exponent) == 2.0
 					in >> capillary_pressure_values[4]; // maximum Pc
 					in >> i; // alpha_switch (default = 0)
 					if (i > 0)
@@ -2575,8 +2575,8 @@ double CMediumProperties::HeatCapacity(long number, double theta, CFiniteElement
 				heat_capacity_fluids = 0.0;
 				porosity = 0.0;
 			}
-			heat_capacity
-			    = porosity * heat_capacity_fluids + (1.0 - porosity) * specific_heat_capacity_solid * density_solid;
+			heat_capacity = porosity * heat_capacity_fluids
+			                + (1.0 - porosity) * specific_heat_capacity_solid * density_solid;
 			break;
 		case 2: // boiling model for YD
 			// YD/OK: n c rho = n S^g c^g rho^g + n S^l c^l rho^l + (1-n) c^s rho^s
@@ -2847,8 +2847,8 @@ double* CMediumProperties::HeatDispersionTensorNew(int ip)
 		switch (Dim)
 		{
 			case 1: // line elements
-				heat_dispersion_tensor[0]
-				    = heat_conductivity_porous_medium[0] + alpha_l * heat_capacity_fluids * fluid_density * vg;
+				heat_dispersion_tensor[0] = heat_conductivity_porous_medium[0]
+				                            + alpha_l * heat_capacity_fluids * fluid_density * vg;
 				break;
 			case 2:
 				D[0] = (alpha_t * vg) + (alpha_l - alpha_t) * (velocity[0] * velocity[0]) / vg;
@@ -2856,8 +2856,8 @@ double* CMediumProperties::HeatDispersionTensorNew(int ip)
 				D[2] = ((alpha_l - alpha_t) * (velocity[1] * velocity[0])) / vg;
 				D[3] = (alpha_t * vg) + (alpha_l - alpha_t) * (velocity[1] * velocity[1]) / vg;
 				for (i = 0; i < 4; i++)
-					heat_dispersion_tensor[i]
-					    = heat_conductivity_porous_medium[i] + (D[i] * heat_capacity_fluids * fluid_density);
+					heat_dispersion_tensor[i] = heat_conductivity_porous_medium[i]
+					                            + (D[i] * heat_capacity_fluids * fluid_density);
 				break;
 			case 3:
 				D[0] = (alpha_t * vg) + (alpha_l - alpha_t) * (velocity[0] * velocity[0]) / vg;
@@ -2870,8 +2870,8 @@ double* CMediumProperties::HeatDispersionTensorNew(int ip)
 				D[7] = ((alpha_l - alpha_t) * (velocity[2] * velocity[1])) / vg;
 				D[8] = (alpha_t * vg) + (alpha_l - alpha_t) * (velocity[2] * velocity[2]) / vg;
 				for (i = 0; i < 9; i++)
-					heat_dispersion_tensor[i]
-					    = heat_conductivity_porous_medium[i] + (D[i] * heat_capacity_fluids * fluid_density);
+					heat_dispersion_tensor[i] = heat_conductivity_porous_medium[i]
+					                            + (D[i] * heat_capacity_fluids * fluid_density);
 				break;
 		}
 	}
@@ -2920,8 +2920,8 @@ double* CMediumProperties::MassDispersionTensorNew(int ip, int tr_phase) // SB +
 	Daq = m_cp->CalcDiffusionCoefficientCP(index, theta, m_pcs);
 	molecular_diffusion_value = Daq * TortuosityFunction(index, g, theta);
 
-	molecular_diffusion_value
-	    = m_cp->CalcDiffusionCoefficientCP(index, theta, m_pcs) * TortuosityFunction(index, g, theta);
+	molecular_diffusion_value = m_cp->CalcDiffusionCoefficientCP(index, theta, m_pcs)
+	                            * TortuosityFunction(index, g, theta);
 
 	molecular_diffusion_value *= Porosity(index, theta);
 	// CB, SB
@@ -2942,7 +2942,7 @@ double* CMediumProperties::MassDispersionTensorNew(int ip, int tr_phase) // SB +
 		{
 			//--------------------------------------------------------------------
 			case 1: // line elements
-			    ; // Do nothing
+				; // Do nothing
 				break;
 			//--------------------------------------------------------------------
 			case 2:
@@ -3772,22 +3772,21 @@ double CMediumProperties::Porosity(long number, double theta)
 		nidx1 = nidx0 + 1;
 		if (mode == 0) // Gauss point values
 		{
-			//assem->ComputeShapefct(1);
-			primary_variable[i] = (1. - theta) * assem->interpolate(nidx0,
-			                                                        pcs_temp) +
-			                      theta* assem->interpolate(nidx1, pcs_temp);
-		}                         // Node values
+			// assem->ComputeShapefct(1);
+			primary_variable[i] = (1. - theta) * assem->interpolate(nidx0, pcs_temp)
+			                      + theta * assem->interpolate(nidx1, pcs_temp);
+		} // Node values
 		else if (mode == 1)
-			primary_variable[i]
-			    = (1. - theta) * pcs_temp->GetNodeValue(number, nidx0) + theta * pcs_temp->GetNodeValue(number, nidx1);
+			primary_variable[i] = (1. - theta) * pcs_temp->GetNodeValue(number, nidx0)
+			                      + theta * pcs_temp->GetNodeValue(number, nidx1);
 		// Element average value
 		else if (mode == 2)
 			primary_variable[i] = (1. - theta) * assem->elemnt_average(nidx0, pcs_temp)
 			                      + theta * assem->elemnt_average(nidx1, pcs_temp);
 		else if (mode == 1) // Node values
 
-			primary_variable[i]
-			    = (1. - theta) * pcs_temp->GetNodeValue(number, nidx0) + theta * pcs_temp->GetNodeValue(number, nidx1);
+			primary_variable[i] = (1. - theta) * pcs_temp->GetNodeValue(number, nidx0)
+			                      + theta * pcs_temp->GetNodeValue(number, nidx1);
 		else if (mode == 2) // Element average value
 
 			primary_variable[i] = (1. - theta) * assem->elemnt_average(nidx0, pcs_temp)
@@ -3972,15 +3971,14 @@ double CMediumProperties::Porosity(CElement* assem)
 		nidx1 = nidx0 + 1;
 		if (mode == 0) // Gauss point values
 		{
-
-			//assem->ComputeShapefct(1);
-			primary_variable[i] = (1. - theta) * assem->interpolate(nidx0,pcs_temp)
-			                      + theta* assem->interpolate(nidx1,pcs_temp);
+			// assem->ComputeShapefct(1);
+			primary_variable[i] = (1. - theta) * assem->interpolate(nidx0, pcs_temp)
+			                      + theta * assem->interpolate(nidx1, pcs_temp);
 		}
 		else if (mode == 1) // Node values
 
-			primary_variable[i]
-			    = (1. - theta) * pcs_temp->GetNodeValue(number, nidx0) + theta * pcs_temp->GetNodeValue(number, nidx1);
+			primary_variable[i] = (1. - theta) * pcs_temp->GetNodeValue(number, nidx0)
+			                      + theta * pcs_temp->GetNodeValue(number, nidx1);
 		else if (mode == 2) // Element average value
 
 			primary_variable[i] = (1. - theta) * assem->elemnt_average(nidx0, pcs_temp)
@@ -4004,8 +4002,8 @@ double CMediumProperties::Porosity(CElement* assem)
 			    = PorosityVolumetricFreeSwellingConstantIonicstrength(number, primary_variable[0], primary_variable[1]);
 			break;
 		case 4: // n = f(S), Constrained chemical swelling
-			porosity = PorosityEffectiveConstrainedSwellingConstantIonicStrength(number, primary_variable[0],
-			                                                                     primary_variable[1], &porosity_sw);
+			porosity = PorosityEffectiveConstrainedSwellingConstantIonicStrength(
+			    number, primary_variable[0], primary_variable[1], &porosity_sw);
 			break;
 		case 5: // n = f(S), Free chemical swelling, I const
 			porosity = PorosityVolumetricFreeSwelling(number, primary_variable[0], primary_variable[1]);
@@ -4045,7 +4043,7 @@ double CMediumProperties::Porosity(CElement* assem)
 				pcs_temp = pcs_vector[i];
 				//			if ((pcs_temp->pcs_type_name.compare("GROUNDWATER_FLOW") == 0) ||
 				//(pcs_temp->pcs_type_name.compare("RICHARDS_FLOW") ==
-				// 0)||(pcs_temp->pcs_type_name.compare("MULTI_PHASE_FLOW") == 0))
+				//0)||(pcs_temp->pcs_type_name.compare("MULTI_PHASE_FLOW") == 0))
 				if ((pcs_temp->getProcessType() == FiniteElement::GROUNDWATER_FLOW)
 				    || (pcs_temp->getProcessType() == FiniteElement::RICHARDS_FLOW)
 				    // TF
@@ -4444,8 +4442,7 @@ double* CMediumProperties::PermeabilityTensor(long index)
 				// then relative permeability change
 				k_rel = (pow((n_rel - permeability_porosity_model_values[0])
 				                 / (1 - permeability_porosity_model_values[0]),
-				             permeability_porosity_model_values[2])
-				         + permeability_porosity_model_values[3])
+				             permeability_porosity_model_values[2]) + permeability_porosity_model_values[3])
 				        / (1 + permeability_porosity_model_values[3]);
 				// finially permeability
 				k_new = k_rel * permeability_porosity_model_values[1];
@@ -5082,7 +5079,7 @@ double CMediumProperties::PressureSaturationDependency(const double wetting_satu
 		case 10: //  unconfined 3D GW  6/2012 JOD
 			return 0; // set phi/(rho * g) in storage
 		case 99: // The old iterative method. Should anyone need it (but it is somewhat inaccurate at low and high
-			// saturations)
+		         // saturations)
 			ds = 1.0e-2;
 			do
 			{
@@ -5542,8 +5539,8 @@ void CMediumProperties::SetDistributedELEProperties(string file_name)
 				m_ele_geo->mat_vector(j) = garage[j];
 			garage.clear();
 			// Set the VOL_MAT value from (1-POROSITY-VOL_BIO)
-			m_ele_geo->mat_vector(mat_vec_size)
-			    = 1 - m_ele_geo->mat_vector(por_index) - m_ele_geo->mat_vector(vol_bio_index);
+			m_ele_geo->mat_vector(mat_vec_size) = 1 - m_ele_geo->mat_vector(por_index)
+			                                      - m_ele_geo->mat_vector(vol_bio_index);
 		}
 	}
 	//----------------------------------------------------------------------
@@ -5742,14 +5739,10 @@ void CMediumProperties::WriteTecplotDistributedProperties()
 **************************************************************************/
 long GetNearestHetVal2(long EleIndex,
                        CFEMesh* m_msh,
-                       vector<double>
-                           xvals,
-                       vector<double>
-                           yvals,
-                       vector<double>
-                           zvals,
-                       vector<double>
-                           mmpvals)
+                       vector<double> xvals,
+                       vector<double> yvals,
+                       vector<double> zvals,
+                       vector<double> mmpvals)
 {
 	(void)mmpvals;
 	long i, nextele, no_values;
@@ -5799,14 +5792,10 @@ long GetNearestHetVal2(long EleIndex,
 **************************************************************************/
 double GetAverageHetVal2(long EleIndex,
                          CFEMesh* m_msh,
-                         vector<double>
-                             xvals,
-                         vector<double>
-                             yvals,
-                         vector<double>
-                             zvals,
-                         vector<double>
-                             mmpvals)
+                         vector<double> xvals,
+                         vector<double> yvals,
+                         vector<double> zvals,
+                         vector<double> mmpvals)
 {
 	long i, j, ihet;
 	double average;
@@ -6005,12 +5994,10 @@ void CMediumProperties::CalStressPermeabilityFactor3(double* kfac)
 			                   + c_coefficient[12 + i * 4] * xyz[2]
 			                   - max(pG, 0.0));
 	// am at 100
-	double am0_h
-	    = a01 - (c_coefficient[7] / (-Kn + c_coefficient[7] / c_coefficient[3]) + c_coefficient[4] + c_coefficient[5]
-	             + c_coefficient[6]);
-	double am0_H
-	    = a01 - (c_coefficient[8] / (-Kn + c_coefficient[8] / c_coefficient[3]) + c_coefficient[4] + c_coefficient[5]
-	             + c_coefficient[6]);
+	double am0_h = a01 - (c_coefficient[7] / (-Kn + c_coefficient[7] / c_coefficient[3]) + c_coefficient[4]
+	                      + c_coefficient[5] + c_coefficient[6]);
+	double am0_H = a01 - (c_coefficient[8] / (-Kn + c_coefficient[8] / c_coefficient[3]) + c_coefficient[4]
+	                      + c_coefficient[5] + c_coefficient[6]);
 	double ah0_h = am0_h * am0_h;
 	double ah0_H = am0_H * am0_H;
 	if (ah0_h > am0_h)
@@ -7727,9 +7714,9 @@ double CMediumProperties::PermeabilityPressureFunction(long index, double* gp, d
 			for (i = 0; i < nn; i++)
 				z[i] = GetNodeZ(element_nodes[i]);
 			/* Spannung = sigma(z0) + d_sigma/d_z*z */
-			sigma
-			    = permeability_pressure_model_values[2]
-			      + permeability_pressure_model_values[3] * InterpolValueVector(ElGetElementType(index), z, 0., 0., 0.);
+			sigma = permeability_pressure_model_values[2]
+			        + permeability_pressure_model_values[3]
+			              * InterpolValueVector(ElGetElementType(index), z, 0., 0., 0.);
 			/* Auf effektive Spannung umrechnen */
 			sigma -= p;
 			k_rel = exp(permeability_pressure_model_values[0] - permeability_pressure_model_values[1] * log(sigma));
@@ -7775,9 +7762,9 @@ double CMediumProperties::PermeabilityPressureFunction(long index, double* gp, d
 			for (i = 0; i < nn; i++)
 				z[i] = GetNodeZ(element_nodes[i]);
 			/* Spannung = sigma(z0) + d_sigma/d_z*z */
-			sigma
-			    = permeability_pressure_model_values[1]
-			      + permeability_pressure_model_values[2] * InterpolValueVector(ElGetElementType(index), z, 0., 0., 0.);
+			sigma = permeability_pressure_model_values[1]
+			        + permeability_pressure_model_values[2]
+			              * InterpolValueVector(ElGetElementType(index), z, 0., 0., 0.);
 			/* Auf effektive Spannung umrechnen */
 			sigma -= p;
 			k_rel = GetCurveValue((int)permeability_pressure_model_values[0], 0, sigma, &i);

--- a/FEM/rf_mmp_new.cpp
+++ b/FEM/rf_mmp_new.cpp
@@ -124,14 +124,14 @@ CMediumProperties::CMediumProperties() : geo_dimension(0), _mesh(NULL), _geo_typ
 	vol_bio_model = 0;
 	foc = 0.0;
 	alpha_t_model = -1;
-	graindiameter = 0; // CB Chiogna et al alpha-t model
+	graindiameter = 0; //CB Chiogna et al alpha-t model
 	hydraulicrad = 0;
 	betaexpo = 0;
-	ElementVolumeMultiplyer = 1.0; // SB / JOD 2014-11-10
+	ElementVolumeMultiplyer = 1.0; //SB / JOD 2014-11-10
 
-	permeability_pressure_model = -1; // 01.09.2011. WW
-	permeability_strain_model = -1; // 01.09.2011. WW
-	forchheimer_cf = 0.0; // NW
+	permeability_pressure_model = -1; //01.09.2011. WW
+	permeability_strain_model = -1; //01.09.2011. WW
+	forchheimer_cf = 0.0; //NW
 	forchheimer_De = .0;
 	forchheimer_a1 = .0;
 	forchheimer_a2 = .0;
@@ -3772,10 +3772,11 @@ double CMediumProperties::Porosity(long number, double theta)
 		nidx1 = nidx0 + 1;
 		if (mode == 0) // Gauss point values
 		{
-			assem->ComputeShapefct(1);
-			primary_variable[i]
-			    = (1. - theta) * assem->interpolate(nidx0, pcs_temp) + theta * assem->interpolate(nidx1, pcs_temp);
-		} // Node values
+			//assem->ComputeShapefct(1);
+			primary_variable[i] = (1. - theta) * assem->interpolate(nidx0,
+			                                                        pcs_temp) +
+			                      theta* assem->interpolate(nidx1, pcs_temp);
+		}                         // Node values
 		else if (mode == 1)
 			primary_variable[i]
 			    = (1. - theta) * pcs_temp->GetNodeValue(number, nidx0) + theta * pcs_temp->GetNodeValue(number, nidx1);
@@ -3971,9 +3972,10 @@ double CMediumProperties::Porosity(CElement* assem)
 		nidx1 = nidx0 + 1;
 		if (mode == 0) // Gauss point values
 		{
-			assem->ComputeShapefct(1);
-			primary_variable[i]
-			    = (1. - theta) * assem->interpolate(nidx0, pcs_temp) + theta * assem->interpolate(nidx1, pcs_temp);
+
+			//assem->ComputeShapefct(1);
+			primary_variable[i] = (1. - theta) * assem->interpolate(nidx0,pcs_temp)
+			                      + theta* assem->interpolate(nidx1,pcs_temp);
 		}
 		else if (mode == 1) // Node values
 

--- a/FEM/rf_num_new.cpp
+++ b/FEM/rf_num_new.cpp
@@ -197,8 +197,8 @@ bool NUMRead(string file_base_name)
 	num_file.seekg(0L, ios::beg);
 	//========================================================================
 	// Keyword loop
-	cout << "NUMRead"
-	     << "\n";
+	cout << "NUMRead" << "\n";
+	int max_num_integration_pnts = 0;
 	while (!num_file.eof())
 	{
 		num_file.getline(line, MAX_ZEILE);
@@ -216,11 +216,22 @@ bool NUMRead(string file_base_name)
 		{
 			m_num = new CNumerics("default");
 			position = m_num->Read(&num_file);
+
+			max_num_integration_pnts = std::max(max_num_integration_pnts,
+				                            m_num->ele_gauss_points);
+
 			num_vector.push_back(m_num);
-			num_file.seekg(position, ios::beg);
-			m_num->NumConfigure(overall_coupling_exists); // JT2012
-		} // keyword found
-	} // eof
+			num_file.seekg(position,ios::beg);
+			m_num->NumConfigure(overall_coupling_exists);					  // JT2012
+		}                         // keyword found
+	}                                     // eof
+
+	// Unify the number of integration points.
+	for (std::size_t i=0; i<num_vector.size(); i++)
+	{
+		num_vector[i]->ele_gauss_points = max_num_integration_pnts;
+	}
+
 	return true;
 }
 

--- a/FEM/rf_num_new.cpp
+++ b/FEM/rf_num_new.cpp
@@ -203,12 +203,12 @@ bool NUMRead(string file_base_name)
 	{
 		num_file.getline(line, MAX_ZEILE);
 		line_string = line;
-		if(line_string.find("#STOP") != string::npos)
+		if (line_string.find("#STOP") != string::npos)
 		{
 			// Unify the number of integration points.
 			if (max_num_integration_pnts > 3)
 				max_num_integration_pnts = 3;
-			for (std::size_t i=0; i<num_vector.size(); i++)
+			for (std::size_t i = 0; i < num_vector.size(); i++)
 			{
 				num_vector[i]->ele_gauss_points = max_num_integration_pnts;
 			}
@@ -227,14 +227,13 @@ bool NUMRead(string file_base_name)
 			m_num = new CNumerics("default");
 			position = m_num->Read(&num_file);
 
-			max_num_integration_pnts = std::max(max_num_integration_pnts,
-				                            m_num->ele_gauss_points);
+			max_num_integration_pnts = std::max(max_num_integration_pnts, m_num->ele_gauss_points);
 
 			num_vector.push_back(m_num);
-			num_file.seekg(position,ios::beg);
-			m_num->NumConfigure(overall_coupling_exists);					  // JT2012
-		}                         // keyword found
-	}                                     // eof
+			num_file.seekg(position, ios::beg);
+			m_num->NumConfigure(overall_coupling_exists); // JT2012
+		} // keyword found
+	} // eof
 
 	return true;
 }
@@ -414,13 +413,13 @@ ios::pos_type CNumerics::Read(ifstream* num_file)
 					break;
 				//
 				case FiniteElement::EVNORM: // 1 tolerance for each primary variable (for Deformation, only 1 tolerance
-					// required. Applies to x,y,z)
+				                            // required. Applies to x,y,z)
 					for (int i = 0; i < DOF_NUMBER_MAX; i++)
 						line >> nls_error_tolerance[i];
 					break;
 				//
 				case FiniteElement::LMAX: // 1 tolerance for each primary variable (for Deformation, only 1 tolerance
-					// required. Applies to x,y,z)
+				                          // required. Applies to x,y,z)
 					for (int i = 0; i < DOF_NUMBER_MAX; i++)
 						line >> nls_error_tolerance[i];
 					break;
@@ -545,13 +544,13 @@ ios::pos_type CNumerics::Read(ifstream* num_file)
 					break;
 				//
 				case FiniteElement::EVNORM: // 1 tolerance for each primary variable (for Deformation, only 1 tolerance
-					// required. Applies to x,y,z)
+				                            // required. Applies to x,y,z)
 					for (int i = 0; i < DOF_NUMBER_MAX; i++)
 						line >> cpl_error_tolerance[i];
 					break;
 				//
 				case FiniteElement::LMAX: // 1 tolerance for each primary variable (for Deformation, only 1 tolerance
-					// required. Applies to x,y,z)
+				                          // required. Applies to x,y,z)
 					for (int i = 0; i < DOF_NUMBER_MAX; i++)
 						line >> cpl_error_tolerance[i];
 					break;

--- a/FEM/rf_num_new.cpp
+++ b/FEM/rf_num_new.cpp
@@ -116,7 +116,7 @@ CNumerics::CNumerics(string name)
 		cpl_error_tolerance[i] = -1.0; // JT2012: should not default this. Should always be entered by user!
 	//
 	// ELE
-	ele_gauss_points = 3;
+	ele_gauss_points = 2;
 	ele_mass_lumping = 0;
 	ele_upwind_method = 0; // CB
 	ele_upwinding = 0;

--- a/FEM/rf_num_new.cpp
+++ b/FEM/rf_num_new.cpp
@@ -116,7 +116,7 @@ CNumerics::CNumerics(string name)
 		cpl_error_tolerance[i] = -1.0; // JT2012: should not default this. Should always be entered by user!
 	//
 	// ELE
-	ele_gauss_points = 2;
+	ele_gauss_points = 3;
 	ele_mass_lumping = 0;
 	ele_upwind_method = 0; // CB
 	ele_upwinding = 0;

--- a/FEM/rf_num_new.cpp
+++ b/FEM/rf_num_new.cpp
@@ -203,8 +203,18 @@ bool NUMRead(string file_base_name)
 	{
 		num_file.getline(line, MAX_ZEILE);
 		line_string = line;
-		if (line_string.find("#STOP") != string::npos)
+		if(line_string.find("#STOP") != string::npos)
+		{
+			// Unify the number of integration points.
+			if (max_num_integration_pnts > 3)
+				max_num_integration_pnts = 3;
+			for (std::size_t i=0; i<num_vector.size(); i++)
+			{
+				num_vector[i]->ele_gauss_points = max_num_integration_pnts;
+			}
+
 			return true;
+		}
 		//
 		if (line_string.find("$OVERALL_COUPLING") != string::npos)
 		{
@@ -225,12 +235,6 @@ bool NUMRead(string file_base_name)
 			m_num->NumConfigure(overall_coupling_exists);					  // JT2012
 		}                         // keyword found
 	}                                     // eof
-
-	// Unify the number of integration points.
-	for (std::size_t i=0; i<num_vector.size(); i++)
-	{
-		num_vector[i]->ele_gauss_points = max_num_integration_pnts;
-	}
 
 	return true;
 }

--- a/FEM/rf_num_new.h
+++ b/FEM/rf_num_new.h
@@ -68,7 +68,7 @@ public:
 	std::string cpl_variable; // MB
 	std::string cpl_process; // JT
 	std::string cpl_variable_JOD; // JT->JOD. This one defaults to FLUX. I'm not sure what you want to do with it, but
-	// cpl_variable must default to "NONE".
+	                              // cpl_variable must default to "NONE".
 	int cpl_max_iterations;
 	int cpl_min_iterations; // JT2012
 	double cpl_error_tolerance[DOF_NUMBER_MAX]; // JT2012: array function of dof

--- a/FEM/rf_num_new.h
+++ b/FEM/rf_num_new.h
@@ -31,6 +31,10 @@
 class CNumerics
 {
 public:
+	int getNumIntegrationSamplePoints () const
+	{
+		return ele_gauss_points;
+	}
 	// method
 	std::string method_name; // OK
 	// PCS

--- a/FEM/rf_pcs.cpp
+++ b/FEM/rf_pcs.cpp
@@ -5697,7 +5697,7 @@ else
 //
 //
 
-		//				MXDumpGLS("rf_pcs1.txt",1,eqs->b,eqs->x); //abort();
+		//	MXDumpGLS("rf_pcs1.txt",1,eqs->b,eqs->x); //abort();
 #if defined(USE_PETSC)  // || defined(other parallel libs)//03~04.3012.
 		MPI_Barrier (MPI_COMM_WORLD);
 		  //	eqs_new->AssembleRHS_PETSc();
@@ -8013,25 +8013,12 @@ void CRFProcess::IncorporateSourceTerms(const int rank)
 						if (elem->GetMark())
 						{
 							fem->ConfigElement(elem);
-							if(getProcessType() == FiniteElement::MULTI_COMPONENTIAL_FLOW)	fem->Cal_VelocityMCF();
+							fem->Config();
+
+							if(getProcessType() == FiniteElement::MULTI_COMPONENTIAL_FLOW)
+								fem->Cal_VelocityMCF();
 							else
-							fem->Cal_Velocity();
-					}
-					gp_ele = ele_gp_value[ele_index];
-					gp_ele->GetEleVelocity(vel);
-					EleType = elem->GetElementType();
-					if (EleType == MshElemType::LINE) // Line
-						cnodev->node_value += vel[0];
-					// Traingle & Qua
-					if (EleType == MshElemType::TRIANGLE || EleType == MshElemType::QUAD)
-					{
-						for (size_t i_face = 0; i_face < m_msh->face_vector.size(); i_face++)
-						{
-							face = m_msh->face_vector[i_face];
-							if ((size_t)m_st->element_st_vector[i_st] == face->GetOwner()->GetIndex())
-								//
-								q_face = PointProduction(vel, m_msh->face_normal[i_face]) * face->GetVolume();
-							// for(i_node)
+								fem->Cal_Velocity();
 						}
 						cnodev->node_value = +q_face / 2;
 					}

--- a/FEM/rf_pcs.cpp
+++ b/FEM/rf_pcs.cpp
@@ -1000,7 +1000,7 @@ void CRFProcess::SetBoundaryConditionAndSourceTerm()
 {
 	std::string pcs_type_name(convertProcessTypeToString(this->getProcessType()));
 
-	if (pcs_type_name_vector.size() && pcs_type_name_vector[0].find("DYNAMIC") != string::npos) // WW
+	if (!pcs_type_name_vector.empty() && pcs_type_name_vector[0].find("DYNAMIC") != string::npos) // WW
 	{
 		setBC_danymic_problems();
 		setST_danymic_problems();
@@ -10681,7 +10681,7 @@ void CRFProcess::CalcSecondaryVariablesUnsaturatedFlow(bool initial)
 			if (elem->GetMark()) // Marked for use
 			{
 				elem->SetOrder(false);
-				fem->CalcSatuation(*elem);
+				fem->CalcSaturation(*elem);
 			}
 		}
 	}

--- a/FEM/rf_pcs.cpp
+++ b/FEM/rf_pcs.cpp
@@ -10149,7 +10149,7 @@ void CRFProcess::Extropolation_GaussValue()
 			if (elem->GetMark()) // Marked for use
 			{
 				for(k = 0; k < NS; k++)
-					fem->ExtropolateGauss(this, k);
+					fem->ExtropolateGauss(*elem, this, k);
 			}
 		}
 	}
@@ -10206,7 +10206,7 @@ void CRFProcess::Extropolation_MatValue()
 			elem = m_msh->ele_vector[i];
 			if (elem->GetMark()) // Marked for use
 			{
-				fem->CalcNodeMatParatemer();
+				fem->CalcNodeMatParatemer(*elem);
 			}
 		}
 	}
@@ -10720,8 +10720,7 @@ void CRFProcess::CalcSecondaryVariablesUnsaturatedFlow(bool initial)
 				if (elem->GetMark()) // Marked for use
 				{
 					elem->SetOrder(false);
-					fem->ConfigElement(elem, false);
-					fem->CalcSatuation();
+					fem->CalcSatuation(*elem);
 				}
 			}
 		}
@@ -10772,8 +10771,8 @@ void CRFProcess::CalcSecondaryVariablesTNEQ()
 		elem = m_msh->ele_vector[i];
 		if (elem->GetMark()) // Marked for use
 		{
-			fem->UpdateSolidDensity(i);          // HS, thermal storage reactions
-			fem->ExtrapolateGauss_ReactRate_TNEQ_TES( this ); // HS added 19.02.2013
+			fem->UpdateSolidDensity(elem->GetIndex());          // HS, thermal storage reactions
+			fem->ExtrapolateGauss_ReactRate_TNEQ_TES( *elem, this ); // HS added 19.02.2013
 		}
 	}
 }
@@ -10809,8 +10808,8 @@ void CRFProcess::CalcSecondaryVariablesTES()
 		CElem* const elem = m_msh->ele_vector[i];
 		if (elem->GetMark()) // Marked for use
 		{
-			fem->UpdateSolidDensity(i);          // HS, thermal storage reactions
-			fem->ExtrapolateGauss_ReactRate_TNEQ_TES( this ); // HS added 19.02.2013
+			fem->UpdateSolidDensity(elem->GetIndex());          // HS, thermal storage reactions
+			fem->ExtrapolateGauss_ReactRate_TNEQ_TES( *elem, this ); // HS added 19.02.2013
 		}
 	}
 }

--- a/FEM/rf_pcs.cpp
+++ b/FEM/rf_pcs.cpp
@@ -1001,9 +1001,6 @@ void initializeConstrainedProcesses(std::vector<CRFProcess*>& pcs_vector)
 
 void CRFProcess::SetBoundaryConditionAndSourceTerm()
 {
-#ifndef WIN32
-	BaseLib::MemWatch mem_watch;
-#endif
 	std::string pcs_type_name(
 	        convertProcessTypeToString(this->getProcessType()));
 
@@ -1049,9 +1046,6 @@ void CRFProcess::SetBoundaryConditionAndSourceTerm()
 			if(WriteProcessed_BC == 1)
 				Write_Processed_BC();
 		}
-#ifndef WIN32
-		ScreenMessaged("\tcurrent mem: %d MB\n", mem_watch.getVirtMemUsage() / (1024*1024) );
-#endif
 		// ST - create ST groups for each process
 		ScreenMessage("-> Create ST\n");
 		CSourceTermGroup* m_st_group = NULL;

--- a/FEM/rf_pcs.cpp
+++ b/FEM/rf_pcs.cpp
@@ -904,9 +904,8 @@ void CRFProcess::Create()
 		{
 			int Axisymm = 1; // ani-axisymmetry
 			if (m_msh->isAxisymmetry())
-				Axisymm = -1;  // Axisymmetry is true
-			fem = new CFiniteElementStd(this, Axisymm
-			                            * m_msh->GetCoordinateFlag());
+				Axisymm = -1; // Axisymmetry is true
+			fem = new CFiniteElementStd(this, Axisymm * m_msh->GetCoordinateFlag());
 			fem->SetGaussPointNumber(m_num->ele_gauss_points);
 		}
 	}
@@ -999,11 +998,9 @@ void initializeConstrainedProcesses(std::vector<CRFProcess*>& pcs_vector)
 
 void CRFProcess::SetBoundaryConditionAndSourceTerm()
 {
-	std::string pcs_type_name(
-	        convertProcessTypeToString(this->getProcessType()));
+	std::string pcs_type_name(convertProcessTypeToString(this->getProcessType()));
 
-	if (pcs_type_name_vector.size() && pcs_type_name_vector[0].find("DYNAMIC")
-	    != string::npos)                  //WW
+	if (pcs_type_name_vector.size() && pcs_type_name_vector[0].find("DYNAMIC") != string::npos) // WW
 	{
 		setBC_danymic_problems();
 		setST_danymic_problems();
@@ -1015,33 +1012,31 @@ void CRFProcess::SetBoundaryConditionAndSourceTerm()
 		ScreenMessage("-> Create BC\n");
 		CBoundaryConditionsGroup* m_bc_group = NULL;
 
-		//25.08.2011. WW
-		if(WriteProcessed_BC == 2)
+		// 25.08.2011. WW
+		if (WriteProcessed_BC == 2)
 			Read_Processed_BC();
 		else
 		{
 			for (int i = 0; i < DOF; i++)
 			{
-				//OKm_bc_group = BCGetGroup(_pcs_type_name,pcs_primary_function_name[i]);
-				//OKif(!m_bc_group){
+				// OKm_bc_group = BCGetGroup(_pcs_type_name,pcs_primary_function_name[i]);
+				// OKif(!m_bc_group){
 				BCGroupDelete(pcs_type_name, pcs_primary_function_name[i]);
 				m_bc_group = new CBoundaryConditionsGroup();
-				//OK
+				// OK
 				m_bc_group->setProcessTypeName(pcs_type_name);
-				m_bc_group->setProcessPrimaryVariableName(
-				        pcs_primary_function_name[i]); //OK
+				m_bc_group->setProcessPrimaryVariableName(pcs_primary_function_name[i]); // OK
 				m_bc_group->Set(this, Shift[i]);
 
-				bc_group_list.push_back(m_bc_group); //Useless, to be removed. WW
+				bc_group_list.push_back(m_bc_group); // Useless, to be removed. WW
 				m_bc_group = NULL;
-				//OK}
+				// OK}
 			}
 #ifndef USE_PETSC
-			if (bc_node_value.size() < 1) //WW
-				cout << "Warning: no boundary conditions specified for "
-				     << pcs_type_name << endl;
+			if (bc_node_value.size() < 1) // WW
+				cout << "Warning: no boundary conditions specified for " << pcs_type_name << endl;
 #endif
-			if(WriteProcessed_BC == 1)
+			if (WriteProcessed_BC == 1)
 				Write_Processed_BC();
 		}
 		// ST - create ST groups for each process
@@ -1050,23 +1045,22 @@ void CRFProcess::SetBoundaryConditionAndSourceTerm()
 
 		if (WriteSourceNBC_RHS == 2) // Read from file
 			ReadRHS_of_ST_NeumannBC();
-		else                      // WW // Calculate directly
+		else // WW // Calculate directly
 		{
 			for (int i = 0; i < DOF; i++)
 			{
-				//OK m_st_group = m_st_group->Get(pcs_primary_function_name[i]);
-				m_st_group = STGetGroup(pcs_type_name,
-				                        pcs_primary_function_name[i]);
+				// OK m_st_group = m_st_group->Get(pcs_primary_function_name[i]);
+				m_st_group = STGetGroup(pcs_type_name, pcs_primary_function_name[i]);
 
 				if (!m_st_group)
 				{
 					m_st_group = new CSourceTermGroup();
-					//OK
+					// OK
 					m_st_group->pcs_type_name = pcs_type_name;
-					//OK
+					// OK
 					m_st_group->pcs_pv_name = pcs_primary_function_name[i];
 					m_st_group->Set(this, Shift[i]);
-					//Useless, to be removed. WW
+					// Useless, to be removed. WW
 					st_group_list.push_back(m_st_group);
 				}
 			}
@@ -1249,8 +1243,8 @@ void CRFProcess::WriteSolution()
 	                          + number2str(rank) + ".asc";
 
 #else
-	std::string m_file_name
-	    = FileName + "_" + pcs_type_name + "_" + pcs_primary_function_name[0] + "_primary_value.asc";
+	std::string m_file_name = FileName + "_" + pcs_type_name + "_" + pcs_primary_function_name[0]
+	                          + "_primary_value.asc";
 #endif
 	std::ofstream os(m_file_name.c_str(), ios::trunc | ios::out);
 	if (!os.good())
@@ -1297,8 +1291,8 @@ void CRFProcess::ReadSolution()
 	                          + number2str(rank) + ".asc";
 
 #else
-	std::string m_file_name
-	    = FileName + "_" + pcs_type_name + "_" + pcs_primary_function_name[0] + "_primary_value.asc";
+	std::string m_file_name = FileName + "_" + pcs_type_name + "_" + pcs_primary_function_name[0]
+	                          + "_primary_value.asc";
 #endif
 	std::ifstream is(m_file_name.c_str(), ios::in);
 	if (!is.good())
@@ -5582,7 +5576,7 @@ void CRFProcess::GlobalAssembly()
 				// WW
 				fem->SetElementNodesDomain(m_dom->element_nodes_dom[i]);
 				fem->ConfigElement(elem, Check2D3D);
-				fem->m_dom = m_dom; //OK
+				fem->m_dom = m_dom; // OK
 				fem->Assembly();
 			}
 		}
@@ -5624,22 +5618,16 @@ else
 			// Marked for use //WX: modified for coupled excavation
 			if (elem->GetMark() && elem->GetExcavState() == -1)
 			{
+				elem->SetOrder(false);
+				fem->ConfigElement(elem, Check2D3D);
+				fem->Assembly();
+				// NEUMANN CONTROL---------
+				if (Tim->time_control_type == TimeControlType::NEUMANN)
 				{
-					elem->SetOrder(false);
-					fem->ConfigElement(elem, Check2D3D);
-					fem->Assembly();
-					// NEUMANN CONTROL---------
-					if (Tim->time_control_type == TimeControlType::NEUMANN)
-					{
-						Tim->time_step_length_neumann = MMin(
-						        Tim->time_step_length_neumann, timebuffer);
-						Tim->time_step_length_neumann *= 0.5
-						                                 * elem->GetVolume()
-						                                 * elem->GetVolume();
-						if (Tim->time_step_length_neumann < MKleinsteZahl)
-							Tim->time_step_length_neumann = 1.0e-5;
-					}
-					//------------------------------
+					Tim->time_step_length_neumann = MMin(Tim->time_step_length_neumann, timebuffer);
+					Tim->time_step_length_neumann *= 0.5 * elem->GetVolume() * elem->GetVolume();
+					if (Tim->time_step_length_neumann < MKleinsteZahl)
+						Tim->time_step_length_neumann = 1.0e-5;
 				}
 				//------------------------------
 			}
@@ -5697,11 +5685,11 @@ else
 //
 //
 
-		//	MXDumpGLS("rf_pcs1.txt",1,eqs->b,eqs->x); //abort();
-#if defined(USE_PETSC)  // || defined(other parallel libs)//03~04.3012.
-		MPI_Barrier (MPI_COMM_WORLD);
-		  //	eqs_new->AssembleRHS_PETSc();
-		//eqs_new->AssembleMatrixPETSc(MAT_FINAL_ASSEMBLY );
+//	MXDumpGLS("rf_pcs1.txt",1,eqs->b,eqs->x); //abort();
+#if defined(USE_PETSC) // || defined(other parallel libs)//03~04.3012.
+	MPI_Barrier(MPI_COMM_WORLD);
+//	eqs_new->AssembleRHS_PETSc();
+// eqs_new->AssembleMatrixPETSc(MAT_FINAL_ASSEMBLY );
 #endif
 }
 
@@ -5734,7 +5722,7 @@ void CRFProcess::GlobalAssembly_std(const bool is_mixed_order, bool Check2D3D)
 
 		elem->SetOrder(m_msh->getOrder());
 		fem->setMixedOrderFlag(is_mixed_order);
-		fem->ConfigElement(elem,Check2D3D);
+		fem->ConfigElement(elem, Check2D3D);
 		fem->Assembly();
 	}
 }
@@ -5842,63 +5830,51 @@ void CRFProcess::CalIntegrationPointValue()
 		const size_t mesh_ele_vector_size(m_msh->ele_vector.size());
 		for (size_t i = 0; i < mesh_ele_vector_size; i++)
 		{
-			if ((getProcessType() == FiniteElement::HEAT_TRANSPORT || getProcessType() == FiniteElement::MASS_TRANSPORT) && !elem->selected)
-				continue;   // not selected for TOTAL_FLUX calculation JOD 2014-11-10
-			fem->ConfigElement(elem);
-			fem->Config(); //OK4709
-			// fem->m_dom = NULL; // To be used for parallization
-			if(getProcessType() == FiniteElement::MULTI_COMPONENTIAL_FLOW)
-				fem->Cal_VelocityMCF();
-			else
-				fem->Cal_Velocity();
-
-			//moved here from additional lower loop
-			if (getProcessType() == FiniteElement::TNEQ || getProcessType() == FiniteElement::TES)
+			elem = m_msh->ele_vector[i];
+			if (elem->GetMark()) // Marked for use
 			{
-				fem->CalcSolidDensityRate(); // HS, thermal storage reactions
+				if ((getProcessType() == FiniteElement::HEAT_TRANSPORT
+				     || getProcessType() == FiniteElement::MASS_TRANSPORT) && !elem->selected)
+					continue; // not selected for TOTAL_FLUX calculation JOD 2014-11-10
+				fem->ConfigElement(elem);
+				fem->Config(); // OK4709
+				// fem->m_dom = NULL; // To be used for parallization
+				if (getProcessType() == FiniteElement::MULTI_COMPONENTIAL_FLOW)
+					fem->Cal_VelocityMCF();
+				else
+					fem->Cal_Velocity();
+
+				// moved here from additional lower loop
+				if (getProcessType() == FiniteElement::TNEQ || getProcessType() == FiniteElement::TES)
+				{
+					fem->CalcSolidDensityRate(); // HS, thermal storage reactions
+				}
 			}
 		}
 	}
-   } else { //NW
-       const size_t mesh_ele_vector_size(m_msh->ele_vector.size());
-       const size_t v_itr_max(this->m_num->local_picard1_max_iterations);
-       double pre_v[3] = {};
-       double new_v[3] = {};
-       //std::cout << "  Start local Picard iteration: tolerance = " << this->m_num->local_picard1_tolerance << std::endl;
-       size_t i_itr = 0;
-       double vel_error = .0;
-       for (i_itr=0; i_itr<v_itr_max; ++i_itr)
-       {
-           //std::cout << "  non-linear iteration: " << i_itr << "/" << v_itr_max << std::endl;
-           vel_error = .0;
-           for (size_t i = 0; i < mesh_ele_vector_size; i++)
-           {
-               elem = m_msh->ele_vector[i];
-               if (elem->GetMark())                        // Marked for use
-               {
-                   ElementValue* gp_ele = ele_gp_value[i];
-                   gp_ele->GetEleVelocity(pre_v);
+	else
+	{ // NW
+		const size_t mesh_ele_vector_size(m_msh->ele_vector.size());
+		const size_t v_itr_max(this->m_num->local_picard1_max_iterations);
+		double pre_v[3] = {};
+		double new_v[3] = {};
+		// std::cout << "  Start local Picard iteration: tolerance = " << this->m_num->local_picard1_tolerance <<
+		// std::endl;
+		size_t i_itr = 0;
+		double vel_error = .0;
+		for (i_itr = 0; i_itr < v_itr_max; ++i_itr)
+		{
+			// std::cout << "  non-linear iteration: " << i_itr << "/" << v_itr_max << std::endl;
+			vel_error = .0;
+			for (size_t i = 0; i < mesh_ele_vector_size; i++)
+			{
+				elem = m_msh->ele_vector[i];
+				if (elem->GetMark()) // Marked for use
+				{
+					ElementValue* gp_ele = ele_gp_value[i];
+					gp_ele->GetEleVelocity(pre_v);
 
-                   fem->ConfigElement(elem);
-                   fem->Config();                           //OK4709
-                   // fem->m_dom = NULL; // To be used for parallization
-
-                   fem->Cal_Velocity();
-
-                   gp_ele->GetEleVelocity(new_v);
-                   vel_error = max(vel_error, fabs(new_v[0]-pre_v[0]));
-                   vel_error = max(vel_error, fabs(new_v[1]-pre_v[1]));
-                   vel_error = max(vel_error, fabs(new_v[2]-pre_v[2]));
-               }
-           }
-           //std::cout << "  error (max. norm): " << vel_error << std::endl;
-           bool isConverged = (vel_error < this->m_num->local_picard1_tolerance);
-           if (isConverged) break;
-       }
-       std::cout << "  Local Picard iteration: itr. count = " << i_itr << "/" << v_itr_max << ", error(max. norm)=" << vel_error << std::endl;
-   }
-
-					fem->ConfigElement(elem, m_num->ele_gauss_points);
+					fem->ConfigElement(elem);
 					fem->Config(); // OK4709
 					// fem->m_dom = NULL; // To be used for parallization
 
@@ -6681,8 +6657,7 @@ void CRFProcess::IncorporateBoundaryConditions(const int rank)
 				for (ii = 0; ii < dof; ii++) // 28.2.2007 WW
 
 					if (convertPrimaryVariableToString(m_bc->getProcessPrimaryVariable())
-					        .find(pcs_primary_function_name[ii])
-					    != string::npos)
+					        .find(pcs_primary_function_name[ii]) != string::npos)
 					{
 						idx_1 = GetNodeValueIndex(pcs_primary_function_name[ii]) + 1;
 						break;
@@ -7411,7 +7386,7 @@ bool CRFProcess::checkConstrainedBC(CBoundaryCondition const& bc, CBoundaryCondi
 					    = m_msh->nod_vector[bc_node.geo_node_number]->getConnectedNodes()[j];
 					if (connected_node_id == static_cast<std::size_t>(bc_node.geo_node_number))
 					{
-						std::valarray<double>temp_vel(this->getNodeVelocityVector(connected_node_id));
+						std::valarray<double> temp_vel(this->getNodeVelocityVector(connected_node_id));
 						temp_vel *= static_cast<double>(no_connected_nodes - 1);
 						vel += temp_vel;
 					}
@@ -7442,15 +7417,15 @@ bool CRFProcess::checkConstrainedBC(CBoundaryCondition const& bc, CBoundaryCondi
 			// select case to handle BC
 			if (scalar_prod < 0.05 && scalar_prod >= -1.01 // small tolerance of ~5°
 			    && local_constrained.constrainedDirection == ConstrainedType::NEGATIVE) // velocity vector and bc
-			// surface normal point in
-			// opposite directions
+			                                                                            // surface normal point in
+			                                                                            // opposite directions
 			{
 				return true; // do not apply BC (maybe later implementation: change BC to ST at this node)
 			}
 			else if (scalar_prod <= 1.01 && scalar_prod >= -0.05 // small tolerance of ~5°
 			         && local_constrained.constrainedDirection == ConstrainedType::POSITIVE) // velocity vector points
-			// in same direction as bc
-			// surface normal
+			                                                                                 // in same direction as bc
+			                                                                                 // surface normal
 			{
 				return true; // do not apply BC (maybe later implementation: change BC to ST at this node)
 			}
@@ -8008,17 +7983,29 @@ void CRFProcess::IncorporateSourceTerms(const int rank)
 					elem = m_msh->ele_vector[ele_index];
 					if (elem->GetMark())
 					{
-						long ele_index = m_st->element_st_vector[i_st];
-						elem = m_msh->ele_vector[ele_index];
-						if (elem->GetMark())
-						{
-							fem->ConfigElement(elem);
-							fem->Config();
+						fem->ConfigElement(elem);
+						fem->Config();
 
-							if(getProcessType() == FiniteElement::MULTI_COMPONENTIAL_FLOW)
-								fem->Cal_VelocityMCF();
-							else
-								fem->Cal_Velocity();
+						if (getProcessType() == FiniteElement::MULTI_COMPONENTIAL_FLOW)
+							fem->Cal_VelocityMCF();
+						else
+							fem->Cal_Velocity();
+					}
+					gp_ele = ele_gp_value[ele_index];
+					gp_ele->GetEleVelocity(vel);
+					EleType = elem->GetElementType();
+					if (EleType == MshElemType::LINE) // Line
+						cnodev->node_value += vel[0];
+					// Traingle & Qua
+					if (EleType == MshElemType::TRIANGLE || EleType == MshElemType::QUAD)
+					{
+						for (size_t i_face = 0; i_face < m_msh->face_vector.size(); i_face++)
+						{
+							face = m_msh->face_vector[i_face];
+							if ((size_t)m_st->element_st_vector[i_st] == face->GetOwner()->GetIndex())
+								//
+								q_face = PointProduction(vel, m_msh->face_normal[i_face]) * face->GetVolume();
+							// for(i_node)
 						}
 						cnodev->node_value = +q_face / 2;
 					}
@@ -8127,7 +8114,7 @@ void CRFProcess::IncorporateSourceTerms(const int rank)
 		for (i = begin; i < end; i++)
 		{
 			if (rank > -1) // parallel version: stgem_node_value_in_dom and stgem_local_index_in_dom contain only values
-			// for the corresponding domain  == rank
+			               // for the corresponding domain  == rank
 			{
 				//				cout << "rank " << rank ;
 				gindex = stgem_node_value_in_dom[i]; // contains indexes to water-st_vec
@@ -8544,7 +8531,7 @@ std::string PCSProblemType()
 	//	for (i = 0; i < no_processes; i++) {
 	//		m_pcs = pcs_vector[i];
 	//		switch (m_pcs->pcs_type_name[7]) { // _pcs_type_name[7] should be 'W' because 'R' is reserved for Richard
-	// Flow.
+	//Flow.
 	//		case 'W':
 	//			if (pcs_problem_type.empty())
 	//				pcs_problem_type = "RANDOM_WALK";
@@ -10130,12 +10117,8 @@ void CRFProcess::Extropolation_GaussValue()
 		elem = m_msh->ele_vector[i];
 		if (elem->GetMark()) // Marked for use
 		{
-			elem = m_msh->ele_vector[i];
-			if (elem->GetMark()) // Marked for use
-			{
-				for(k = 0; k < NS; k++)
-					fem->ExtropolateGauss(*elem, this, k);
-			}
+			for (k = 0; k < NS; k++)
+				fem->ExtropolateGauss(*elem, this, k);
 		}
 	}
 }
@@ -10188,11 +10171,7 @@ void CRFProcess::Extropolation_MatValue()
 		elem = m_msh->ele_vector[i];
 		if (elem->GetMark()) // Marked for use
 		{
-			elem = m_msh->ele_vector[i];
-			if (elem->GetMark()) // Marked for use
-			{
-				fem->CalcNodeMatParatemer(*elem);
-			}
+			fem->CalcNodeMatParatemer(*elem);
 		}
 	}
 }
@@ -10701,12 +10680,8 @@ void CRFProcess::CalcSecondaryVariablesUnsaturatedFlow(bool initial)
 			elem = m_msh->ele_vector[i];
 			if (elem->GetMark()) // Marked for use
 			{
-				elem = m_msh->ele_vector[i];
-				if (elem->GetMark()) // Marked for use
-				{
-					elem->SetOrder(false);
-					fem->CalcSatuation(*elem);
-				}
+				elem->SetOrder(false);
+				fem->CalcSatuation(*elem);
 			}
 		}
 	}
@@ -10756,8 +10731,8 @@ void CRFProcess::CalcSecondaryVariablesTNEQ()
 		elem = m_msh->ele_vector[i];
 		if (elem->GetMark()) // Marked for use
 		{
-			fem->UpdateSolidDensity(elem->GetIndex());          // HS, thermal storage reactions
-			fem->ExtrapolateGauss_ReactRate_TNEQ_TES( *elem, this ); // HS added 19.02.2013
+			fem->UpdateSolidDensity(elem->GetIndex()); // HS, thermal storage reactions
+			fem->ExtrapolateGauss_ReactRate_TNEQ_TES(*elem, this); // HS added 19.02.2013
 		}
 	}
 }
@@ -10793,8 +10768,8 @@ void CRFProcess::CalcSecondaryVariablesTES()
 		CElem* const elem = m_msh->ele_vector[i];
 		if (elem->GetMark()) // Marked for use
 		{
-			fem->UpdateSolidDensity(elem->GetIndex());          // HS, thermal storage reactions
-			fem->ExtrapolateGauss_ReactRate_TNEQ_TES( *elem, this ); // HS added 19.02.2013
+			fem->UpdateSolidDensity(elem->GetIndex()); // HS, thermal storage reactions
+			fem->ExtrapolateGauss_ReactRate_TNEQ_TES(*elem, this); // HS added 19.02.2013
 		}
 	}
 }
@@ -11719,31 +11694,14 @@ void CRFProcess::CalcELEFluxes(const GEOLIB::Polyline* const ply, double* result
 	else
 		m_pcs_flow = PCSGet(FiniteElement::GROUNDWATER_FLOW);
 
-			// Configure Element for interpolation of node velocities to GP velocities
-			fem->ConfigElement(m_ele);
-			// velocity vector
-			for (size_t j = 0; j < 3; j++) {
-				//v[j] = m_pcs_flow->GetElementValue(m_ele->GetIndex(), v_eidx[j]);
-				// Calculate Element velocity
-				v[j] = fem->Get_Element_Velocity(m_ele->GetIndex(), m_pcs_flow, 0, j);
-			}
-			//Test mit Knotengeschwindigkeiten
-			//double temp_v[3];
-			//temp_v[0] = temp_v[1] = temp_v[2] = 0.0;
-			//int variable_index[3];
-			//variable_index[0] = m_pcs_flow->GetNodeValueIndex("VELOCITY_X1");
-			//variable_index[1] = m_pcs_flow->GetNodeValueIndex("VELOCITY_Y1");
-			//variable_index[2] = m_pcs_flow->GetNodeValueIndex("VELOCITY_Z1");
-			//
-			//for (size_t j = 0; j < 3; j++)
-			//{
-			//	for (size_t k = 0; k < m_ele->GetNodesNumber(false); k++)
-			//	{
-			//		temp_v[j] += m_pcs_flow->GetNodeValue(element_nodes[k], variable_index[j]);
-			//	}
-			//	temp_v[j] /=  m_ele->GetNodesNumber(false);
-			//	v[j] = temp_v[j];
-			//}
+	// calculates element velocity based on 1 GP
+	// CalcELEVelocities();
+
+	int v_eidx[3];
+	int v_eidx_2[3];
+	v_eidx[0] = m_pcs_flow->GetElementValueIndex("VELOCITY1_X");
+	v_eidx[1] = m_pcs_flow->GetElementValueIndex("VELOCITY1_Y");
+	v_eidx[2] = m_pcs_flow->GetElementValueIndex("VELOCITY1_Z");
 
 	if (pcs_type == FiniteElement::MULTI_PHASE_FLOW)
 	{
@@ -11815,7 +11773,7 @@ void CRFProcess::CalcELEFluxes(const GEOLIB::Polyline* const ply, double* result
 		Use_Element = true;
 
 		// Configure Element for interpolation of node velocities to GP velocities
-		fem->ConfigElement(m_ele, m_num->ele_gauss_points);
+		fem->ConfigElement(m_ele);
 		// velocity vector
 		for (size_t j = 0; j < 3; j++)
 		{
@@ -12238,9 +12196,9 @@ void CRFProcess::CalcELEMassFluxes(const GEOLIB::Polyline* const ply, std::strin
 					if (norm_v != 0)
 					{
 						Disp_xx = alpha_l * pow(v[0], 2) / norm_v + alpha_t * pow(v[1], 2) / norm_v; // ToDo:
-						// z-Dimension
+						                                                                             // z-Dimension
 						Disp_yy = alpha_l * pow(v[1], 2) / norm_v + alpha_t * pow(v[0], 2) / norm_v; // ToDo:
-						// z-Dimension
+						                                                                             // z-Dimension
 						Disp_xy = (alpha_l - alpha_t) * v[0] * v[1] / norm_v; // ToDo: z-Dimension
 						// calculate dispersive mass flux
 						j_disp[0] = porosity * (Disp_xx * ConcentrationGradient[0]
@@ -12681,8 +12639,8 @@ void CRFProcess::AssembleParabolicEquationRHSVector(CNode* m_nod)
 				if (m_ele->GetMark())
 				{
 					cout << m_ele->GetIndex() << "\n";
-					//WW ldummy = m_nod->GetIndex();
-					//WW ddummy = eqs->b[m_nod->GetIndex()];
+					// WW ldummy = m_nod->GetIndex();
+					// WW ddummy = eqs->b[m_nod->GetIndex()];
 					fem->ConfigElement(m_ele, false);
 					fem->AssembleParabolicEquationRHSVector();
 					// WW ddummy = eqs->b[m_nod->GetIndex()];
@@ -12701,7 +12659,7 @@ void CRFProcess::AssembleParabolicEquationRHSVector(CNode* m_nod)
 				if (check_sign < 0.0)
 					continue;
 				{
-					//cout << m_ele->GetIndex() << "\n";
+					// cout << m_ele->GetIndex() << "\n";
 					fem->ConfigElement(m_ele, false);
 					fem->AssembleParabolicEquationRHSVector();
 				}
@@ -13356,25 +13314,17 @@ bool CRFProcess::ELERelations()
 			succeed = false;
 	}
 
-		// FEM
-		if (type == 4 || type == 41)
-		{
-			// Set initialization function
-			CRFProcessDeformation* dm_pcs = (CRFProcessDeformation*) this;
-			dm_pcs->Initialization();
-			if (!dm_pcs->GetFEMAssembler())
-				succeed = false;
-		}
-		else                      // Initialize FEM calculator
-		{
-			int Axisymm = 1; // ani-axisymmetry
-			if (m_msh->isAxisymmetry())
-				Axisymm = -1;  // Axisymmetry is true
-			//OK4801 needs NUM
-			fem = new CFiniteElementStd(this, Axisymm * m_msh->GetCoordinateFlag());
-			if (!fem)
-				succeed = false;
-		}
+	// Element matrix output. WW
+	if (Write_Matrix)
+	{
+		cout << "->Write Matrix" << '\n';
+		string m_file_name = FileName + "_" + convertProcessTypeToString(this->getProcessType())
+		                     + "_element_matrix.txt";
+		matrix_file = new fstream(m_file_name.c_str(), ios::trunc | ios::out);
+		if (!matrix_file->good())
+			cout << "Warning in GlobalAssembly: Matrix files are not found"
+			     << "\n";
+	}
 
 	// FEM
 	if (type == 4 || type == 41)
@@ -13382,7 +13332,7 @@ bool CRFProcess::ELERelations()
 		// Set initialization function
 		CRFProcessDeformation* dm_pcs = (CRFProcessDeformation*)this;
 		dm_pcs->Initialization();
-		if (!dm_pcs->GetFEM_Assembler())
+		if (!dm_pcs->GetFEMAssembler())
 			succeed = false;
 	}
 	else // Initialize FEM calculator
@@ -13928,8 +13878,8 @@ void CRFProcess::WriteBC()
 		return;
 
 #ifdef USE_PETSC
-	std::string m_file_name
-	    = FileName + "_" + convertProcessTypeToString(this->getProcessType()) + "_BC_ST_" + number2str(myrank) + ".asc";
+	std::string m_file_name = FileName + "_" + convertProcessTypeToString(this->getProcessType()) + "_BC_ST_"
+	                          + number2str(myrank) + ".asc";
 #else
 	std::string m_file_name = FileName + "_" + convertProcessTypeToString(this->getProcessType()) + "_BC_ST.asc";
 #endif
@@ -14668,8 +14618,8 @@ void CRFProcess::UpdateTransientBC()
 				}
 		}
 		std::vector<double> interpol_res;
-		MathLib::PiecewiseLinearInterpolation(interpolation_points, interpolation_values, nodes_as_interpol_points,
-		                                      interpol_res);
+		MathLib::PiecewiseLinearInterpolation(
+		    interpolation_points, interpolation_values, nodes_as_interpol_points, interpol_res);
 
 		for (long k = start_i; k < end_i; k++)
 			bc_node_value[k]->node_value = interpol_res[k - start_i];
@@ -14876,8 +14826,8 @@ void CRFProcess::CalGPVelocitiesfromECLIPSE(string path, int timestep, int phase
 // Programming: 11/2010 DL, BG
 // Modification:
 //-------------------------------------------------------------------------
-void CRFProcess::CO2_H2O_NaCl_VLE_isobaric(double T, double P, Phase_Properties& vapor, Phase_Properties& liquid,
-                                           Phase_Properties& solid, int f)
+void CRFProcess::CO2_H2O_NaCl_VLE_isobaric(
+    double T, double P, Phase_Properties& vapor, Phase_Properties& liquid, Phase_Properties& solid, int f)
 {
 	// f ---  1 V-L-S, 2 V-L, 3 CO2-L-S, 4 CO2-L
 
@@ -15269,18 +15219,16 @@ void CRFProcess::CalculateFluidDensitiesAndViscositiesAtNodes(CRFProcess* m_pcs)
 		// Read CO2 concentration in water and calculate moles of CO2 in liquid phase
 		indexProcess = MassTransportID[1];
 		// +1: new timelevel
-		variable_index
-		    = pcs_vector[indexProcess]->GetNodeValueIndex(pcs_vector[indexProcess]->pcs_primary_function_name[0])
-		      + TimeStepVariableIndex;
+		variable_index = pcs_vector[indexProcess]->GetNodeValueIndex(
+		                     pcs_vector[indexProcess]->pcs_primary_function_name[0]) + TimeStepVariableIndex;
 		//[mol/m³]
 		c_CO2inLiquid = pcs_vector[indexProcess]->GetNodeValue(i, variable_index);
 
 		// Read NaCl concentration in water and calculate moles of NaCl in liquid phase
 		indexProcess = MassTransportID[2];
 		// +1: new timelevel
-		variable_index
-		    = pcs_vector[indexProcess]->GetNodeValueIndex(pcs_vector[indexProcess]->pcs_primary_function_name[0])
-		      + TimeStepVariableIndex;
+		variable_index = pcs_vector[indexProcess]->GetNodeValueIndex(
+		                     pcs_vector[indexProcess]->pcs_primary_function_name[0]) + TimeStepVariableIndex;
 		//[mol/m³]
 		c_NaClinLiquid = pcs_vector[indexProcess]->GetNodeValue(i, variable_index);
 
@@ -15357,9 +15305,8 @@ void CRFProcess::CalculateFluidDensitiesAndViscositiesAtNodes(CRFProcess* m_pcs)
 			// Read H2O concentration in gas and calculate moles of H2O in gas phase
 			indexProcess = MassTransportID[4];
 			// +1: new timelevel
-			variable_index
-			    = pcs_vector[indexProcess]->GetNodeValueIndex(pcs_vector[indexProcess]->pcs_primary_function_name[0])
-			      + TimeStepVariableIndex;
+			variable_index = pcs_vector[indexProcess]->GetNodeValueIndex(
+			                     pcs_vector[indexProcess]->pcs_primary_function_name[0]) + TimeStepVariableIndex;
 			//[mol/m³]
 			c_H2OinGas = pcs_vector[indexProcess]->GetNodeValue(i, variable_index);
 
@@ -15533,10 +15480,10 @@ void CRFProcess::Phase_Transition_CO2(CRFProcess* m_pcs, int Step)
 		saturation_liquid = m_pcs->GetNodeValue(i, variable_index);
 		saturation_gas = 1 - saturation_liquid;
 		// calculate new effective saturation that sum up to 1
-		saturation_liquid_effective
-		    = (saturation_liquid - saturation_liquid_min) / (1 - saturation_liquid_min - saturation_gas_min);
-		saturation_gas_effective
-		    = (saturation_gas - saturation_gas_min) / (1 - saturation_liquid_min - saturation_gas_min);
+		saturation_liquid_effective = (saturation_liquid - saturation_liquid_min)
+		                              / (1 - saturation_liquid_min - saturation_gas_min);
+		saturation_gas_effective = (saturation_gas - saturation_gas_min)
+		                           / (1 - saturation_liquid_min - saturation_gas_min);
 		if (saturation_liquid_effective < 1e-10)
 		{
 			saturation_liquid_effective = 0;
@@ -15583,9 +15530,8 @@ void CRFProcess::Phase_Transition_CO2(CRFProcess* m_pcs, int Step)
 		indexProcess = MassTransportID[1];
 		solid.CO2 = 0;
 		// +1: new timelevel
-		variable_index
-		    = pcs_vector[indexProcess]->GetNodeValueIndex(pcs_vector[indexProcess]->pcs_primary_function_name[0])
-		      + TimeStepVariableIndex;
+		variable_index = pcs_vector[indexProcess]->GetNodeValueIndex(
+		                     pcs_vector[indexProcess]->pcs_primary_function_name[0]) + TimeStepVariableIndex;
 		//[mol/m³]
 		c_CO2inLiquid = pcs_vector[indexProcess]->GetNodeValue(i, variable_index);
 		liquid.CO2 = c_CO2inLiquid * liquid.volume; //[mol] = mol/m³ * m³
@@ -15595,9 +15541,8 @@ void CRFProcess::Phase_Transition_CO2(CRFProcess* m_pcs, int Step)
 		gas.NaCl = 0;
 		solid.NaCl = 0;
 		// +1: new timelevel
-		variable_index
-		    = pcs_vector[indexProcess]->GetNodeValueIndex(pcs_vector[indexProcess]->pcs_primary_function_name[0])
-		      + TimeStepVariableIndex;
+		variable_index = pcs_vector[indexProcess]->GetNodeValueIndex(
+		                     pcs_vector[indexProcess]->pcs_primary_function_name[0]) + TimeStepVariableIndex;
 		//[mol/m³]
 		c_NaClinLiquid = pcs_vector[indexProcess]->GetNodeValue(i, variable_index);
 		//[mol] = mol/m³ * m³
@@ -15639,9 +15584,8 @@ void CRFProcess::Phase_Transition_CO2(CRFProcess* m_pcs, int Step)
 			// phase transition after reactions -> use old liquid.H2O because no phase movement
 			indexProcess = MassTransportID[0];
 			// +1: new timelevel
-			variable_index
-			    = pcs_vector[indexProcess]->GetNodeValueIndex(pcs_vector[indexProcess]->pcs_primary_function_name[0])
-			      + 1;
+			variable_index = pcs_vector[indexProcess]->GetNodeValueIndex(
+			                     pcs_vector[indexProcess]->pcs_primary_function_name[0]) + 1;
 			//[mol/m³]
 			c_H2OinLiquid = pcs_vector[indexProcess]->GetNodeValue(i, variable_index);
 			//[mol] = mol/m³ * m³
@@ -15652,8 +15596,7 @@ void CRFProcess::Phase_Transition_CO2(CRFProcess* m_pcs, int Step)
 			// this new pressure, new phase saturations
 			//[mol]
 			liquid.H2O = (Density_liquid * liquid.volume - liquid.CO2 * Molweight_CO2 * 1e-3
-			              - liquid.NaCl * Molweight_NaCl * 1e-3)
-			             / (Molweight_H2O * 1e-3);
+			              - liquid.NaCl * Molweight_NaCl * 1e-3) / (Molweight_H2O * 1e-3);
 
 		// if (m_pcs->Tim->step_current == 1)
 		// liquid.H2O = (Density_liquid * liquid.volume - liquid.CO2 * Molweight_CO2 * 1e-3 - liquid.NaCl *
@@ -15671,9 +15614,8 @@ void CRFProcess::Phase_Transition_CO2(CRFProcess* m_pcs, int Step)
 		// Read H2O concentration in gas and calculate moles of H2O in gas phase
 		indexProcess = MassTransportID[4];
 		// +1: new timelevel
-		variable_index
-		    = pcs_vector[indexProcess]->GetNodeValueIndex(pcs_vector[indexProcess]->pcs_primary_function_name[0])
-		      + TimeStepVariableIndex;
+		variable_index = pcs_vector[indexProcess]->GetNodeValueIndex(
+		                     pcs_vector[indexProcess]->pcs_primary_function_name[0]) + TimeStepVariableIndex;
 		//[mol/m³]
 		c_H2OinGas = pcs_vector[indexProcess]->GetNodeValue(i, variable_index);
 		gas.H2O = c_H2OinGas * gas.volume; //[mol] = mol/m³ * m³
@@ -15691,9 +15633,8 @@ void CRFProcess::Phase_Transition_CO2(CRFProcess* m_pcs, int Step)
 			// phase transition after reactions -> use old liquid.H2O because no phase movement
 			indexProcess = MassTransportID[3];
 			// +1: new timelevel
-			variable_index
-			    = pcs_vector[indexProcess]->GetNodeValueIndex(pcs_vector[indexProcess]->pcs_primary_function_name[0])
-			      + 1;
+			variable_index = pcs_vector[indexProcess]->GetNodeValueIndex(
+			                     pcs_vector[indexProcess]->pcs_primary_function_name[0]) + 1;
 			//[mol/m³]
 			c_CO2inGas = pcs_vector[indexProcess]->GetNodeValue(i, variable_index);
 			gas.CO2 = c_CO2inGas * gas.volume; //[mol] = mol/m³ * m³

--- a/FEM/rf_pcs.cpp
+++ b/FEM/rf_pcs.cpp
@@ -915,8 +915,6 @@ void CRFProcess::Create()
 	if (PCSSetIC_USER)
 		PCSSetIC_USER(pcs_type_number);
 
-	if (compute_domain_face_normal) // WW
-		m_msh->FaceNormal();
 	/// Variable index for equation. 20.08.2010. WW
 	if (p_var_index)
 		for (int i = 0; i < pcs_number_of_primary_nvals; i++)
@@ -5699,11 +5697,11 @@ else
 //
 //
 
-//		  MXDumpGLS("rf_pcs1.txt",1,eqs->b,eqs->x); //abort();
-#if defined(USE_PETSC) // || defined(other parallel libs)//03~04.3012.
-	MPI_Barrier(MPI_COMM_WORLD);
-//	eqs_new->AssembleRHS_PETSc();
-// eqs_new->AssembleMatrixPETSc(MAT_FINAL_ASSEMBLY );
+		//				MXDumpGLS("rf_pcs1.txt",1,eqs->b,eqs->x); //abort();
+#if defined(USE_PETSC)  // || defined(other parallel libs)//03~04.3012.
+		MPI_Barrier (MPI_COMM_WORLD);
+		  //	eqs_new->AssembleRHS_PETSc();
+		//eqs_new->AssembleMatrixPETSc(MAT_FINAL_ASSEMBLY );
 #endif
 }
 

--- a/FEM/rf_pcs.cpp
+++ b/FEM/rf_pcs.cpp
@@ -10148,7 +10148,6 @@ void CRFProcess::Extropolation_GaussValue()
 			elem = m_msh->ele_vector[i];
 			if (elem->GetMark()) // Marked for use
 			{
-				fem->ConfigElement(elem);
 				for(k = 0; k < NS; k++)
 					fem->ExtropolateGauss(this, k);
 			}
@@ -10207,7 +10206,6 @@ void CRFProcess::Extropolation_MatValue()
 			elem = m_msh->ele_vector[i];
 			if (elem->GetMark()) // Marked for use
 			{
-				fem->ConfigElement(elem);
 				fem->CalcNodeMatParatemer();
 			}
 		}
@@ -10774,7 +10772,6 @@ void CRFProcess::CalcSecondaryVariablesTNEQ()
 		elem = m_msh->ele_vector[i];
 		if (elem->GetMark()) // Marked for use
 		{
-			fem->ConfigElement(elem);
 			fem->UpdateSolidDensity(i);          // HS, thermal storage reactions
 			fem->ExtrapolateGauss_ReactRate_TNEQ_TES( this ); // HS added 19.02.2013
 		}
@@ -10812,7 +10809,6 @@ void CRFProcess::CalcSecondaryVariablesTES()
 		CElem* const elem = m_msh->ele_vector[i];
 		if (elem->GetMark()) // Marked for use
 		{
-			fem->ConfigElement(elem);
 			fem->UpdateSolidDensity(i);          // HS, thermal storage reactions
 			fem->ExtrapolateGauss_ReactRate_TNEQ_TES( this ); // HS added 19.02.2013
 		}

--- a/FEM/rf_pcs.h
+++ b/FEM/rf_pcs.h
@@ -409,6 +409,9 @@ public:
 		return orig_size;
 	}
 
+	FiniteElement::CFiniteElementStd* getLinearFEMAssembler()
+	{ return fem; }
+
 	//....................................................................
 	// 7-MFP
 	//....................................................................
@@ -461,6 +464,9 @@ public:
 	//....................................................................
 	// 6-ST
 	void CreateSTGroup();
+
+	void SetBoundaryConditionAndSourceTerm();
+
 	//....................................................................
 	// 7-MFP
 	//....................................................................
@@ -691,10 +697,10 @@ public:
 	void AllocateLocalMatrixMemory();
 	virtual void GlobalAssembly(); // Make as a virtul function. //10.09.201l. WW
 	/// For all PDEs excluding that for deformation. 24.11.2010l. WW
-	void GlobalAssembly_std(bool is_quad, bool Check2D3D = false);
+	void GlobalAssembly_std(const bool is_mixed_order, bool Check2D3D = false);
 	/// Assemble EQS for deformation process.
-	virtual void GlobalAssembly_DM(){};
-#if defined(NEW_EQS) && defined(JFNK_H2M)
+	virtual void GlobalAssembly_DM() {};
+#if defined (NEW_EQS) && defined(JFNK_H2M)
 	/// Jacobian free methid to calculate J*v.
 	// 11.08.2010.
 	void Jacobian_Multi_Vector_JFNK(double* v = NULL, double* Jv = NULL);

--- a/FEM/rf_pcs.h
+++ b/FEM/rf_pcs.h
@@ -409,8 +409,7 @@ public:
 		return orig_size;
 	}
 
-	FiniteElement::CFiniteElementStd* getLinearFEMAssembler()
-	{ return fem; }
+	FiniteElement::CFiniteElementStd* getLinearFEMAssembler() { return fem; }
 
 	//....................................................................
 	// 7-MFP
@@ -512,11 +511,11 @@ public:
 	std::string simulator_model_path; // path to exclipse input data file (*.data), with extension
 	bool PrecalculatedFiles; // defines if Eclipse or dumux is calculated or if precalculated files are used
 	bool SaveEclipseDataFiles; // WTP: save Eclipse data input files for benchmarking on systems with no Eclipse
-	// licenses; use in combination with Precalculated Files
+	                           // licenses; use in combination with Precalculated Files
 	std::string simulator_well_path; // path to well schedule ( *.well), with extension
 	// SB redo wtp
 	std::string dissolved_co2_pcs_name; // Keyword DISSOLVED_CO2_PCS_NAME; Name of MASS_TRANSPORT Process which is used
-	// to store total dissolved CO2 from ECLIPSE
+	                                    // to store total dissolved CO2 from ECLIPSE
 	std::string dissolved_co2_ingas_pcs_name;
 
 	//....................................................................
@@ -608,6 +607,7 @@ public:
 	//-----------------------------
 
 	std::vector<std::string> const& getElementValueNameVector() { return ele_val_name_vector; }
+
 private:
 	// PCH
 	std::vector<std::string> ele_val_name_vector;
@@ -699,8 +699,8 @@ public:
 	/// For all PDEs excluding that for deformation. 24.11.2010l. WW
 	void GlobalAssembly_std(const bool is_mixed_order, bool Check2D3D = false);
 	/// Assemble EQS for deformation process.
-	virtual void GlobalAssembly_DM() {};
-#if defined (NEW_EQS) && defined(JFNK_H2M)
+	virtual void GlobalAssembly_DM(){};
+#if defined(NEW_EQS) && defined(JFNK_H2M)
 	/// Jacobian free methid to calculate J*v.
 	// 11.08.2010.
 	void Jacobian_Multi_Vector_JFNK(double* v = NULL, double* Jv = NULL);
@@ -735,9 +735,11 @@ public:
 	bool hasConstrainedST() { return _hasConstrainedST; }
 	void hasConstrainedBC(const bool state) { _hasConstrainedBC = state; }
 	void hasConstrainedST(const bool state) { _hasConstrainedST = state; }
+
 	void setidxVx(int index) { _idxVx = index; }
 	void setidxVy(int index) { _idxVy = index; }
 	void setidxVz(int index) { _idxVz = index; }
+
 	// ST
 	void IncorporateSourceTerms(const int rank = -1);
 // WW void CheckSTGroup(); //OK

--- a/FEM/rf_random_walk.cpp
+++ b/FEM/rf_random_walk.cpp
@@ -1112,7 +1112,7 @@ void RandomWalk::InterpolateVelocityOfTheParticleByBilinear(int option, Particle
 					for (int i = 0; i < (long)m_msh->ele_vector.size(); i++)
 					{
 						elem = m_mini->ele_vector[i];
-						fem->ConfigElement(elem, m_pcs->m_num->ele_gauss_points);
+						fem->ConfigElement(elem);
 						// Assembly gotta be written different way
 						fem->Assembly(0, d);
 					}

--- a/FEM/rf_react.cpp
+++ b/FEM/rf_react.cpp
@@ -1722,7 +1722,7 @@ void CRFProcess::InterpolateTempGP(CRFProcess* m_pcs, std::string name)
 	long group;
 	double T_ele;
 	double GP[3];
-	static double Node_T[8];
+	//WW static double Node_T[8];
 	static double dbuff0[20];
 	int index1;                           //idxp,idxcp,idxS;
 	CMediumProperties* m_mmp = NULL;
@@ -1777,8 +1777,8 @@ void CRFProcess::ExtropolateTempGP(CRFProcess* m_pcs, std::string name)
 //	double GP[3];
 	static double Node_T[8];
 	double T_sum = 0.0;
-	int index1, index_nod; // idxp,idxcp,idxS;
-	CMediumProperties* m_mmp = NULL;
+	int index1, index_nod;                //idxp,idxcp,idxS;
+	//WW CMediumProperties* m_mmp = NULL;
 	MeshLib::CElem* elem = NULL;
 
 	index1 = m_pcs->GetElementValueIndex(name) + 1; //->fem->interpolate(

--- a/FEM/rf_react.cpp
+++ b/FEM/rf_react.cpp
@@ -1723,7 +1723,8 @@ void CRFProcess::InterpolateTempGP(CRFProcess* m_pcs, std::string name)
 	double T_ele;
 	double GP[3];
 	static double Node_T[8];
-	int index1; // idxp,idxcp,idxS;
+	static double dbuff0[20];
+	int index1;                           //idxp,idxcp,idxS;
 	CMediumProperties* m_mmp = NULL;
 	MeshLib::CElem* elem = NULL;
 	index1 = m_pcs->GetElementValueIndex(name) + 1; //->fem->interpolate(
@@ -1748,30 +1749,32 @@ void CRFProcess::InterpolateTempGP(CRFProcess* m_pcs, std::string name)
 		else
 			GP[0] = GP[1] = GP[2] = 0.0;
 
-		m_pcs->fem->ConfigElement(elem, m_num->ele_gauss_points);
+		m_pcs->fem->ConfigElement(elem);
 		m_pcs->fem->setUnitCoordinates(GP);
-		m_pcs->fem->ComputeShapefct(1); // Linear
-		for (j = 0; j < elem->GetVertexNumber(); j++)
+		m_pcs->fem->ComputeShapefct(1, dbuff0); // Linear interpolation function
+
+		T_ele = 0.;
+		for(j = 0; j < elem->GetVertexNumber(); j++)
 		{
 			enode = elem->GetNodeIndex(j);
-			// m_pcs_mmp
-			Node_T[j] = m_pcs->GetNodeValue(enode, m_pcs->GetNodeValueIndex(name) + 1);
+			//m_pcs_mmp
+			T_ele +=  dbuff0[j] * m_pcs->GetNodeValue(enode,m_pcs->GetNodeValueIndex(name) + 1);
 		}
-		T_ele = fem->interpolate(Node_T);
-		m_pcs->SetElementValue(i, index1, T_ele);
-		m_pcs->SetElementValue(i, index1 - 1, T_ele);
+
+		m_pcs->SetElementValue(i,index1,T_ele);
+		m_pcs->SetElementValue(i,index1 - 1,T_ele);
 	}
 }
 
 // MX
 void CRFProcess::ExtropolateTempGP(CRFProcess* m_pcs, std::string name)
 {
-	MshElemType::type EleType;
+//	MshElemType::type EleType;
 	int j;
 	size_t i;
 	long enode, nn;
-	long group;
-	double GP[3];
+//	long group;
+//	double GP[3];
 	static double Node_T[8];
 	double T_sum = 0.0;
 	int index1, index_nod; // idxp,idxcp,idxS;
@@ -1790,6 +1793,7 @@ void CRFProcess::ExtropolateTempGP(CRFProcess* m_pcs, std::string name)
 		m_pcs->GetAssembler();
 
 		// Activated Element
+		/*
 		group = elem->GetPatchIndex();
 		m_mmp = mmp_vector[group];
 		m_mmp->m_pcs = m_pcs; // m_pcs_mmp
@@ -1804,10 +1808,11 @@ void CRFProcess::ExtropolateTempGP(CRFProcess* m_pcs, std::string name)
 		else
 			GP[0] = GP[1] = GP[2] = 0.0;
 
-		m_pcs->fem->ConfigElement(elem, m_pcs->m_num->ele_gauss_points);
+		m_pcs->fem->ConfigElement(elem);
 		m_pcs->fem->setUnitCoordinates(GP);
 		m_pcs->fem->ComputeShapefct(1); // Linear
-		for (j = 0; j < elem->GetVertexNumber(); j++)
+		*/
+		for(j = 0; j < elem->GetVertexNumber(); j++)
 		{
 			enode = elem->GetNodeIndex(j);
 			Node_T[j] = m_pcs->GetElementValue(i, index1);

--- a/FEM/rf_react.cpp
+++ b/FEM/rf_react.cpp
@@ -1767,7 +1767,6 @@ void CRFProcess::InterpolateTempGP(CRFProcess* m_pcs, std::string name)
 // MX
 void CRFProcess::ExtropolateTempGP(CRFProcess* m_pcs, std::string name)
 {
-	//	MshElemType::type EleType;
 	int j;
 	size_t i;
 	long enode, nn;

--- a/FEM/rf_react.cpp
+++ b/FEM/rf_react.cpp
@@ -836,9 +836,7 @@ int REACT::WriteInputPQCString(long index, /*ifstream *pqc_iinfile,*/ stringstre
 			for (i = ii; i < ii + rcml_number_of_gas_species; i++)
 			{
 				speciesname = this->pqc_names[i];
-				//			cout << "Testing index vectors: " << speciesname << ",   With vectors: " << pqc_names[i] <<
-				//",
-				//"
+				//			cout << "Testing index vectors: " << speciesname << ",   With vectors: " << pqc_names[i] << ", "
 				//<< pcs_vector[pqc_process[i]]->pcs_number << ", " << pqc_index[i];
 				dval = pcs_vector[pqc_process[i]]->GetNodeValue(index, pqc_index[i]);
 				//			cout << dval << "\n";
@@ -1722,9 +1720,9 @@ void CRFProcess::InterpolateTempGP(CRFProcess* m_pcs, std::string name)
 	long group;
 	double T_ele;
 	double GP[3];
-	//WW static double Node_T[8];
+	// WW static double Node_T[8];
 	static double dbuff0[20];
-	int index1;                           //idxp,idxcp,idxS;
+	int index1; // idxp,idxcp,idxS;
 	CMediumProperties* m_mmp = NULL;
 	MeshLib::CElem* elem = NULL;
 	index1 = m_pcs->GetElementValueIndex(name) + 1; //->fem->interpolate(
@@ -1754,31 +1752,31 @@ void CRFProcess::InterpolateTempGP(CRFProcess* m_pcs, std::string name)
 		m_pcs->fem->ComputeShapefct(1, dbuff0); // Linear interpolation function
 
 		T_ele = 0.;
-		for(j = 0; j < elem->GetVertexNumber(); j++)
+		for (j = 0; j < elem->GetVertexNumber(); j++)
 		{
 			enode = elem->GetNodeIndex(j);
-			//m_pcs_mmp
-			T_ele +=  dbuff0[j] * m_pcs->GetNodeValue(enode,m_pcs->GetNodeValueIndex(name) + 1);
+			// m_pcs_mmp
+			T_ele += dbuff0[j] * m_pcs->GetNodeValue(enode, m_pcs->GetNodeValueIndex(name) + 1);
 		}
 
-		m_pcs->SetElementValue(i,index1,T_ele);
-		m_pcs->SetElementValue(i,index1 - 1,T_ele);
+		m_pcs->SetElementValue(i, index1, T_ele);
+		m_pcs->SetElementValue(i, index1 - 1, T_ele);
 	}
 }
 
 // MX
 void CRFProcess::ExtropolateTempGP(CRFProcess* m_pcs, std::string name)
 {
-//	MshElemType::type EleType;
+	//	MshElemType::type EleType;
 	int j;
 	size_t i;
 	long enode, nn;
-//	long group;
-//	double GP[3];
+	//	long group;
+	//	double GP[3];
 	static double Node_T[8];
 	double T_sum = 0.0;
-	int index1, index_nod;                //idxp,idxcp,idxS;
-	//WW CMediumProperties* m_mmp = NULL;
+	int index1, index_nod; // idxp,idxcp,idxS;
+	// WW CMediumProperties* m_mmp = NULL;
 	MeshLib::CElem* elem = NULL;
 
 	index1 = m_pcs->GetElementValueIndex(name) + 1; //->fem->interpolate(
@@ -1796,23 +1794,23 @@ void CRFProcess::ExtropolateTempGP(CRFProcess* m_pcs, std::string name)
 		/*
 		group = elem->GetPatchIndex();
 		m_mmp = mmp_vector[group];
-		m_mmp->m_pcs = m_pcs; // m_pcs_mmp
+		m_mmp->m_pcs = m_pcs;     //m_pcs_mmp
 		EleType = elem->GetElementType();
-		if (EleType == MshElemType::TRIANGLE) // Traingle
+		if(EleType == MshElemType::TRIANGLE) // Traingle
 		{
-			GP[0] = GP[1] = 0.1 / 0.3;
-			GP[2] = 0.0;
+		    GP[0] = GP[1] = 0.1 / 0.3;
+		    GP[2] = 0.0;
 		}
-		else if (EleType == MshElemType::TETRAHEDRON)
-			GP[0] = GP[1] = GP[2] = 0.25;
+		else if(EleType == MshElemType::TETRAHEDRON)
+		    GP[0] = GP[1] = GP[2] = 0.25;
 		else
-			GP[0] = GP[1] = GP[2] = 0.0;
+		    GP[0] = GP[1] = GP[2] = 0.0;
 
 		m_pcs->fem->ConfigElement(elem);
 		m_pcs->fem->setUnitCoordinates(GP);
 		m_pcs->fem->ComputeShapefct(1); // Linear
 		*/
-		for(j = 0; j < elem->GetVertexNumber(); j++)
+		for (j = 0; j < elem->GetVertexNumber(); j++)
 		{
 			enode = elem->GetNodeIndex(j);
 			Node_T[j] = m_pcs->GetElementValue(i, index1);
@@ -3354,9 +3352,7 @@ int REACT::WriteInputPhreeqc(long index, /*ifstream *pqc_iinfile,*/ ofstream* ou
 			for (i = ii; i < ii + rcml_number_of_gas_species; i++)
 			{
 				speciesname = this->pqc_names[i];
-				//			cout << "Testing index vectors: " << speciesname << ",   With vectors: " << pqc_names[i] <<
-				//",
-				//"
+				//			cout << "Testing index vectors: " << speciesname << ",   With vectors: " << pqc_names[i] << ", "
 				//<< pcs_vector[pqc_process[i]]->pcs_number << ", " << pqc_index[i];
 				dval = pcs_vector[pqc_process[i]]->GetNodeValue(index, pqc_index[i]);
 				//			cout << dval << "\n";
@@ -5301,8 +5297,7 @@ void REACT::ExecuteReactionsPHREEQCNewLib(void)
 	cout << "MDL_DEBUG: final input is " << nline << " lines, nodes " << ii << "/" << this->nodenumber << "\n";
 	cout << "\n"
 	     << "MDL_DEBUG: ****** Current input:"
-	     << "\n"
-	     << out_buff.str() << "\n"
+	     << "\n" << out_buff.str() << "\n"
 	     << "MDL_DEBUG: ****** end of input"
 	     << "\n";
 #endif

--- a/FEM/rf_st_new.cpp
+++ b/FEM/rf_st_new.cpp
@@ -3162,26 +3162,28 @@ void CSourceTermGroup::SetPNT(CRFProcess* pcs, CSourceTerm* st, const int ShiftI
 		std::cout << "      - Green-Ampt" << std::endl;
 	}
 
-	if (st->getProcessDistributionType() == FiniteElement::SYSTEM_DEPENDENT)
-	{
-		nod_val->setProcessDistributionType(st->getProcessDistributionType());
-		pcs->compute_domain_face_normal = true; // WW
-		CElem* elem = NULL;
-		CNode* cnode = NULL; // WW
-		for (size_t i = 0; i < m_msh->ele_vector.size(); i++)
-		{
-			elem = m_msh->ele_vector[i];
-			if (!elem->GetMark())
-				continue;
-			int nn = elem->GetNodesNumber(m_msh->getOrder());
-			for (long j = 0; j < nn; j++)
-			{
-				cnode = elem->GetNode(j); // WW
-				if (cnode->GetIndex() == (size_t)st->geo_node_number)
-					st->element_st_vector.push_back(i);
-			}
-		}
-	}
+   if (st->getProcessDistributionType() == FiniteElement::SYSTEM_DEPENDENT)
+   {
+      nod_val->setProcessDistributionType (st->getProcessDistributionType());
+      pcs->compute_domain_face_normal = true;     //WW
+      m_msh->FaceNormal();
+
+      CElem* elem = NULL;
+      CNode* cnode = NULL;                        //WW
+      for (size_t i = 0; i < m_msh->ele_vector.size(); i++)
+      {
+         elem = m_msh->ele_vector[i];
+         if (!elem->GetMark())
+            continue;
+         int nn = elem->GetNodesNumber(m_msh->getOrder());
+         for (long j = 0; j < nn; j++)
+         {
+            cnode = elem->GetNode(j);             //WW
+            if (cnode->GetIndex() == (size_t)st->geo_node_number)
+               st->element_st_vector.push_back(i);
+         }
+      }
+   }
 
 	if (st->getProcessDistributionType() == FiniteElement::TRANSFER_SURROUNDING)
 	{ // TN - Belegung mit Fl�chenelementen
@@ -3750,6 +3752,8 @@ void CSourceTermGroup::SetPolylineNodeValueVector(CSourceTerm* st,
 		}
 	} else if (distype == FiniteElement::SYSTEM_DEPENDENT) { //System Dependented YD
 		m_pcs->compute_domain_face_normal = true; //WW
+		m_msh->FaceNormal();
+
 		long no_face = (long) m_msh->face_vector.size();
 		for (long i = 0; i < no_face; i++) {
 			int node_on_line = 0;

--- a/FEM/rf_st_new.cpp
+++ b/FEM/rf_st_new.cpp
@@ -1787,8 +1787,6 @@ void CSourceTerm::FaceIntegration(CRFProcess* pcs, std::vector<long> const &node
    //vec<CNode*> e_nodes(20);
    // vec<CElem*> e_neis(6);
 
-   CElem* face = new CElem(1);
-   face->SetFace();
    this_number_of_nodes = (long) nodes_on_sfc.size();
    int nSize = (long) msh->nod_vector.size();
    std::vector<long> G2L(nSize);
@@ -1865,6 +1863,8 @@ void CSourceTerm::FaceIntegration(CRFProcess* pcs, std::vector<long> const &node
 
    int count;
    double fac = 1.0;
+   CElem* face = new CElem(1);
+  // face->SetFace();
    for (i = 0; i < (long) vec_possible_elements.size(); i++)
    {
       elem = msh->ele_vector[vec_possible_elements[i]];
@@ -1907,7 +1907,6 @@ void CSourceTerm::FaceIntegration(CRFProcess* pcs, std::vector<long> const &node
             fac = 0.5;
          face->SetFace(elem, j);
          face->SetOrder(msh->getOrder());
-         face->ComputeVolume();
          fem_assembler->setOrder(msh->getOrder() ? 2 : 1);
          fem_assembler->ConfigElement(face, true);
          fem_assembler->FaceIntegration(nodesFVal);

--- a/FEM/rf_st_new.cpp
+++ b/FEM/rf_st_new.cpp
@@ -55,7 +55,9 @@ last modified
 // BaseLib
 #include "FileTools.h"
 
-//#include "pcs_dm.h"
+#include "fem_ele_std.h"
+#include "fem_ele_vec.h"
+#include "pcs_dm.h"
 
 // FEM
 //#include "problem.h"
@@ -1658,246 +1660,261 @@ void CSourceTerm::EdgeIntegration(CFEMesh* msh, const std::vector<long>& nodes_o
  01/2010 NW improvement of efficiency to search faces
  **************************************************************************/
 
-void CSourceTerm::FaceIntegration(CFEMesh* msh, std::vector<long> const& nodes_on_sfc,
-                                  std::vector<double>& node_value_vector)
+void CSourceTerm::FaceIntegration(CRFProcess* pcs, std::vector<long> const &nodes_on_sfc,
+		std::vector<double>&node_value_vector)
 {
-	if (!msh)
-	{
-		std::cout << "Warning in CSourceTerm::FaceIntegration: no MSH data, function doesn't function";
-		return;
-	}
+   CFEMesh* msh = pcs->m_msh;
+   if (!msh)
+   {
+      std::cout
+         << "Warning in CSourceTerm::FaceIntegration: no MSH data, function doesn't function";
+      return;
+   }
 
-	long i, j, k, l;
-	long this_number_of_nodes;
-	int nfaces, nfn;
-	int nodesFace[8];
-	double nodesFVal[8];
+   long i, j, k, l;
+   long this_number_of_nodes;
+   int nfaces; //, nfn;
+   int nodesFace[8];
+   double nodesFVal[8];
 
-	bool Const = false;
-	if (this->getProcessDistributionType() == FiniteElement::CONSTANT
-	    || this->getProcessDistributionType() == FiniteElement::CONSTANT_NEUMANN
-	    || this->getProcessDistributionType() == FiniteElement::RECHARGE) // MW
-		//	if (dis_type_name.find("CONSTANT") != std::string::npos)
-		Const = true;
-	//----------------------------------------------------------------------
-	// Interpolation of polygon values to nodes_on_sfc
-	if (!Const) // Get node BC by interpolation with surface
-	{
-		int nPointsPly = 0;
-		double Area1, Area2;
-		double Tol = 1.0e-9;
-		bool Passed;
-		const int Size = (int)nodes_on_sfc.size();
-		double gC[3], p1[3], p2[3], vn[3], unit[3], NTri[3];
+   bool Const = false;
+   if (this->getProcessDistributionType() == FiniteElement::CONSTANT
+       || this->getProcessDistributionType() == FiniteElement::CONSTANT_NEUMANN
+       || this->getProcessDistributionType() == FiniteElement::RECHARGE)	//MW
+      //	if (dis_type_name.find("CONSTANT") != std::string::npos)
+      Const = true;
+   //----------------------------------------------------------------------
+   // Interpolation of polygon values to nodes_on_sfc
+   if (!Const)                                    // Get node BC by interpolation with surface
+   {
+      int nPointsPly = 0;
+      double Area1, Area2;
+      double Tol = 1.0e-9;
+      bool Passed;
+      const int Size = (int) nodes_on_sfc.size();
+      double gC[3], p1[3], p2[3], vn[3], unit[3], NTri[3];
 
-		CGLPolyline* m_polyline = NULL;
-		Surface* m_surface = NULL;
-		m_surface = GEOGetSFCByName(geo_name); // CC
+      CGLPolyline* m_polyline = NULL;
+      Surface *m_surface = NULL;
+      m_surface = GEOGetSFCByName(geo_name);      //CC
 
-		// list<CGLPolyline*>::const_iterator p = m_surface->polyline_of_surface_list.begin();
-		std::vector<CGLPolyline*>::iterator p = m_surface->polyline_of_surface_vector.begin();
+      // list<CGLPolyline*>::const_iterator p = m_surface->polyline_of_surface_list.begin();
+      std::vector<CGLPolyline*>::iterator p =
+         m_surface->polyline_of_surface_vector.begin();
 
-		for (j = 0; j < Size; j++)
-		{
-			double const* const pn(msh->nod_vector[nodes_on_sfc[j]]->getData());
-			//         pn[0] = msh->nod_vector[nodes_on_sfc[j]]->X();
-			//         pn[1] = msh->nod_vector[nodes_on_sfc[j]]->Y();
-			//         pn[2] = msh->nod_vector[nodes_on_sfc[j]]->Z();
-			node_value_vector[j] = 0.0;
-			Passed = false;
-			// nodes close to first polyline
-			p = m_surface->polyline_of_surface_vector.begin();
-			while (p != m_surface->polyline_of_surface_vector.end())
-			{
-				m_polyline = *p;
-				// Grativity center of this polygon
-				for (i = 0; i < 3; i++)
-					gC[i] = 0.0;
-				vn[2] = 0.0;
-				nPointsPly = (int)m_polyline->point_vector.size();
-				if (m_polyline->point_vector.front() == m_polyline->point_vector.back())
-					nPointsPly -= 1;
-				for (i = 0; i < nPointsPly; i++)
-				{
-					gC[0] += m_polyline->point_vector[i]->x;
-					gC[1] += m_polyline->point_vector[i]->y;
-					gC[2] += m_polyline->point_vector[i]->z;
+      for (j = 0; j < Size; j++)
+      {
+         double const*const pn (msh->nod_vector[nodes_on_sfc[j]]->getData());
+//         pn[0] = msh->nod_vector[nodes_on_sfc[j]]->X();
+//         pn[1] = msh->nod_vector[nodes_on_sfc[j]]->Y();
+//         pn[2] = msh->nod_vector[nodes_on_sfc[j]]->Z();
+         node_value_vector[j] = 0.0;
+         Passed = false;
+         // nodes close to first polyline
+         p = m_surface->polyline_of_surface_vector.begin();
+         while (p != m_surface->polyline_of_surface_vector.end())
+         {
+            m_polyline = *p;
+            // Grativity center of this polygon
+            for (i = 0; i < 3; i++)
+               gC[i] = 0.0;
+            vn[2] = 0.0;
+            nPointsPly = (int) m_polyline->point_vector.size();
+            if (m_polyline->point_vector.front() == m_polyline->point_vector.back())
+               nPointsPly -= 1;
+            for (i = 0; i < nPointsPly; i++)
+            {
+               gC[0] += m_polyline->point_vector[i]->x;
+               gC[1] += m_polyline->point_vector[i]->y;
+               gC[2] += m_polyline->point_vector[i]->z;
 
-					vn[2] += m_polyline->point_vector[i]->getPropert();
-				}
-				for (i = 0; i < 3; i++)
-					gC[i] /= (double)nPointsPly;
-				// BC value at center is an average of all point values of polygon
-				vn[2] /= (double)nPointsPly;
+               vn[2] += m_polyline->point_vector[i]->getPropert();
+            }
+            for (i = 0; i < 3; i++)
+               gC[i] /= (double) nPointsPly;
+            // BC value at center is an average of all point values of polygon
+            vn[2] /= (double) nPointsPly;
 
-				// Area of this polygon by the grativity center
-				for (i = 0; i < nPointsPly; i++)
-				{
-					p1[0] = m_polyline->point_vector[i]->x;
-					p1[1] = m_polyline->point_vector[i]->y;
-					p1[2] = m_polyline->point_vector[i]->z;
-					k = i + 1;
-					if (i == nPointsPly - 1)
-						k = 0;
-					p2[0] = m_polyline->point_vector[k]->x;
-					p2[1] = m_polyline->point_vector[k]->y;
-					p2[2] = m_polyline->point_vector[k]->z;
+            // Area of this polygon by the grativity center
+            for (i = 0; i < nPointsPly; i++)
+            {
+               p1[0] = m_polyline->point_vector[i]->x;
+               p1[1] = m_polyline->point_vector[i]->y;
+               p1[2] = m_polyline->point_vector[i]->z;
+               k = i + 1;
+               if (i == nPointsPly - 1)
+                  k = 0;
+               p2[0] = m_polyline->point_vector[k]->x;
+               p2[1] = m_polyline->point_vector[k]->y;
+               p2[2] = m_polyline->point_vector[k]->z;
 
-					vn[0] = m_polyline->point_vector[i]->getPropert();
-					vn[1] = m_polyline->point_vector[k]->getPropert();
+               vn[0] = m_polyline->point_vector[i]->getPropert();
+               vn[1] = m_polyline->point_vector[k]->getPropert();
 
-					Area1 = fabs(ComputeDetTri(p1, gC, p2));
+               Area1 = fabs(ComputeDetTri(p1, gC, p2));
 
-					Area2 = 0.0;
-					// Check if pn is in the triangle by points (p1, gC, p2)
-					Area2 = fabs(ComputeDetTri(p2, gC, pn));
-					unit[0] = fabs(ComputeDetTri(gC, p1, pn));
-					unit[1] = fabs(ComputeDetTri(p1, p2, pn));
-					Area2 += unit[0] + unit[1];
-					if (fabs(Area1 - Area2) < Tol)
-					{
-						// Intopolation whin triangle (p1,p2,gC)
-						// Shape function
-						for (l = 0; l < 2; l++)
-							unit[l] /= Area1;
-						ShapeFunctionTri(NTri, unit);
-						for (l = 0; l < 3; l++)
-							node_value_vector[j] += vn[l] * NTri[l];
-						Passed = true;
-						break;
-					}
-				}
-				//
-				p++;
-				if (Passed)
-					break;
-			} // while
-		} // j
-	}
+               Area2 = 0.0;
+               // Check if pn is in the triangle by points (p1, gC, p2)
+               Area2 = fabs(ComputeDetTri(p2, gC, pn));
+               unit[0] = fabs(ComputeDetTri(gC, p1, pn));
+               unit[1] = fabs(ComputeDetTri(p1, p2, pn));
+               Area2 += unit[0] + unit[1];
+               if (fabs(Area1 - Area2) < Tol)
+               {
+                  // Intopolation whin triangle (p1,p2,gC)
+                  // Shape function
+                  for (l = 0; l < 2; l++)
+                     unit[l] /= Area1;
+                  ShapeFunctionTri(NTri, unit);
+                  for (l = 0; l < 3; l++)
+                     node_value_vector[j] += vn[l] * NTri[l];
+                  Passed = true;
+                  break;
+               }
 
-	int Axisymm = 1; // ani-axisymmetry
-	// CFEMesh* msh = m_pcs->m_msh;
-	if (msh->isAxisymmetry())
-		Axisymm = -1; // Axisymmetry is true
-	CElem* elem = NULL;
-	CElem* face = new CElem(1);
-	CElement* fem = new CElement(Axisymm * msh->GetCoordinateFlag());
-	CNode* e_node = NULL;
-	CElem* e_nei = NULL;
-	// vec<CNode*> e_nodes(20);
-	// vec<CElem*> e_neis(6);
+            }
+            //
+            p++;
+            if (Passed)
+               break;
+         }                                        // while
+      }                                           //j
+   }
 
-	face->SetFace();
-	this_number_of_nodes = (long)nodes_on_sfc.size();
-	int nSize = (long)msh->nod_vector.size();
-	std::vector<long> G2L(nSize);
-	std::vector<double> NVal(this_number_of_nodes);
+   CElem* elem = NULL;
+   CNode* e_node = NULL;
+   CElem* e_nei = NULL;
+   //vec<CNode*> e_nodes(20);
+   // vec<CElem*> e_neis(6);
 
-	for (i = 0; i < nSize; i++)
-	{
-		msh->nod_vector[i]->SetMark(false);
-		G2L[i] = -1;
-	}
+   CElem* face = new CElem(1);
+   face->SetFace();
+   this_number_of_nodes = (long) nodes_on_sfc.size();
+   int nSize = (long) msh->nod_vector.size();
+   std::vector<long> G2L(nSize);
+   std::vector<double> NVal(this_number_of_nodes);
 
-	for (i = 0; i < this_number_of_nodes; i++)
-	{
-		NVal[i] = 0.0;
-		k = nodes_on_sfc[i];
-		G2L[k] = i;
-	}
+   for (i = 0; i < nSize; i++)
+   {
+      msh->nod_vector[i]->SetMark(false);
+      G2L[i] = -1;
+   }
 
-	//----------------------------------------------------------------------
-	// NW 15.01.2010
-	// 1) search element faces on the surface
-	// 2) face integration
+   for (i = 0; i < this_number_of_nodes; i++)
+   {
+      NVal[i] = 0.0;
+      k = nodes_on_sfc[i];
+      G2L[k] = i;
+   }
 
-	// init
-	for (i = 0; i < (long)msh->ele_vector.size(); i++)
-	{
-		msh->ele_vector[i]->selected = 0; // TODO can use a new variable
-	}
-	std::set<long> set_nodes_on_sfc; // unique set of node id on the surface
-	for (i = 0; i < (long)nodes_on_sfc.size(); i++)
-	{
-		set_nodes_on_sfc.insert(nodes_on_sfc[i]);
-	}
+   //----------------------------------------------------------------------
+   // NW 15.01.2010
+   // 1) search element faces on the surface
+   // 2) face integration
 
-	// filtering elements: elements should have nodes on the surface
-	// Notice: node-elements relation has to be constructed beforehand
-	// CB THMBM
-	// this->getProcess()->CheckMarkedElement(); // CB added to remove bug with deactivated Subdomains
-	std::vector<long> vec_possible_elements;
-	for (i = 0; i < this_number_of_nodes; i++)
-	{
-		k = nodes_on_sfc[i];
-		for (j = 0; j < (long)msh->nod_vector[k]->getConnectedElementIDs().size(); j++)
-		{
-			l = msh->nod_vector[k]->getConnectedElementIDs()[j];
-			if (msh->ele_vector[l]->selected == 0)
-				vec_possible_elements.push_back(l);
-			msh->ele_vector[l]->selected += 1; // remember how many nodes of an element are on the surface
-		}
-	}
+   //init
+   for (i = 0; i < (long) msh->ele_vector.size(); i++)
+   {
+      msh->ele_vector[i]->selected = 0;           //TODO can use a new variable
+   }
+   std::set<long> set_nodes_on_sfc;               //unique set of node id on the surface
+   for (i = 0; i < (long) nodes_on_sfc.size(); i++)
+   {
+      set_nodes_on_sfc.insert(nodes_on_sfc[i]);
+   }
 
-// search elements & face integration
+   //filtering elements: elements should have nodes on the surface
+   //Notice: node-elements relation has to be constructed beforehand
+   // CB THMBM
+   //this->getProcess()->CheckMarkedElement(); // CB added to remove bug with deactivated Subdomains
+   std::vector<long> vec_possible_elements;
+   for (i = 0; i < this_number_of_nodes; i++)
+   {
+      k = nodes_on_sfc[i];
+      for (j = 0; j < (long) msh->nod_vector[k]->getConnectedElementIDs().size(); j++)
+      {
+         l = msh->nod_vector[k]->getConnectedElementIDs()[j];
+         if (msh->ele_vector[l]->selected == 0)
+            vec_possible_elements.push_back(l);
+         msh->ele_vector[l]->selected += 1;       // remember how many nodes of an element are on the surface
+      }
+   }
+
+   CElement* fem_assembler_quad = NULL;
+   CElement* fem_assembler_line = dynamic_cast<CElement*>(pcs->getLinearFEMAssembler());
+   if (   pcs->getProcessType() == FiniteElement::DEFORMATION
+	   || pcs->getProcessType() == FiniteElement::DEFORMATION_DYNAMIC
+       || pcs->getProcessType() == FiniteElement::DEFORMATION_FLOW
+       || pcs->getProcessType() == FiniteElement::DEFORMATION_H2) 
+    {
+           process::CRFProcessDeformation* dm_pcs = dynamic_cast<process::CRFProcessDeformation*>(pcs);
+           fem_assembler_quad = dynamic_cast<CElement*>(dm_pcs->GetFEMAssembler());
+    }
+   
+   CElement* fem_assembler = (msh->getOrder() == 1) ? fem_assembler_quad : fem_assembler_line;
+   assert(fem_assembler);
+
+   fem_assembler->setOrder(msh->getOrder()+1);
+
+   //search elements & face integration
 #if defined(USE_PETSC) // || defined (other parallel linear solver lib). //WW. 05.2013
 	const size_t id_act_l_max = static_cast<size_t>(msh->getNumNodesLocal());
 	const size_t id_max_l = msh->GetNodesNumber(false);
 	const size_t id_act_h_max = msh->getLargestActiveNodeID_Quadratic();
 #endif
 
-	int count;
-	double fac = 1.0;
-	for (i = 0; i < (long)vec_possible_elements.size(); i++)
-	{
-		elem = msh->ele_vector[vec_possible_elements[i]];
-		if (!elem->GetMark())
-			continue;
-		nfaces = elem->GetFacesNumber();
-		elem->SetOrder(msh->getOrder());
-		for (j = 0; j < nfaces; j++)
-		{
-			e_nei = elem->GetNeighbor(j);
-			nfn = elem->GetElementFaceNodes(j, nodesFace);
-			// 1st check
-			if (elem->selected < nfn)
-				continue;
+   int count;
+   double fac = 1.0;
+   for (i = 0; i < (long) vec_possible_elements.size(); i++)
+   {
+      elem = msh->ele_vector[vec_possible_elements[i]];
+      if (!elem->GetMark())
+         continue;
+      nfaces = elem->GetFacesNumber();
+      elem->SetOrder(msh->getOrder());
+      for (j = 0; j < nfaces; j++)
+      {
+         e_nei = elem->GetNeighbor(j);
+         const int nfn = elem->GetElementFaceNodes(j, nodesFace);
+         //1st check
+         if (elem->selected < nfn)
+            continue;
 
-			if (elem->GetDimension() != 3)
-				continue;
+         if(elem->GetDimension() != 3)
+            continue;
 
-			// 2nd check: if all nodes of the face are on the surface
-			count = 0;
-			for (k = 0; k < nfn; k++)
-			{
-				e_node = elem->GetNode(nodesFace[k]);
-				if (set_nodes_on_sfc.count(e_node->GetIndex()) > 0)
-				{
-					count++;
-				}
-			}
-			if (count != nfn)
-				continue;
-			// face integration
-			for (k = 0; k < nfn; k++)
-			{
-				e_node = elem->GetNode(nodesFace[k]);
-				nodesFVal[k] = node_value_vector[G2L[e_node->GetIndex()]];
-			}
-			fac = 1.0;
-			// Not a surface face
-			if (elem->GetDimension() == e_nei->GetDimension())
-				fac = 0.5;
-			face->SetFace(elem, j);
-			face->SetOrder(msh->getOrder());
-			face->ComputeVolume();
-			fem->setOrder(msh->getOrder() + 1);
-			fem->ConfigElement(face, this->_pcs->m_num->ele_gauss_points, true);
-			fem->FaceIntegration(nodesFVal);
+         //2nd check: if all nodes of the face are on the surface
+         count = 0;
+         for (k = 0; k < nfn; k++)
+         {
+            e_node = elem->GetNode(nodesFace[k]);
+            if (set_nodes_on_sfc.count(e_node->GetIndex()) > 0)
+            {
+               count++;
+            }
+         }
+         if (count != nfn)
+            continue;
+         // face integration
+         for (k = 0; k < nfn; k++)
+         {
+            e_node = elem->GetNode(nodesFace[k]);
+            nodesFVal[k] = node_value_vector[G2L[e_node->GetIndex()]];
+         }
+         fac = 1.0;
+                                                  // Not a surface face
+         if (elem->GetDimension() == e_nei->GetDimension())
+            fac = 0.5;
+         face->SetFace(elem, j);
+         face->SetOrder(msh->getOrder());
+         face->ComputeVolume();
+         fem_assembler->setOrder(msh->getOrder() ? 2 : 1);
+         fem_assembler->ConfigElement(face, true);
+         fem_assembler->FaceIntegration(nodesFVal);
 
-			for (k = 0; k < nfn; k++)
-			{
-				e_node = elem->GetNode(nodesFace[k]);
+         for (k = 0; k < nfn; k++)
+         {
+            e_node = elem->GetNode(nodesFace[k]);
 
 #if defined(USE_PETSC) // || defined (other parallel linear solver lib). //WW. 05.2013
 				if (!e_node->isNonGhost(id_act_l_max, id_max_l, id_act_h_max))
@@ -1966,10 +1983,65 @@ void CSourceTerm::FaceIntegration(CFEMesh* msh, std::vector<long> const& nodes_o
 	for (i = 0; i < nSize; i++)
 		msh->nod_vector[i]->SetMark(true);
 
-	NVal.clear();
-	G2L.clear();
-	delete fem;
-	delete face;
+   /*
+    //----------------------------------------------------------------------
+    int count;
+    double fac=1.0;
+    for (i = 0; i < (long)msh->ele_vector.size(); i++)
+    {
+    elem = msh->ele_vector[i];
+    if(!elem->GetMark()) continue;
+    nfaces = elem->GetFacesNumber();
+    elem->SetOrder(msh->getOrder());
+    for(j=0; j<nfaces; j++)
+   {
+   e_nei =  elem->GetNeighbor(j);
+   nfn = elem->GetElementFaceNodes(j, nodesFace);
+   count=0;
+   for(k=0; k<nfn; k++)
+   {
+   e_node = elem->GetNode(nodesFace[k]);
+   for (l = 0; l <this_number_of_nodes; l++)
+   {
+   if(*e_node==*msh->nod_vector[nodes_on_sfc[l]])
+   {
+   count++;
+   break;
+   }
+   }
+   }
+   if(count!=nfn) continue;
+   for(k=0; k<nfn; k++)
+   {
+   e_node = elem->GetNode(nodesFace[k]);
+   nodesFVal[k] = node_value_vector[G2L[e_node->GetIndex()]];
+   }
+   fac = 1.0;
+   if(elem->GetDimension()==e_nei->GetDimension()) // Not a surface face
+   fac = 0.5;
+   face->SetFace(elem, j);
+   face->SetOrder(msh->getOrder());
+   face->ComputeVolume();
+   fem->setOrder(msh->getOrder()+1);
+   fem->ConfigElement(face, true);
+   fem->FaceIntegration(nodesFVal);
+   for(k=0; k<nfn; k++)
+   {
+   e_node = elem->GetNode(nodesFace[k]);
+   NVal[G2L[e_node->GetIndex()]] += fac*nodesFVal[k];
+   }
+   }
+   }
+   */
+
+   for (i = 0; i < this_number_of_nodes; i++)
+      node_value_vector[i] = NVal[i];
+   for (i = 0; i < nSize; i++)
+      msh->nod_vector[i]->SetMark(true);
+
+   NVal.clear();
+   G2L.clear();
+   delete face;
 }
 
 /**************************************************************************
@@ -1980,74 +2052,83 @@ void CSourceTerm::FaceIntegration(CFEMesh* msh, std::vector<long> const& nodes_o
  08/2005 WW Re-Implementation
  09/2010 TF re structured some things
  **************************************************************************/
-void CSourceTerm::DomainIntegration(CFEMesh* msh, const std::vector<long>& nodes_in_dom,
-                                    std::vector<double>& node_value_vector) const
+void CSourceTerm::DomainIntegration(CRFProcess* pcs, const std::vector<long>&nodes_in_dom,
+std::vector<double>&node_value_vector) const
 {
-	double nodesFVal[8];
+   double nodesFVal[8];
+   vec<CNode*> e_nodes(20);
 
-	int Axisymm = 1; // ani-axisymmetry
-	if (msh->isAxisymmetry())
-		Axisymm = -1; // Axisymmetry is true
-	CElement* fem = new CElement(Axisymm * msh->GetCoordinateFlag());
-	vec<CNode*> e_nodes(20);
+   CFEMesh* msh = pcs->m_msh;
 
-	const size_t this_number_of_nodes(nodes_in_dom.size());
-	const size_t nSize(msh->nod_vector.size());
-	std::vector<long> G2L(nSize);
-	std::vector<double> NVal(this_number_of_nodes);
+   const size_t this_number_of_nodes (nodes_in_dom.size());
+   const size_t nSize (msh->nod_vector.size());
+   std::vector<long> G2L(nSize);
+   std::vector<double> NVal(this_number_of_nodes);
 
-	for (size_t i = 0; i < nSize; i++)
-	{
-		msh->nod_vector[i]->SetMark(false);
-		G2L[i] = -1;
-	}
+   for (size_t i = 0; i < nSize; i++)
+   {
+      msh->nod_vector[i]->SetMark(false);
+      G2L[i] = -1;
+   }
 
-	for (size_t i = 0; i < this_number_of_nodes; i++)
-	{
-		NVal[i] = 0.0;
-		G2L[nodes_in_dom[i]] = i;
-	}
+   for (size_t i = 0; i < this_number_of_nodes; i++)
+   {
+      NVal[i] = 0.0;
+      G2L[nodes_in_dom[i]] = i;
+   }
 
-	size_t count = 0;
-	for (size_t i = 0; i < msh->ele_vector.size(); i++)
-	{
-		CElem* elem(msh->ele_vector[i]);
-		if (!elem->GetMark())
-			continue;
-		elem->GetNodes(e_nodes);
-		size_t nn = elem->GetNodesNumber(msh->getOrder());
-		count = 0;
-		for (size_t j = 0; j < nn; j++)
-		{
-			for (size_t k = 0; k < this_number_of_nodes; k++)
-			{
-				if (*e_nodes[j] == *msh->nod_vector[nodes_in_dom[k]])
-				{
-					count++;
-					break;
-				}
-			}
-		}
-		if (count != nn)
-			continue;
-		for (size_t j = 0; j < nn; j++)
-			nodesFVal[j] = node_value_vector[G2L[e_nodes[j]->GetIndex()]];
-		fem->ConfigElement(elem, this->_pcs->m_num->ele_gauss_points, true);
-		fem->setOrder(msh->getOrder() + 1);
-		fem->FaceIntegration(nodesFVal);
-		for (size_t j = 0; j < nn; j++)
-			NVal[G2L[e_nodes[j]->GetIndex()]] += nodesFVal[j];
-	}
+   CElement* fem_assembler = dynamic_cast<CElement*>(pcs->getLinearFEMAssembler());
+   if (!fem_assembler)
+   {
+	   if (   pcs->getProcessType() == FiniteElement::DEFORMATION
+		   || pcs->getProcessType() == FiniteElement::DEFORMATION_DYNAMIC
+           || pcs->getProcessType() == FiniteElement::DEFORMATION_FLOW
+           || pcs->getProcessType() == FiniteElement::DEFORMATION_H2) 
+       {
+           process::CRFProcessDeformation* dm_pcs = dynamic_cast<process::CRFProcessDeformation*>(pcs);
+           fem_assembler = dynamic_cast<CElement*>(dm_pcs->GetFEMAssembler());
+       }
+   }
+   fem_assembler->setOrder(msh->getOrder()+1);
 
-	for (size_t i = 0; i < this_number_of_nodes; i++)
-		node_value_vector[i] = NVal[i];
-	for (size_t i = 0; i < nSize; i++)
-		msh->nod_vector[i]->SetMark(true);
+   size_t count = 0;
+   for (size_t i = 0; i < msh->ele_vector.size(); i++)
+   {
+      CElem* elem (msh->ele_vector[i]);
+      if (!elem->GetMark())
+         continue;
+      elem->GetNodes(e_nodes);
+      size_t nn = elem->GetNodesNumber(msh->getOrder());
+      count = 0;
+      for (size_t j = 0; j < nn; j++)
+      {
+         for (size_t k = 0; k < this_number_of_nodes; k++)
+         {
+            if (*e_nodes[j] == *msh->nod_vector[nodes_in_dom[k]])
+            {
+               count++;
+               break;
+            }
+         }
+      }
+      if (count != nn)
+         continue;
+      for (size_t j = 0; j < nn; j++)
+         nodesFVal[j] = node_value_vector[G2L[e_nodes[j]->GetIndex()]];
+      fem_assembler->ConfigElement(elem);
+      fem_assembler->DomainIntegration(nodesFVal);
+      for (size_t j = 0; j < nn; j++)
+         NVal[G2L[e_nodes[j]->GetIndex()]] += nodesFVal[j];
+   }
 
-	NVal.clear();
-	G2L.clear();
-	e_nodes.resize(0);
-	delete fem;
+   for (size_t i = 0; i < this_number_of_nodes; i++)
+      node_value_vector[i] = NVal[i];
+   for (size_t i = 0; i < nSize; i++)
+      msh->nod_vector[i]->SetMark(true);
+
+   NVal.clear();
+   G2L.clear();
+   e_nodes.resize(0);
 }
 
 /**************************************************************************
@@ -3586,61 +3667,60 @@ void CSourceTerm::InterpolatePolylineNodeValueVector(std::vector<double> const& 
         std::vector<long>& ply_nod_vector_cond,
         std::vector<double>& ply_nod_val_vector)
 {
-    long number_of_nodes = (long) ply_nod_vector.size();
-    ply_nod_val_vector.resize(number_of_nodes);
+	long number_of_nodes = (long) ply_nod_vector.size();
+	ply_nod_val_vector.resize(number_of_nodes);
 
-    if (st->getProcessDistributionType() == FiniteElement::LINEAR
-            || st->getProcessDistributionType() == FiniteElement::LINEAR_NEUMANN) {
-        st->InterpolatePolylineNodeValueVector(old_ply, st->DistribedBC, ply_nod_val_vector);
-    } else if (st->getProcessDistributionType() == FiniteElement::SYSTEM_DEPENDENT) {
-        CRFProcess* m_pcs = NULL;
-        m_pcs = PCSGet(pcs_type_name);
-        m_pcs->compute_domain_face_normal = true; //WW
-        long no_face = (long) m_msh->face_vector.size();
-        for (long i = 0; i < no_face; i++) {
-            int node_on_line = 0;
-            int no_vertex = m_msh->face_vector[i]->GetVertexNumber();
-            for (long jj = 0; jj < no_vertex; jj++) {
-                for (long kk = 0; kk < number_of_nodes; kk++) {
-                    if (ply_nod_vector[kk]
-                            == m_msh->face_vector[i]->GetNodeIndex(jj)) node_on_line++;
-                } // end nodes
-            } // end vertices
-            if (node_on_line == 2) st->element_st_vector.push_back(
-                    m_msh->face_vector[i]->GetOwner()->GetIndex());
-        } // end faces
-    } // end system dependent
-    else //WW
-    {
-        for (long i = 0; i < number_of_nodes; i++) {
-            ply_nod_val_vector[i] = st->geo_node_value;
-            //			if (st->dis_type == 12)
-            if (st->getProcessDistributionType() == FiniteElement::CONSTANT_GEO)
-                ply_nod_val_vector[i] = st->geo_node_value / (double) number_of_nodes; // distribute flow to nodes along
-polyline. To do.. 4.10.06
-        }
-    }
+	CRFProcess* m_pcs = PCSGet(pcs_type_name);
 
-    if (st->getProcessDistributionType() == FiniteElement::CONSTANT_NEUMANN
-            || st->getProcessDistributionType()
-                    == FiniteElement::LINEAR_NEUMANN
-            || st->getProcessDistributionType() == FiniteElement::GREEN_AMPT) {
-        if (m_msh->GetMaxElementDim() == 1) // 1D  //WW MB
-            st->DomainIntegration(m_msh, ply_nod_vector, ply_nod_val_vector);
-        else st->EdgeIntegration(m_msh, ply_nod_vector, ply_nod_val_vector);
-    }
+	if (st->getProcessDistributionType() == FiniteElement::LINEAR
+			|| st->getProcessDistributionType() == FiniteElement::LINEAR_NEUMANN) {
+		st->InterpolatePolylineNodeValueVector(old_ply, st->DistribedBC, ply_nod_val_vector);
+	} else if (st->getProcessDistributionType() == FiniteElement::SYSTEM_DEPENDENT) {
+		m_pcs->compute_domain_face_normal = true; //WW
+		long no_face = (long) m_msh->face_vector.size();
+		for (long i = 0; i < no_face; i++) {
+			int node_on_line = 0;
+			int no_vertex = m_msh->face_vector[i]->GetVertexNumber();
+			for (long jj = 0; jj < no_vertex; jj++) {
+				for (long kk = 0; kk < number_of_nodes; kk++) {
+					if (ply_nod_vector[kk]
+							== m_msh->face_vector[i]->GetNodeIndex(jj)) node_on_line++;
+				} // end nodes
+			} // end vertices
+			if (node_on_line == 2) st->element_st_vector.push_back(
+					m_msh->face_vector[i]->GetOwner()->GetIndex());
+		} // end faces
+	} // end system dependent
+	else //WW
+	{
+		for (long i = 0; i < number_of_nodes; i++) {
+			ply_nod_val_vector[i] = st->geo_node_value;
+			//			if (st->dis_type == 12)
+			if (st->getProcessDistributionType() == FiniteElement::CONSTANT_GEO)
+				ply_nod_val_vector[i] = st->geo_node_value / (double) number_of_nodes; // distribute flow to nodes along polyline. To do.. 4.10.06
+		}
+	}
 
-    if ( st->getProcessDistributionType() == FiniteElement::CRITICALDEPTH
-            || st->getProcessDistributionType() == FiniteElement::NORMALDEPTH
-            || st->getProcessDistributionType() == FiniteElement::ANALYTICAL) {
-        st->node_value_vectorArea.resize(number_of_nodes);
-        for (long i = 0; i < number_of_nodes; i++)
-            st->node_value_vectorArea[i] = 1.0; //Element width !
-        st->EdgeIntegration(m_msh, ply_nod_vector, st->node_value_vectorArea);
-    }
+	if (st->getProcessDistributionType() == FiniteElement::CONSTANT_NEUMANN
+			|| st->getProcessDistributionType()
+					== FiniteElement::LINEAR_NEUMANN
+			|| st->getProcessDistributionType() == FiniteElement::GREEN_AMPT) {
+		if (m_msh->GetMaxElementDim() == 1) // 1D  //WW MB
+			st->DomainIntegration(m_pcs, ply_nod_vector, ply_nod_val_vector);
+		else st->EdgeIntegration(m_msh, ply_nod_vector, ply_nod_val_vector);
+	}
 
-    if (st->isCoupled() && st->node_averaging)
-        AreaAssembly(st, ply_nod_vector_cond, ply_nod_val_vector);
+	if ( st->getProcessDistributionType() == FiniteElement::CRITICALDEPTH
+			|| st->getProcessDistributionType() == FiniteElement::NORMALDEPTH
+			|| st->getProcessDistributionType() == FiniteElement::ANALYTICAL) {
+		st->node_value_vectorArea.resize(number_of_nodes);
+		for (long i = 0; i < number_of_nodes; i++)
+			st->node_value_vectorArea[i] = 1.0; //Element width !
+		st->EdgeIntegration(m_msh, ply_nod_vector, st->node_value_vectorArea);
+	}
+
+	if (st->isCoupled() && st->node_averaging)
+		AreaAssembly(st, ply_nod_vector_cond, ply_nod_val_vector);
 }
 */
 
@@ -3655,6 +3735,8 @@ void CSourceTermGroup::SetPolylineNodeValueVector(CSourceTerm* st,
 
 	FiniteElement::DistributionType distype(st->getProcessDistributionType());
 
+	CRFProcess* m_pcs = PCSGet(pcs_type_name);
+
 	// linear
 	if (distype == FiniteElement::LINEAR || distype == FiniteElement::LINEAR_NEUMANN)
 	{
@@ -3666,14 +3748,10 @@ void CSourceTermGroup::SetPolylineNodeValueVector(CSourceTerm* st,
 			m_msh->getPointsForInterpolationAlongPolyline(polyline, nodes_as_interpol_points);
 			st->InterpolatePolylineNodeValueVector(nodes_as_interpol_points, ply_nod_val_vector);
 		}
-	}
-	else if (distype == FiniteElement::SYSTEM_DEPENDENT)
-	{ // System Dependented YD
-		CRFProcess* m_pcs(PCSGet(pcs_type_name));
-		m_pcs->compute_domain_face_normal = true; // WW
-		long no_face = (long)m_msh->face_vector.size();
-		for (long i = 0; i < no_face; i++)
-		{
+	} else if (distype == FiniteElement::SYSTEM_DEPENDENT) { //System Dependented YD
+		m_pcs->compute_domain_face_normal = true; //WW
+		long no_face = (long) m_msh->face_vector.size();
+		for (long i = 0; i < no_face; i++) {
 			int node_on_line = 0;
 			int no_vertex = m_msh->face_vector[i]->GetVertexNumber();
 			for (long jj = 0; jj < no_vertex; jj++)
@@ -3710,9 +3788,9 @@ void CSourceTermGroup::SetPolylineNodeValueVector(CSourceTerm* st,
 	    || distype == FiniteElement::RECHARGE) // MW
 	{
 		if (m_msh->GetMaxElementDim() == 1) // 1D  //WW MB
-			st->DomainIntegration(m_msh, ply_nod_vector, ply_nod_val_vector);
-		else
-			st->EdgeIntegration(m_msh, ply_nod_vector, ply_nod_val_vector);
+			st->DomainIntegration(m_pcs, ply_nod_vector,
+					ply_nod_val_vector);
+		else st->EdgeIntegration(m_msh, ply_nod_vector, ply_nod_val_vector);
 	}
 
 	if (distype == FiniteElement::CRITICALDEPTH || distype == FiniteElement::NORMALDEPTH
@@ -3734,7 +3812,8 @@ void CSourceTermGroup::SetPolylineNodeValueVector(CSourceTerm* st,
 		}
 
 		if (m_msh->GetMaxElementDim() == 1) // 1D  //WW MB
-			st->DomainIntegration(m_msh, ply_nod_vector, st->node_value_vectorArea);
+			st->DomainIntegration(m_pcs, ply_nod_vector,
+					 st->node_value_vectorArea);
 		else
 			st->EdgeIntegration(m_msh, ply_nod_vector, st->node_value_vectorArea);
 
@@ -3770,18 +3849,23 @@ void CSourceTermGroup::AreaAssembly(const CSourceTerm* const st,
                                     const std::vector<long>& ply_nod_vector_cond,
                                     std::vector<double>& ply_nod_val_vector) const
 {
-	if (pcs_type_name == "RICHARDS_FLOW" || pcs_type_name == "MULTI_PHASE_FLOW")
-	{
-		if (m_msh_cond->GetMaxElementDim() == 1) // 1D  //WW MB
-			st->DomainIntegration(m_msh_cond, ply_nod_vector_cond, ply_nod_val_vector);
-		else
-			st->EdgeIntegration(m_msh_cond, ply_nod_vector_cond, ply_nod_val_vector);
-		double sum_node_value = 0;
-		for (size_t i = 0; i < ply_nod_val_vector.size(); i++)
-			sum_node_value += ply_nod_val_vector[i];
-		for (size_t i = 0; i < ply_nod_val_vector.size(); i++)
-			ply_nod_val_vector[i] /= sum_node_value;
-	}
+   if (pcs_type_name == "RICHARDS_FLOW" || pcs_type_name == "MULTI_PHASE_FLOW")
+   {
+      if (m_msh_cond->GetMaxElementDim() == 1)    // 1D  //WW MB
+      {	  
+          CRFProcess* m_pcs = PCSGet(pcs_type_name);
+          st->DomainIntegration(m_pcs, ply_nod_vector_cond,
+            ply_nod_val_vector);
+      }
+      else
+         st->EdgeIntegration(m_msh_cond, ply_nod_vector_cond,
+            ply_nod_val_vector);
+      double sum_node_value = 0;
+      for (size_t i = 0; i < ply_nod_val_vector.size(); i++)
+         sum_node_value += ply_nod_val_vector[i];
+      for (size_t  i = 0; i < ply_nod_val_vector.size(); i++)
+         ply_nod_val_vector[i] /= sum_node_value;
+   }
 }
 
 /**************************************************************************
@@ -3795,32 +3879,73 @@ void CSourceTermGroup::SetSurfaceNodeValueVector(CSourceTerm* st, Surface* m_sfc
                                                  std::vector<long> const& sfc_nod_vector,
                                                  std::vector<double>& sfc_nod_val_vector)
 {
-	// CRFProcess* m_pcs = NULL;
-	// m_pcs = PCSGet(pcs_type_name);
-	long number_of_nodes = (long)sfc_nod_vector.size();
-	sfc_nod_val_vector.resize(number_of_nodes);
+   CRFProcess* m_pcs = PCSGet(pcs_type_name);
+   long number_of_nodes = (long) sfc_nod_vector.size();
+   sfc_nod_val_vector.resize(number_of_nodes);
 
-	for (long i = 0; i < number_of_nodes; i++)
-		sfc_nod_val_vector[i] = st->geo_node_value;
-	// KR & TF - case not used
-	//	if (m_st->dis_type == 12) //To do. 4.10.06
-	//		for (long i = 0; i < number_of_nodes; i++)
-	//			sfc_nod_val_vector[i] = m_st->geo_node_value
-	//					/ (double) number_of_nodes;
+   for (long i = 0; i < number_of_nodes; i++)
+      sfc_nod_val_vector[i] = st->geo_node_value;
+   // KR & TF - case not used
+   //	if (m_st->dis_type == 12) //To do. 4.10.06
+   //		for (long i = 0; i < number_of_nodes; i++)
+   //			sfc_nod_val_vector[i] = m_st->geo_node_value
+   //					/ (double) number_of_nodes;
 
-	//	if (st->dis_type == 2 || st->dis_type == 4) { // Piecewise linear distributed, polygon-wise WW
-	if (st->getProcessDistributionType() == FiniteElement::LINEAR
-	    || st->getProcessDistributionType() == FiniteElement::LINEAR_NEUMANN)
-	{
-		CGLPolyline* m_ply = NULL;
-		std::vector<CGLPolyline*>::iterator p = m_sfc->polyline_of_surface_vector.begin();
-		p = m_sfc->polyline_of_surface_vector.begin();
-		while (p != m_sfc->polyline_of_surface_vector.end())
-		{
-			m_ply = *p;
-			long nPointsPly = (long)m_ply->point_vector.size();
-			if (m_ply->point_vector.front() == m_ply->point_vector.back())
-				nPointsPly -= 1;
+   //	if (st->dis_type == 2 || st->dis_type == 4) { // Piecewise linear distributed, polygon-wise WW
+   if (st->getProcessDistributionType() == FiniteElement::LINEAR || st->getProcessDistributionType() == FiniteElement::LINEAR_NEUMANN)
+   {
+      CGLPolyline* m_ply = NULL;
+      std::vector<CGLPolyline*>::iterator p =
+         m_sfc->polyline_of_surface_vector.begin();
+      p = m_sfc->polyline_of_surface_vector.begin();
+      while (p != m_sfc->polyline_of_surface_vector.end())
+      {
+         m_ply = *p;
+         long nPointsPly = (long) m_ply->point_vector.size();
+         if (m_ply->point_vector.front() == m_ply->point_vector.back())
+            nPointsPly -= 1;
+
+         for (long k = 0; k < (long) st->DistribedBC.size(); k++)
+         {
+            for (long l = 0; l < nPointsPly; l++)
+            {
+               if (st->PointsHaveDistribedBC[k]
+                  == m_ply->point_vector[l]->id)
+               {
+                  if (fabs(st->DistribedBC[k]) < MKleinsteZahl)
+                     st->DistribedBC[k] = 1.0e-20;
+                  m_ply->point_vector[l]->setPropert (st->DistribedBC[k]);
+                  break;
+               }                                  // end l
+            }                                     // end k
+         }                                        // end polyline
+         // InterpolationAlongPolyline(m_polyline, node_value_vector);
+         p++;
+      }                                           // end while
+   }                                              // end linear
+
+   // neumann, Green-Ampt, Philip
+   //	if (st->dis_type == 3 || st->dis_type == 4 || st->dis_type == 10
+   //				|| st->dis_type == 11) {
+   /*|| st->getProcessDistributionType() == PHILIP */
+   if (st->getProcessDistributionType() == FiniteElement::CONSTANT_NEUMANN
+		   || st->getProcessDistributionType() == FiniteElement::LINEAR_NEUMANN
+		   || st->getProcessDistributionType() == FiniteElement::GREEN_AMPT
+		   || st->getProcessDistributionType() == FiniteElement::RECHARGE)
+   {
+      if (m_msh->GetMaxElementDim() == 2)         // For all meshes with 1-D or 2-D elements
+         st->DomainIntegration(m_pcs, sfc_nod_vector, sfc_nod_val_vector);
+      else if (m_msh->GetMaxElementDim() == 3)    // For all meshes with 3-D elements
+         st->FaceIntegration(m_pcs, sfc_nod_vector, sfc_nod_val_vector);
+   }                                              // end neumann
+  else if (st->getProcessDistributionType() == FiniteElement::FUNCTION) // 25.08.2011. WW
+   {
+      for (size_t j = 0; j < sfc_nod_vector.size(); j++)
+      {
+         double const*const pnt (m_msh->nod_vector[sfc_nod_vector[j]]->getData());
+         sfc_nod_val_vector[j] = st->dis_linear_f->getValue(pnt[0], pnt[1], pnt[2]);
+      }
+   }
 
 			for (long k = 0; k < (long)st->DistribedBC.size(); k++)
 			{

--- a/FEM/rf_st_new.cpp
+++ b/FEM/rf_st_new.cpp
@@ -1907,8 +1907,9 @@ void CSourceTerm::FaceIntegration(CRFProcess* pcs, std::vector<long> const &node
             fac = 0.5;
          face->SetFace(elem, j);
          face->SetOrder(msh->getOrder());
+		 face->FillTransformMatrix();
          fem_assembler->setOrder(msh->getOrder() ? 2 : 1);
-         fem_assembler->ConfigElement(face, true);
+         fem_assembler->ConfigElement(face);
          fem_assembler->FaceIntegration(nodesFVal);
 
          for (k = 0; k < nfn; k++)

--- a/FEM/rf_st_new.cpp
+++ b/FEM/rf_st_new.cpp
@@ -1836,7 +1836,7 @@ void CSourceTerm::FaceIntegration(CRFProcess* pcs, std::vector<long> const& node
 	}
 
 	CElement* fem_assembler_quad = NULL;
-	CElement* fem_assembler_line = dynamic_cast<CElement*>(pcs->getLinearFEMAssembler());
+	CElement* fem_assembler_linear = dynamic_cast<CElement*>(pcs->getLinearFEMAssembler());
 	if (pcs->getProcessType() == FiniteElement::DEFORMATION
 	    || pcs->getProcessType() == FiniteElement::DEFORMATION_DYNAMIC
 	    || pcs->getProcessType() == FiniteElement::DEFORMATION_FLOW
@@ -1846,7 +1846,7 @@ void CSourceTerm::FaceIntegration(CRFProcess* pcs, std::vector<long> const& node
 		fem_assembler_quad = dynamic_cast<CElement*>(dm_pcs->GetFEMAssembler());
 	}
 
-	CElement* fem_assembler = (msh->getOrder() == 1) ? fem_assembler_quad : fem_assembler_line;
+	CElement* fem_assembler = (msh->getOrder() == 1) ? fem_assembler_quad : fem_assembler_linear;
 	assert(fem_assembler);
 
 	fem_assembler->setOrder(msh->getOrder() + 1);

--- a/FEM/rf_st_new.h
+++ b/FEM/rf_st_new.h
@@ -72,12 +72,12 @@ public:
 	                     const std::vector<long>& nodes_on_ply,
 	                     std::vector<double>& node_value_vector) const;
 
-	void FaceIntegration(MeshLib::CFEMesh* m_msh,
-	                     std::vector<long> const& nodes_on_sfc,
-	                     std::vector<double>& node_value_vector);
-	void DomainIntegration(MeshLib::CFEMesh* m_msh,
-	                       const std::vector<long>& nodes_in_dom,
-	                       std::vector<double>& node_value_vector) const;
+	void FaceIntegration(CRFProcess* pcs,
+	                     std::vector<long> const & nodes_on_sfc,
+	                     std::vector<double> & node_value_vector);
+	void DomainIntegration(CRFProcess* pcs,
+	                       const std::vector<long> & nodes_in_dom,
+	                       std::vector<double> & node_value_vector) const;
 
 	void SetNOD2MSHNOD(std::vector<long>& nodes, std::vector<long>& conditional_nodes);
 

--- a/FEM/vtk.cpp
+++ b/FEM/vtk.cpp
@@ -476,8 +476,8 @@ bool CVTK::WriteMeshNodes(std::fstream& fin, bool output_data, CFEMesh* msh, lon
 	return true;
 }
 
-bool CVTK::WriteMeshElementConnectivity(std::fstream& fin, bool output_data, CFEMesh* msh, long& offset,
-                                        long& sum_ele_components)
+bool CVTK::WriteMeshElementConnectivity(
+    std::fstream& fin, bool output_data, CFEMesh* msh, long& offset, long& sum_ele_components)
 {
 	if (output_data)
 	{
@@ -1385,7 +1385,7 @@ bool CVTK::WriteElementValue(std::fstream& fin, bool output_data, COutput* out, 
 				if (!this->useBinary)
 				{
 					fin << "          ";
-					for(long i_e = 0; i_e < (long)msh->ele_vector.size(); i_e++)
+					for (long i_e = 0; i_e < (long)msh->ele_vector.size(); i_e++)
 					{
 						ele = msh->ele_vector[i_e];
 						ele->SetOrder(false);

--- a/FEM/vtk.cpp
+++ b/FEM/vtk.cpp
@@ -1329,7 +1329,13 @@ bool CVTK::WriteElementValue(std::fstream& fin, bool output_data, COutput* out, 
 					for (long i_e = 0; i_e < (long)msh->ele_vector.size(); i_e++)
 					{
 						ele = msh->ele_vector[i_e];
-						double mat_value = getElementMMP(mmp_id, ele, m_pcs);
+						ele->SetOrder(false);
+						CFiniteElementStd* fem = m_pcs->GetAssember();
+						fem->ConfigElement(ele, false);
+						fem->Config();
+						fem->getShapeFunctionCentroid();
+						CMediumProperties* mmp = mmp_vector[ele->GetPatchIndex()];
+						double mat_value = ELEMENT_MMP_VALUES::getValue(mmp, mmp_id, i_e, 0, 1.0);
 						fin << mat_value << " ";
 					}
 					fin << "\n";
@@ -1379,16 +1385,14 @@ bool CVTK::WriteElementValue(std::fstream& fin, bool output_data, COutput* out, 
 				if (!this->useBinary)
 				{
 					fin << "          ";
-					int gp_r, gp_s, gp_t;
-					for (long i_e = 0; i_e < (long)msh->ele_vector.size(); i_e++)
+					for(long i_e = 0; i_e < (long)msh->ele_vector.size(); i_e++)
 					{
 						ele = msh->ele_vector[i_e];
 						ele->SetOrder(false);
 						CFiniteElementStd* fem = m_pcs->GetAssember();
-						fem->ConfigElement(ele, m_pcs->m_num->ele_gauss_points, false);
+						fem->ConfigElement(ele, false);
 						fem->Config();
-						fem->SetGaussPoint(0, gp_r, gp_s, gp_t);
-						fem->ComputeShapefct(1);
+						fem->getShapeFunctionCentroid();
 						CFluidProperties* mfp = mfp_vector[0];
 						mfp->SetFemEleStd(fem);
 						double mat_value = ELEMENT_MFP_VALUES::getValue(mfp, mfp_id);

--- a/FileIO/MeshIO/LegacyVtkInterface.cpp
+++ b/FileIO/MeshIO/LegacyVtkInterface.cpp
@@ -910,7 +910,7 @@ void LegacyVtkInterface::WriteVTKDataArrays(fstream& vtk_file) const
 			{
 				const long node_id = _mesh->nod_vector[j]->GetIndex();
 				double vector6[6];
-				for (size_t component = 0; component < tensor_com; ++component)
+				for (size_t component = 0; component < static_cast<size_t>(tensor_com); ++component)
 					vector6[component] = pcs->GetNodeValue(node_id, tensor_val_idx[component]);
 
 				vtk_file << vector6[0] << " " << vector6[1] << " " << vector6[4] << "\n";

--- a/MSH/MSHEnums.h
+++ b/MSH/MSHEnums.h
@@ -30,7 +30,9 @@ struct MshElemType
 		TETRAHEDRON = 5,
 		PRISM = 6,
 		PYRAMID = 7,
-		INVALID = -1
+		QUAD8 = 8,
+		INVALID = -1,
+		LAST = QUAD8
 	};
 };
 

--- a/MSH/MSHEnums.h
+++ b/MSH/MSHEnums.h
@@ -32,7 +32,7 @@ struct MshElemType
 		PYRAMID = 7,
 		QUAD8 = 8,
 		INVALID = -1,
-		LAST = QUAD8
+		NUM_ELEM_TYPES = 8 /// Number of element types
 	};
 };
 

--- a/MSH/msh_elem.cpp
+++ b/MSH/msh_elem.cpp
@@ -459,6 +459,7 @@ void CElem::SetFace(CElem* onwer, const int Face)
 	no_faces_on_surface = 0;
 	owner = onwer;
 	size_t n = owner->GetElementFaceNodes(Face, nodeIndex_loc);
+	quadratic = owner->quadratic;
 	face_index = Face;
 	patch_index = owner->patch_index;
 	switch(owner->geo_type)
@@ -1665,7 +1666,7 @@ void CElem::setElementProperties(MshElemType::type t, bool isFace)
 			std::cerr << "CElem::setElementProperties MshElemType not handled"
 			          << "\n";
 	}
-	this->nodes_index.resize(nnodes);
+	this->nodes_index.resize(quadratic ? nnodesHQ : nnodes);
 }
 
 // NW

--- a/MSH/msh_elem.cpp
+++ b/MSH/msh_elem.cpp
@@ -460,38 +460,44 @@ void CElem::SetFace(CElem* onwer, const int Face)
 	owner = onwer;
 	size_t n = owner->GetElementFaceNodes(Face, nodeIndex_loc);
 	face_index = Face;
-	switch (owner->geo_type)
+	patch_index = owner->patch_index;
+	switch(owner->geo_type)
 	{
-		// case MshElemType::LINE:  // 1-D bar element
-		case MshElemType::QUAD: // 2-D quadrilateral element
-			this->setElementProperties(MshElemType::LINE, true); // JOD 2014-11-10
-			break;
-		case MshElemType::HEXAHEDRON: // 3-D hexahedral element
-			this->setElementProperties(MshElemType::QUAD, true);
-			break;
-		// case MshElemType::TRIANGLE:  // 2-D triagular element
-		case MshElemType::TETRAHEDRON: // 3-D tetrahedral element
+	//case MshElemType::LINE:  // 1-D bar element
+	case MshElemType::QUAD: // 2-D quadrilateral element
+		this->setElementProperties(MshElemType::LINE, true); // JOD 2014-11-10
+		break;
+	case MshElemType::HEXAHEDRON:             // 3-D hexahedral element
+		this->setElementProperties(MshElemType::QUAD8, true);
+		break;
+	//case MshElemType::TRIANGLE:  // 2-D triagular element
+	case MshElemType::TETRAHEDRON:            // 3-D tetrahedral element
+		this->setElementProperties(MshElemType::TRIANGLE, true);
+		break;
+	case MshElemType::PRISM:
+		if(Face < 2)
 			this->setElementProperties(MshElemType::TRIANGLE, true);
-			break;
-		case MshElemType::PRISM:
-			if (Face < 2)
-				this->setElementProperties(MshElemType::TRIANGLE, true);
-			else
-				this->setElementProperties(MshElemType::QUAD, true);
-			break; // 3-D prismatic element
-		case MshElemType::PYRAMID:
-			if (Face < 1)
-				this->setElementProperties(MshElemType::QUAD, true);
-			else
-				this->setElementProperties(MshElemType::TRIANGLE, true);
-			break; // 3-D pyramid element
-		default:
-			std::cerr << "CElem::SetFace MshElemType not handled"
-			          << "\n";
+		else
+			this->setElementProperties(MshElemType::QUAD8, true);
+		break;                            // 3-D prismatic element
+	case MshElemType::PYRAMID:
+		if(Face < 1)
+			this->setElementProperties(MshElemType::QUAD8, true);
+		else
+			this->setElementProperties(MshElemType::TRIANGLE, true);
+		break;                           // 3-D pyramid element
+	default:
+		std::cerr << "CElem::SetFace MshElemType not handled" << "\n";
+		break;
 	}
 
-	for (size_t i = 0; i < n; i++)
+	if (nodes.Size()<n)
+		nodes.resize(n);
+	for(size_t i = 0; i < n; i++)
+	{
 		nodes[i] = owner->nodes[nodeIndex_loc[i]];
+		nodes_index[i] = nodes[i]->GetIndex();
+	}
 }
 /**************************************************************************
    MSHLib-Method:

--- a/MSH/msh_elem.cpp
+++ b/MSH/msh_elem.cpp
@@ -103,34 +103,33 @@ CElem::CElem(size_t Index, CElem* onwer, int Face) : CCore(Index), normal_vector
 	//
 	switch (owner->geo_type)
 	{
-		// case MshElemType::LINE:  // 1-D bar element //KR need not be processed
-		case MshElemType::QUAD: // 2-D quadrilateral element
-			this->setElementProperties(MshElemType::LINE, true);
-			break;
-		case MshElemType::HEXAHEDRON: // 3-D hexahedral element
-			this->setElementProperties(MshElemType::QUAD, true);
-			break;
-		case MshElemType::TRIANGLE: // 2-D triagular element
-			this->setElementProperties(MshElemType::LINE, true);
-			break;
-		case MshElemType::TETRAHEDRON: // 3-D tetrahedral element
-			this->setElementProperties(MshElemType::TRIANGLE, true);
-			break;
-		case MshElemType::PRISM: // 3-D prismatic element
-			if (Face < 2) // top or bottom face of the prism
-				this->setElementProperties(MshElemType::TRIANGLE, true);
-			else // side of the prism
-				this->setElementProperties(MshElemType::QUAD, true);
-			break;
-		case MshElemType::PYRAMID: // 3-D pyramid element
-			if (Face < 1) // bottom face
-				this->setElementProperties(MshElemType::QUAD, true);
-			else // side faces
-				this->setElementProperties(MshElemType::TRIANGLE, true);
-			break;
-		default:
-			std::cerr << "CElem::CElem MshElemType not handled"
-			          << "\n";
+	//case MshElemType::LINE:  // 1-D bar element //KR need not be processed
+	case MshElemType::QUAD:                   // 2-D quadrilateral element
+		this->setElementProperties(MshElemType::LINE);
+		break;
+	case MshElemType::HEXAHEDRON:             // 3-D hexahedral element
+		this->setElementProperties(MshElemType::QUAD);
+		break;
+	case MshElemType::TRIANGLE:               // 2-D triagular element
+		this->setElementProperties(MshElemType::LINE);
+		break;
+	case MshElemType::TETRAHEDRON:            // 3-D tetrahedral element
+		this->setElementProperties(MshElemType::TRIANGLE);
+		break;
+	case MshElemType::PRISM:                  // 3-D prismatic element
+		if (Face < 2)                     // top or bottom face of the prism
+			this->setElementProperties(MshElemType::TRIANGLE);
+		else                              // side of the prism
+			this->setElementProperties(MshElemType::QUAD);
+		break;
+	case MshElemType::PYRAMID:                // 3-D pyramid element
+		if (Face < 1)                     // bottom face
+			this->setElementProperties(MshElemType::QUAD);
+		else                              // side faces
+			this->setElementProperties(MshElemType::TRIANGLE);
+		break;
+	default:
+		std::cerr << "CElem::CElem MshElemType not handled" << "\n";
 	}
 
 	patch_index = owner->patch_index;
@@ -386,7 +385,9 @@ void CElem::FillTransformMatrix()
 		CrossProduction(zz, xx, yy);
 		NormalizeVector(yy, 3);
 	}
-	else if (geo_type == MshElemType::QUAD || geo_type == MshElemType::TRIANGLE)
+	else if (  geo_type == MshElemType::QUAD
+			|| geo_type == MshElemType::QUAD8
+			|| geo_type == MshElemType::TRIANGLE)
 	{
 		// x"_vec
 		//			xx[0] = nodes[1]->X() - nodes[0]->X();
@@ -466,26 +467,26 @@ void CElem::SetFace(CElem* onwer, const int Face)
 	{
 	//case MshElemType::LINE:  // 1-D bar element
 	case MshElemType::QUAD: // 2-D quadrilateral element
-		this->setElementProperties(MshElemType::LINE, true); // JOD 2014-11-10
+		this->setElementProperties(MshElemType::LINE); // JOD 2014-11-10
 		break;
 	case MshElemType::HEXAHEDRON:             // 3-D hexahedral element
-		this->setElementProperties(MshElemType::QUAD8, true);
+		this->setElementProperties(MshElemType::QUAD8);
 		break;
 	//case MshElemType::TRIANGLE:  // 2-D triagular element
 	case MshElemType::TETRAHEDRON:            // 3-D tetrahedral element
-		this->setElementProperties(MshElemType::TRIANGLE, true);
+		this->setElementProperties(MshElemType::TRIANGLE);
 		break;
 	case MshElemType::PRISM:
 		if(Face < 2)
-			this->setElementProperties(MshElemType::TRIANGLE, true);
+			this->setElementProperties(MshElemType::TRIANGLE);
 		else
-			this->setElementProperties(MshElemType::QUAD8, true);
+			this->setElementProperties(MshElemType::QUAD8);
 		break;                            // 3-D prismatic element
 	case MshElemType::PYRAMID:
 		if(Face < 1)
-			this->setElementProperties(MshElemType::QUAD8, true);
+			this->setElementProperties(MshElemType::QUAD8);
 		else
-			this->setElementProperties(MshElemType::TRIANGLE, true);
+			this->setElementProperties(MshElemType::TRIANGLE);
 		break;                           // 3-D pyramid element
 	default:
 		std::cerr << "CElem::SetFace MshElemType not handled" << "\n";
@@ -1602,69 +1603,76 @@ void CElem::SetNormalVector()
 }
 
 // KR 2010/11/16
-void CElem::setElementProperties(MshElemType::type t, bool isFace)
+void CElem::setElementProperties(MshElemType::type t)
 {
 	switch (t)
 	{
-		case MshElemType::LINE:
-			nnodes = 2;
-			nnodesHQ = 3;
-			ele_dim = 1;
-			geo_type = MshElemType::LINE;
-			nfaces = 2;
-			nedges = 1;
-			break;
-		case MshElemType::QUAD:
-			nnodes = 4;
-			nnodesHQ = (isFace) ? 8 : 9; // if a QUAD is the face of a hex it has 8 nodes, otherwise it has 9
-			ele_dim = 2;
-			geo_type = MshElemType::QUAD;
-			nfaces = 4;
-			nedges = 4;
-			break;
-		case MshElemType::HEXAHEDRON:
-			nnodes = 8;
-			nnodesHQ = 20;
-			ele_dim = 3;
-			nfaces = 6;
-			nedges = 12;
-			geo_type = MshElemType::HEXAHEDRON;
-			break;
-		case MshElemType::TRIANGLE:
-			nnodes = 3;
-			nnodesHQ = 6;
-			ele_dim = 2;
-			geo_type = MshElemType::TRIANGLE;
-			nfaces = 3;
-			nedges = 3;
-			break;
-		case MshElemType::TETRAHEDRON:
-			nnodes = 4;
-			nnodesHQ = 10;
-			ele_dim = 3;
-			geo_type = MshElemType::TETRAHEDRON;
-			nfaces = 4;
-			nedges = 6;
-			break;
-		case MshElemType::PRISM:
-			nnodes = 6;
-			nnodesHQ = 15;
-			ele_dim = 3;
-			geo_type = MshElemType::PRISM;
-			nfaces = 5;
-			nedges = 9;
-			break;
-		case MshElemType::PYRAMID:
-			nnodes = 5;
-			nnodesHQ = 13;
-			ele_dim = 3;
-			geo_type = MshElemType::PYRAMID;
-			nfaces = 5;
-			nedges = 8;
-			break;
-		default:
-			std::cerr << "CElem::setElementProperties MshElemType not handled"
-			          << "\n";
+	case MshElemType::LINE:
+		nnodes = 2;
+		nnodesHQ = 3;
+		ele_dim = 1;
+		geo_type = MshElemType::LINE;
+		nfaces = 2;
+		nedges = 1;
+		break;
+	case MshElemType::QUAD8:
+		nnodes = 4;
+		nnodesHQ = 8;
+		ele_dim = 2;
+		geo_type = MshElemType::QUAD8;
+		nfaces = 4;
+		nedges = 4;
+		break;
+	case MshElemType::QUAD:
+		nnodes = 4;
+		nnodesHQ = 9;
+		ele_dim = 2;
+		geo_type = MshElemType::QUAD;
+		nfaces = 4;
+		nedges = 4;
+		break;
+	case MshElemType::HEXAHEDRON:
+		nnodes = 8;
+		nnodesHQ = 20;
+		ele_dim = 3;
+		nfaces = 6;
+		nedges = 12;
+		geo_type = MshElemType::HEXAHEDRON;
+		break;
+	case MshElemType::TRIANGLE:
+		nnodes = 3;
+		nnodesHQ = 6;
+		ele_dim = 2;
+		geo_type = MshElemType::TRIANGLE;
+		nfaces = 3;
+		nedges = 3;
+		break;
+	case MshElemType::TETRAHEDRON:
+		nnodes = 4;
+		nnodesHQ = 10;
+		ele_dim = 3;
+		geo_type = MshElemType::TETRAHEDRON;
+		nfaces = 4;
+		nedges = 6;
+		break;
+	case MshElemType::PRISM:
+		nnodes = 6;
+		nnodesHQ = 15;
+		ele_dim = 3;
+		geo_type = MshElemType::PRISM;
+		nfaces = 5;
+		nedges = 9;
+		break;
+	case MshElemType::PYRAMID:
+		nnodes = 5;
+		nnodesHQ = 13;
+		ele_dim = 3;
+		geo_type = MshElemType::PYRAMID;
+		nfaces = 5;
+		nedges = 8;
+		break;
+	default:
+		std::cerr << "CElem::setElementProperties MshElemType not handled" << "\n";
 	}
 	this->nodes_index.resize(quadratic ? nnodesHQ : nnodes);
 }

--- a/MSH/msh_elem.cpp
+++ b/MSH/msh_elem.cpp
@@ -103,33 +103,34 @@ CElem::CElem(size_t Index, CElem* onwer, int Face) : CCore(Index), normal_vector
 	//
 	switch (owner->geo_type)
 	{
-	//case MshElemType::LINE:  // 1-D bar element //KR need not be processed
-	case MshElemType::QUAD:                   // 2-D quadrilateral element
-		this->setElementProperties(MshElemType::LINE);
-		break;
-	case MshElemType::HEXAHEDRON:             // 3-D hexahedral element
-		this->setElementProperties(MshElemType::QUAD);
-		break;
-	case MshElemType::TRIANGLE:               // 2-D triagular element
-		this->setElementProperties(MshElemType::LINE);
-		break;
-	case MshElemType::TETRAHEDRON:            // 3-D tetrahedral element
-		this->setElementProperties(MshElemType::TRIANGLE);
-		break;
-	case MshElemType::PRISM:                  // 3-D prismatic element
-		if (Face < 2)                     // top or bottom face of the prism
-			this->setElementProperties(MshElemType::TRIANGLE);
-		else                              // side of the prism
+		// case MshElemType::LINE:  // 1-D bar element //KR need not be processed
+		case MshElemType::QUAD: // 2-D quadrilateral element
+			this->setElementProperties(MshElemType::LINE);
+			break;
+		case MshElemType::HEXAHEDRON: // 3-D hexahedral element
 			this->setElementProperties(MshElemType::QUAD);
-		break;
-	case MshElemType::PYRAMID:                // 3-D pyramid element
-		if (Face < 1)                     // bottom face
-			this->setElementProperties(MshElemType::QUAD);
-		else                              // side faces
+			break;
+		case MshElemType::TRIANGLE: // 2-D triagular element
+			this->setElementProperties(MshElemType::LINE);
+			break;
+		case MshElemType::TETRAHEDRON: // 3-D tetrahedral element
 			this->setElementProperties(MshElemType::TRIANGLE);
-		break;
-	default:
-		std::cerr << "CElem::CElem MshElemType not handled" << "\n";
+			break;
+		case MshElemType::PRISM: // 3-D prismatic element
+			if (Face < 2) // top or bottom face of the prism
+				this->setElementProperties(MshElemType::TRIANGLE);
+			else // side of the prism
+				this->setElementProperties(MshElemType::QUAD);
+			break;
+		case MshElemType::PYRAMID: // 3-D pyramid element
+			if (Face < 1) // bottom face
+				this->setElementProperties(MshElemType::QUAD);
+			else // side faces
+				this->setElementProperties(MshElemType::TRIANGLE);
+			break;
+		default:
+			std::cerr << "CElem::CElem MshElemType not handled"
+			          << "\n";
 	}
 
 	patch_index = owner->patch_index;
@@ -385,9 +386,7 @@ void CElem::FillTransformMatrix()
 		CrossProduction(zz, xx, yy);
 		NormalizeVector(yy, 3);
 	}
-	else if (  geo_type == MshElemType::QUAD
-			|| geo_type == MshElemType::QUAD8
-			|| geo_type == MshElemType::TRIANGLE)
+	else if (geo_type == MshElemType::QUAD || geo_type == MshElemType::QUAD8 || geo_type == MshElemType::TRIANGLE)
 	{
 		// x"_vec
 		//			xx[0] = nodes[1]->X() - nodes[0]->X();
@@ -463,39 +462,40 @@ void CElem::SetFace(CElem* onwer, const int Face)
 	quadratic = owner->quadratic;
 	face_index = Face;
 	patch_index = owner->patch_index;
-	switch(owner->geo_type)
+	switch (owner->geo_type)
 	{
-	//case MshElemType::LINE:  // 1-D bar element
-	case MshElemType::QUAD: // 2-D quadrilateral element
-		this->setElementProperties(MshElemType::LINE); // JOD 2014-11-10
-		break;
-	case MshElemType::HEXAHEDRON:             // 3-D hexahedral element
-		this->setElementProperties(MshElemType::QUAD8);
-		break;
-	//case MshElemType::TRIANGLE:  // 2-D triagular element
-	case MshElemType::TETRAHEDRON:            // 3-D tetrahedral element
-		this->setElementProperties(MshElemType::TRIANGLE);
-		break;
-	case MshElemType::PRISM:
-		if(Face < 2)
-			this->setElementProperties(MshElemType::TRIANGLE);
-		else
+		// case MshElemType::LINE:  // 1-D bar element
+		case MshElemType::QUAD: // 2-D quadrilateral element
+			this->setElementProperties(MshElemType::LINE); // JOD 2014-11-10
+			break;
+		case MshElemType::HEXAHEDRON: // 3-D hexahedral element
 			this->setElementProperties(MshElemType::QUAD8);
-		break;                            // 3-D prismatic element
-	case MshElemType::PYRAMID:
-		if(Face < 1)
-			this->setElementProperties(MshElemType::QUAD8);
-		else
+			break;
+		// case MshElemType::TRIANGLE:  // 2-D triagular element
+		case MshElemType::TETRAHEDRON: // 3-D tetrahedral element
 			this->setElementProperties(MshElemType::TRIANGLE);
-		break;                           // 3-D pyramid element
-	default:
-		std::cerr << "CElem::SetFace MshElemType not handled" << "\n";
-		break;
+			break;
+		case MshElemType::PRISM:
+			if (Face < 2)
+				this->setElementProperties(MshElemType::TRIANGLE);
+			else
+				this->setElementProperties(MshElemType::QUAD8);
+			break; // 3-D prismatic element
+		case MshElemType::PYRAMID:
+			if (Face < 1)
+				this->setElementProperties(MshElemType::QUAD8);
+			else
+				this->setElementProperties(MshElemType::TRIANGLE);
+			break; // 3-D pyramid element
+		default:
+			std::cerr << "CElem::SetFace MshElemType not handled"
+			          << "\n";
+			break;
 	}
 
-	if (nodes.Size()<n)
+	if (nodes.Size() < n)
 		nodes.resize(n);
-	for(size_t i = 0; i < n; i++)
+	for (size_t i = 0; i < n; i++)
 	{
 		nodes[i] = owner->nodes[nodeIndex_loc[i]];
 		nodes_index[i] = nodes[i]->GetIndex();
@@ -636,6 +636,7 @@ void CElem::Read(std::istream& is, int fileType)
 					break;
 				default:
 					geo_type = MshElemType::INVALID;
+					break;
 			}
 			index--;
 			break;
@@ -1607,72 +1608,73 @@ void CElem::setElementProperties(MshElemType::type t)
 {
 	switch (t)
 	{
-	case MshElemType::LINE:
-		nnodes = 2;
-		nnodesHQ = 3;
-		ele_dim = 1;
-		geo_type = MshElemType::LINE;
-		nfaces = 2;
-		nedges = 1;
-		break;
-	case MshElemType::QUAD8:
-		nnodes = 4;
-		nnodesHQ = 8;
-		ele_dim = 2;
-		geo_type = MshElemType::QUAD8;
-		nfaces = 4;
-		nedges = 4;
-		break;
-	case MshElemType::QUAD:
-		nnodes = 4;
-		nnodesHQ = 9;
-		ele_dim = 2;
-		geo_type = MshElemType::QUAD;
-		nfaces = 4;
-		nedges = 4;
-		break;
-	case MshElemType::HEXAHEDRON:
-		nnodes = 8;
-		nnodesHQ = 20;
-		ele_dim = 3;
-		nfaces = 6;
-		nedges = 12;
-		geo_type = MshElemType::HEXAHEDRON;
-		break;
-	case MshElemType::TRIANGLE:
-		nnodes = 3;
-		nnodesHQ = 6;
-		ele_dim = 2;
-		geo_type = MshElemType::TRIANGLE;
-		nfaces = 3;
-		nedges = 3;
-		break;
-	case MshElemType::TETRAHEDRON:
-		nnodes = 4;
-		nnodesHQ = 10;
-		ele_dim = 3;
-		geo_type = MshElemType::TETRAHEDRON;
-		nfaces = 4;
-		nedges = 6;
-		break;
-	case MshElemType::PRISM:
-		nnodes = 6;
-		nnodesHQ = 15;
-		ele_dim = 3;
-		geo_type = MshElemType::PRISM;
-		nfaces = 5;
-		nedges = 9;
-		break;
-	case MshElemType::PYRAMID:
-		nnodes = 5;
-		nnodesHQ = 13;
-		ele_dim = 3;
-		geo_type = MshElemType::PYRAMID;
-		nfaces = 5;
-		nedges = 8;
-		break;
-	default:
-		std::cerr << "CElem::setElementProperties MshElemType not handled" << "\n";
+		case MshElemType::LINE:
+			nnodes = 2;
+			nnodesHQ = 3;
+			ele_dim = 1;
+			geo_type = MshElemType::LINE;
+			nfaces = 2;
+			nedges = 1;
+			break;
+		case MshElemType::QUAD8:
+			nnodes = 4;
+			nnodesHQ = 8;
+			ele_dim = 2;
+			geo_type = MshElemType::QUAD8;
+			nfaces = 4;
+			nedges = 4;
+			break;
+		case MshElemType::QUAD:
+			nnodes = 4;
+			nnodesHQ = 9;
+			ele_dim = 2;
+			geo_type = MshElemType::QUAD;
+			nfaces = 4;
+			nedges = 4;
+			break;
+		case MshElemType::HEXAHEDRON:
+			nnodes = 8;
+			nnodesHQ = 20;
+			ele_dim = 3;
+			nfaces = 6;
+			nedges = 12;
+			geo_type = MshElemType::HEXAHEDRON;
+			break;
+		case MshElemType::TRIANGLE:
+			nnodes = 3;
+			nnodesHQ = 6;
+			ele_dim = 2;
+			geo_type = MshElemType::TRIANGLE;
+			nfaces = 3;
+			nedges = 3;
+			break;
+		case MshElemType::TETRAHEDRON:
+			nnodes = 4;
+			nnodesHQ = 10;
+			ele_dim = 3;
+			geo_type = MshElemType::TETRAHEDRON;
+			nfaces = 4;
+			nedges = 6;
+			break;
+		case MshElemType::PRISM:
+			nnodes = 6;
+			nnodesHQ = 15;
+			ele_dim = 3;
+			geo_type = MshElemType::PRISM;
+			nfaces = 5;
+			nedges = 9;
+			break;
+		case MshElemType::PYRAMID:
+			nnodes = 5;
+			nnodesHQ = 13;
+			ele_dim = 3;
+			geo_type = MshElemType::PYRAMID;
+			nfaces = 5;
+			nedges = 8;
+			break;
+		default:
+			std::cerr << "CElem::setElementProperties MshElemType not handled"
+			          << "\n";
 	}
 	this->nodes_index.resize(quadratic ? nnodesHQ : nnodes);
 }

--- a/MSH/msh_elem.h
+++ b/MSH/msh_elem.h
@@ -76,10 +76,8 @@ public:
 	/**
 	 * \brief Sets the default properties for the given element type.
 	 * \param t The element type of this element.
-	 * \param isFace Signals if the element is initialised as a face of an owner element, some properties of the element
-	 * might change in this case.
 	 */
-	void setElementProperties(MshElemType::type t, bool isFace = false);
+	void setElementProperties(MshElemType::type t);
 
 	/**
 	 * Method (re)sets the patch index. Patch index is used to assign a

--- a/MSH/msh_mesh.cpp
+++ b/MSH/msh_mesh.cpp
@@ -4145,8 +4145,8 @@ void CFEMesh::TopSurfaceIntegration()
 	// Compute shape functions
 	// Check element types of meshes
 	std::vector<MshElemType::type> elem_types;
-	elem_types.reserve(MshElemType::LAST);
-	for (std::size_t i = 0; i < static_cast<std::size_t>(MshElemType::LAST); i++)
+	elem_types.reserve(MshElemType::NUM_ELEM_TYPES);
+	for (std::size_t i = 0; i < static_cast<std::size_t>(MshElemType::NUM_ELEM_TYPES); i++)
 	{
 		elem_types.push_back(MshElemType::INVALID);
 	}

--- a/MSH/msh_mesh.cpp
+++ b/MSH/msh_mesh.cpp
@@ -3884,7 +3884,7 @@ void CFEMesh::Precipitation2NeumannBC(std::string const& fname, std::string cons
 
 		elem->ComputeVolume();
 		fem->setOrder(getOrder() + 1);
-		fem->ConfigElement(elem, 3);
+		fem->ConfigElement(elem);
 		fem->FaceIntegration(node_val);
 		for (k = 0; k < elem->nnodes; k++)
 		{

--- a/MSH/msh_mesh.cpp
+++ b/MSH/msh_mesh.cpp
@@ -4169,7 +4169,7 @@ void CFEMesh::TopSurfaceIntegration()
 
 		elem->ComputeVolume();
 		fem->setOrder(getOrder() + 1);
-		fem->ConfigElement(elem, 3);
+		fem->ConfigElement(elem, true);
 		fem->FaceIntegration(node_val);
 		for (k = 0; k < elem->nnodes; k++)
 		{

--- a/MSH/msh_mesh.cpp
+++ b/MSH/msh_mesh.cpp
@@ -1419,8 +1419,7 @@ long CFEMesh::GetNODOnPNT(const GEOLIB::Point* const pnt) const
 	//		std::cout << "grid coords: " << coords[0] << " " << coords[1] << " " << coords[2] << "\n";
 	//		double llf[3], urb[3];
 	//		_mesh_grid->getGridCornerPoints(pnt->getData(), llf, urb);
-	//		std::cout << "local bbx: " << llf[0] << " " << llf[1] << " " << llf[2] << " x " << urb[0] << " " << urb[1]
-	//<<
+	//		std::cout << "local bbx: " << llf[0] << " " << llf[1] << " " << llf[2] << " x " << urb[0] << " " << urb[1] <<
 	//" " << urb[2] << "\n";
 	//	}
 	//
@@ -1601,8 +1600,8 @@ void CFEMesh::GetNODOnPLY(const GEOLIB::Polyline* const ply,
 	else
 	{
 		const size_t start_act_node_h = NodesNumber_Linear;
-		const size_t end_act_node_h
-		    = NodesNumber_Linear + static_cast<size_t>(loc_NodesNumber_Quadratic - loc_NodesNumber_Linear);
+		const size_t end_act_node_h = NodesNumber_Linear
+		                              + static_cast<size_t>(loc_NodesNumber_Quadratic - loc_NodesNumber_Linear);
 		for (size_t k(0); k < tmp_msh_node_vector.size(); k++)
 		{
 			const size_t n_id = nod_vector[tmp_msh_node_vector[k]]->GetIndex();
@@ -2926,9 +2925,8 @@ void CFEMesh::PrismRefine(int Layer, int subdivision)
 							//                           * NNodesPerRow]->Z();
 							// PlaceNode(kno,(element_nodes[i] + ((CountNLayers+2) - row) * NNodesPerRow));
 							// TF								m_nod->SetCoordinates(xyz);
-							m_nod->SetCoordinates(
-							    nod_vector[m_ele->nodes_index[i] + ((CountNLayers + 1) - row) * NNodesPerRow]
-							        ->getData());
+							m_nod->SetCoordinates(nod_vector[m_ele->nodes_index[i]
+							                                 + ((CountNLayers + 1) - row) * NNodesPerRow]->getData());
 							nod_vector[(m_ele->nodes_index[i] + ((CountNLayers + 2) - row) * NNodesPerRow)] = m_nod;
 						}
 					// neues Element ganz unten
@@ -4148,17 +4146,17 @@ void CFEMesh::TopSurfaceIntegration()
 	// Check element types of meshes
 	std::vector<MshElemType::type> elem_types;
 	elem_types.reserve(MshElemType::LAST);
-	for (std::size_t i=0; i<static_cast<std::size_t>(MshElemType::LAST); i++)
+	for (std::size_t i = 0; i < static_cast<std::size_t>(MshElemType::LAST); i++)
 	{
 		elem_types.push_back(MshElemType::INVALID);
 	}
-	elem_types[static_cast<int>(MshElemType::QUAD)-1] = MshElemType::QUAD;
-	elem_types[static_cast<int>(MshElemType::TRIANGLE)-1] = MshElemType::TRIANGLE;
-	FiniteElement::ShapeFunctionPool* line_shapefunction_pool =
-		new FiniteElement::ShapeFunctionPool(elem_types, *fem, 3);
+	elem_types[static_cast<int>(MshElemType::QUAD) - 1] = MshElemType::QUAD;
+	elem_types[static_cast<int>(MshElemType::TRIANGLE) - 1] = MshElemType::TRIANGLE;
+	FiniteElement::ShapeFunctionPool* line_shapefunction_pool
+	    = new FiniteElement::ShapeFunctionPool(elem_types, *fem, 3);
 	fem->setShapeFunctionPool(line_shapefunction_pool, line_shapefunction_pool);
 
-	for(i = 0; i < (long)face_vector.size(); i++)
+	for (i = 0; i < (long)face_vector.size(); i++)
 	{
 		elem = face_vector[i];
 		if (!elem->GetMark())
@@ -4263,12 +4261,12 @@ void CFEMesh::HydroSysMeshGenerator(string fname, const int nlayers, const doubl
 		{
 			depth = seg * (double)k;
 			a_node = nod_vector[i];
-			gs_out << k + i * (nlayers + 1) << deli << a_node->X() << deli << a_node->Y() << deli << a_node->Z() - depth
+			gs_out << k + i*(nlayers + 1) << deli << a_node->X() << deli << a_node->Y() << deli << a_node->Z() - depth
 			       << deli << "\n";
 		}
 	gs_out << "$ELEMENTS"
 	       << "\n";
-	gs_out << size_nodes_msh_t * nlayers << "\n";
+	gs_out << size_nodes_msh_t* nlayers << "\n";
 	l = 0;
 	int mat_index;
 	for (i = 0; i < size_nodes_msh_t; i++)
@@ -4278,7 +4276,7 @@ void CFEMesh::HydroSysMeshGenerator(string fname, const int nlayers, const doubl
 		for (k = 0; k < nlayers; k++)
 		{
 			l = k + (nlayers + 1) * i;
-			gs_out << k + nlayers * i << deli << mat_index << deli << "line" << deli;
+			gs_out << k + nlayers* i << deli << mat_index << deli << "line" << deli;
 			gs_out << l << deli << l + 1 << "\n";
 			mat_index++;
 		}
@@ -4291,7 +4289,7 @@ void CFEMesh::HydroSysMeshGenerator(string fname, const int nlayers, const doubl
 	for (i = 0; i < size_nodes_msh_t; i++)
 	{
 		k = nlayers;
-		gs_out << k + i * (nlayers + 1) << deli << "\n";
+		gs_out << k + i*(nlayers + 1) << deli << "\n";
 	}
 
 	mat_num += nlayers;
@@ -4504,8 +4502,7 @@ size_t CFEMesh::FindElementByPoint(const double* xyz)
 				a_sub[7] = ComputeDetTex(x1, x6, x4, xyz);
 
 				if (fabs((a_sub[0] + a_sub[1] + a_sub[2] + a_sub[3] + a_sub[4] + a_sub[5] + a_sub[6] + a_sub[7] - a)
-				         / a)
-				    < tol)
+				         / a) < tol)
 				{
 					return i;
 				}
@@ -4526,13 +4523,7 @@ size_t CFEMesh::FindElementByPoint(const double* xyz)
 				a_sub[11] = ComputeDetTex(x6, x8, x7, xyz);
 
 				if (fabs((a_sub[0] + a_sub[1] + a_sub[2] + a_sub[3] + a_sub[4] + a_sub[5] + a_sub[6] + a_sub[7]
-				          + a_sub[8]
-				          + a_sub[9]
-				          + a_sub[10]
-				          + a_sub[11]
-				          - a)
-				         / a)
-				    < tol)
+				          + a_sub[8] + a_sub[9] + a_sub[10] + a_sub[11] - a) / a) < tol)
 				{
 					return i;
 				}

--- a/MSH/msh_mesh.cpp
+++ b/MSH/msh_mesh.cpp
@@ -50,6 +50,7 @@
 // FEM
 #include "fem_ele.h"
 #include "files0.h"
+#include "ShapeFunctionPool.h"
 
 using FiniteElement::CElement;
 
@@ -4143,7 +4144,21 @@ void CFEMesh::TopSurfaceIntegration()
 	ofile_asci.setf(std::ios::scientific, std::ios::floatfield);
 	ofile_asci.precision(14);
 
-	for (i = 0; i < (long)face_vector.size(); i++)
+	// Compute shape functions
+	// Check element types of meshes
+	std::vector<MshElemType::type> elem_types;
+	elem_types.reserve(MshElemType::LAST);
+	for (std::size_t i=0; i<static_cast<std::size_t>(MshElemType::LAST); i++)
+	{
+		elem_types.push_back(MshElemType::INVALID);
+	}
+	elem_types[static_cast<int>(MshElemType::QUAD)-1] = MshElemType::QUAD;
+	elem_types[static_cast<int>(MshElemType::TRIANGLE)-1] = MshElemType::TRIANGLE;
+	FiniteElement::ShapeFunctionPool* line_shapefunction_pool =
+		new FiniteElement::ShapeFunctionPool(elem_types, *fem, 3);
+	fem->setShapeFunctionPool(line_shapefunction_pool, line_shapefunction_pool);
+
+	for(i = 0; i < (long)face_vector.size(); i++)
 	{
 		elem = face_vector[i];
 		if (!elem->GetMark())
@@ -4179,6 +4194,8 @@ void CFEMesh::TopSurfaceIntegration()
 	ofile_asci.close();
 	delete fem;
 	fem = NULL;
+	delete line_shapefunction_pool;
+	line_shapefunction_pool = NULL;
 	val.clear();
 }
 


### PR DESCRIPTION
In the previous versions, the computations of shape functions are conducted within the local assembly over each element, which is redundant for the elements with the same type. 

In this PR, a class is introduced for computing shape functions _N_ and their derivatives with respect to the local coordinates d _N_  /d xi. The class is used to compute  _N_  and d _N_  /d xi at each integration points of all involved element types in a FEM computation, and it also holds all the computation results for later usage in the process of Neumann BC and the local assembly. During the local assembly, the derivatives of shape functions with respect to the global local coordinates are computed and cached before any numerical integration happens. By this way, 
- the redundancy in the shape function computation is reduced significantly, 
- the associated memory usage is less.

For the problem with big mesh or many time steps, the speedup of this improvement vs the previous versions could be distinct (20% has been reported).

Since all local shape function computations have been replaced with the cached data  acquisition, all benchmarks give tiny errors in their results against to that obtained by the previous versions.