### PR TITLE
accept user provided PROCESSOR_COUNT

### DIFF
--- a/scripts/cmake/GeneralProjectSetup.cmake
+++ b/scripts/cmake/GeneralProjectSetup.cmake
@@ -27,8 +27,10 @@ endif () # OGS_BUILD_INFO
 include_directories( ${PROJECT_BINARY_DIR}/Base )
 
 # Check for number of processors
-include(ProcessorCount)
-ProcessorCount(PROCESSOR_COUNT)
+if (NOT DEFINED PROCESSOR_COUNT)
+	include(ProcessorCount)
+	ProcessorCount(PROCESSOR_COUNT)
+endif()
 if(PROCESSOR_COUNT EQUAL 0)
 	message(WARNING "Processor count could not be detected. Setting to one processor.")
 	set(PROCESSOR_COUNT 1)


### PR DESCRIPTION
Currently all the CPUs of a computer are used for benchmarking. This PR allows one to change it by providing e.g. `-DPROCESSOR_COUNT=2`.