### PR TITLE
Reactivate the functionality of deactivating elements during setting of source terms

### DIFF
--- a/FEM/rf_st_new.cpp
+++ b/FEM/rf_st_new.cpp
@@ -1168,6 +1168,9 @@ void CSourceTermGroup::Set(CRFProcess* m_pcs, const int ShiftInNodeVector, std::
 			{
 				set = false;
 				source_term->setProcess(m_pcs); // HS: 01.09.2009
+
+				m_pcs->CheckMarkedElement();
+
 				if (source_term->getGeoType() == GEOLIB::POINT)
 					SetPNT(m_pcs, source_term, ShiftInNodeVector);
 				if (source_term->getGeoType() == GEOLIB::POLYLINE)
@@ -1822,6 +1825,7 @@ void CSourceTerm::FaceIntegration(CRFProcess* pcs, std::vector<long> const& node
 	// Notice: node-elements relation has to be constructed beforehand
 	// CB THMBM
 	// this->getProcess()->CheckMarkedElement(); // CB added to remove bug with deactivated Subdomains
+	// Already added to Set(..)
 	std::vector<long> vec_possible_elements;
 	for (i = 0; i < this_number_of_nodes; i++)
 	{


### PR DESCRIPTION
For the modelling of the coupled deformation included processes with deactivated elements,  the current version removed the calling of Process::CheckMarkedElement() in the assembly of of Neumann BC. That gives wrong nodal BC values for the modelling of coupled THM processes if deactivated elements exist. This PR fixes the problem.