### PR TITLE
Introduced additional tolerances for global Newton.

### DIFF
--- a/FEM/pcs_dm.cpp
+++ b/FEM/pcs_dm.cpp
@@ -828,7 +828,9 @@ double CRFProcessDeformation::Execute(int loop_process_number)
 #if defined(USE_MPI) || defined(USE_PETSC)
 				}
 #endif
-				if (Error <= Tolerance_global_Newton)//testing only relative residual so far
+				if (Error <= Tolerance_global_Newton && Norm <= m_num->nls_abs_residual_tolerance
+				    && NormU <= m_num->nls_abs_unknown_tolerance
+				    && ErrorU <= m_num->nls_rel_unknown_tolerance)
 				{
 					if (ite_steps == 1) // WX:05.2012
 					{

--- a/FEM/rf_num_new.cpp
+++ b/FEM/rf_num_new.cpp
@@ -128,6 +128,9 @@ CNumerics::CNumerics(string name)
 	fct_const_alpha = -1.0; // NW
 	newton_damping_factor = 1.0;
 	newton_damping_tolerance = 1.e3;
+	nls_abs_residual_tolerance = 1.e10;
+	nls_abs_unknown_tolerance = 1.e10;
+	nls_rel_unknown_tolerance = 1.e10;
 	//----------------------------------------------------------------------
 	// Deformation
 	GravityProfile = 0;
@@ -712,6 +715,22 @@ ios::pos_type CNumerics::Read(ifstream* num_file)
 			std::cout << "NR step will be damped by " << newton_damping_factor
 			          << " if relative residual or relative unknown increment decrease by less than "
 			          << newton_damping_tolerance << " from one iteration to the next." << std::endl;
+			continue;
+		}
+		// Extended convergence test for Newton
+		if (line_string.find("$ADDITIONAL_NEWTON_TOLERANCES") != string::npos)
+		{
+			line.str(GetLineFromFile1(num_file));
+			line >> nls_abs_residual_tolerance;
+			line >> nls_abs_unknown_tolerance;
+			line >> nls_rel_unknown_tolerance;
+			line.clear();
+			std::cout << "Additional Newton tolerances have been set. Global NR will converge if: " << std::endl;
+			std::cout << "  DeltaF/DeltaF0 <= " << nls_error_tolerance << " (set using $NON_LINEAR_ITERATIONS)"
+			          << std::endl;
+			std::cout << "  && DeltaF <= " << nls_abs_residual_tolerance << std::endl;
+			std::cout << "  && DeltaU <= " << nls_abs_unknown_tolerance << std::endl;
+			std::cout << "  && DeltaU/DeltaU0 <= " << nls_rel_unknown_tolerance << std::endl;
 			continue;
 		}
 

--- a/FEM/rf_num_new.cpp
+++ b/FEM/rf_num_new.cpp
@@ -128,9 +128,9 @@ CNumerics::CNumerics(string name)
 	fct_const_alpha = -1.0; // NW
 	newton_damping_factor = 1.0;
 	newton_damping_tolerance = 1.e3;
-	nls_abs_residual_tolerance = 1.e10;
-	nls_abs_unknown_tolerance = 1.e10;
-	nls_rel_unknown_tolerance = 1.e10;
+	nls_abs_residual_tolerance = std::numeric_limits<double>::max();
+	nls_abs_unknown_tolerance = std::numeric_limits<double>::max();
+	nls_rel_unknown_tolerance = std::numeric_limits<double>::max();
 	//----------------------------------------------------------------------
 	// Deformation
 	GravityProfile = 0;

--- a/FEM/rf_num_new.h
+++ b/FEM/rf_num_new.h
@@ -105,6 +105,9 @@ public:
 	int lag_vel_method;
 	double newton_damping_factor;
 	double newton_damping_tolerance;
+	double nls_abs_residual_tolerance;
+	double nls_abs_unknown_tolerance;
+	double nls_rel_unknown_tolerance;
 	//
 	// Configure
 	void NumConfigure(bool overall_coupling_exists); // JT2012


### PR DESCRIPTION
Nothing changes for standard input files. With $NON_LINEAR_ITERATIONS the tolerance for the relative residual is set as usual; other tolerances are too high to matter by default. With the new keyword, one can set tolerances for the increment of the unknowns, both absolute and relative, as well as for the absolute residual. Convergence is achieved only if all error checks are satisfied. If one wants to deactivate a particular tolerance, it simply needs to be set to a high value.