### PR TITLE
$EPSILON in the bc-file can replace the automatically calculated search length

### DIFF
--- a/FEM/rf_bc_new.cpp
+++ b/FEM/rf_bc_new.cpp
@@ -1802,9 +1802,10 @@ void CBoundaryCondition::SurfaceInterpolation(CRFProcess* m_pcs,
 	// Interpolation of polygon values to nodes_on_sfc
 	int nPointsPly = 0;
 	double Area1, Area2;
+	double Tol = 1e-9;
 	// NW. Default tolerance is 1e-9 but it can be changed in a BC file.
-	double Tol = this->epsilon;
-	Tol = 1e-9; // just a test: if this works, then I have to change the input files of the benchmarks
+	if (this->epsilon != -1)
+		Tol = this->epsilon;
 	bool Passed;
 	double gC[3], p1[3], p2[3], vn[3], unit[3], NTri[3];
 	//

--- a/FEM/rf_bc_new.cpp
+++ b/FEM/rf_bc_new.cpp
@@ -149,7 +149,7 @@ CBoundaryCondition::CBoundaryCondition() : GeoInfo(), geo_name(""), _curve_index
 	// FCT
 	conditional = false;
 	time_dep_interpol = false;
-	epsilon = -1; // NW
+	epsilon = 1e-9; // NW
 	time_contr_curve = -1; // WX
 	bcExcav = -1; // WX
 	MatGr = -1; // WX
@@ -1378,11 +1378,11 @@ void CBoundaryConditionsGroup::Set(CRFProcess* pcs, int ShiftInNodeVector, const
 					//					debug_out.close();
 					//#endif
 					std::vector<size_t> msh_nod_vec;
-					double computed_search_length = m_msh->getSearchLength();
-					if (bc->epsilon != -1) 
-						m_msh->setSearchLength(bc->epsilon);
+					//double computed_search_length = m_msh->getSearchLength();
+					//if (bc->epsilon != -1) 
+						//m_msh->setSearchLength(bc->epsilon);
 					m_msh->GetNODOnSFC(sfc, msh_nod_vec);
-					m_msh->setSearchLength(computed_search_length);
+					//m_msh->setSearchLength(computed_search_length);
 
 #ifndef NDEBUG
 #ifdef DEBUGMESHNODESEARCH

--- a/FEM/rf_bc_new.cpp
+++ b/FEM/rf_bc_new.cpp
@@ -149,7 +149,7 @@ CBoundaryCondition::CBoundaryCondition() : GeoInfo(), geo_name(""), _curve_index
 	// FCT
 	conditional = false;
 	time_dep_interpol = false;
-	epsilon = 1e-9; // NW
+	epsilon = -1; // NW
 	time_contr_curve = -1; // WX
 	bcExcav = -1; // WX
 	MatGr = -1; // WX
@@ -1379,11 +1379,10 @@ void CBoundaryConditionsGroup::Set(CRFProcess* pcs, int ShiftInNodeVector, const
 					//#endif
 					std::vector<size_t> msh_nod_vec;
 					double computed_search_length = m_msh->getSearchLength();
-					//if (bc->epsilon != -1) 
-						//m_msh->setSearchLength(bc->epsilon);
+					if (bc->epsilon != -1) 
+						m_msh->setSearchLength(bc->epsilon);
 					m_msh->GetNODOnSFC(sfc, msh_nod_vec);
-					//m_msh->setSearchLength(computed_search_length);
-					//ANother Test
+					m_msh->setSearchLength(computed_search_length);
 
 #ifndef NDEBUG
 #ifdef DEBUGMESHNODESEARCH

--- a/FEM/rf_bc_new.cpp
+++ b/FEM/rf_bc_new.cpp
@@ -1378,11 +1378,12 @@ void CBoundaryConditionsGroup::Set(CRFProcess* pcs, int ShiftInNodeVector, const
 					//					debug_out.close();
 					//#endif
 					std::vector<size_t> msh_nod_vec;
-					//double computed_search_length = m_msh->getSearchLength();
+					double computed_search_length = m_msh->getSearchLength();
 					//if (bc->epsilon != -1) 
 						//m_msh->setSearchLength(bc->epsilon);
 					m_msh->GetNODOnSFC(sfc, msh_nod_vec);
 					//m_msh->setSearchLength(computed_search_length);
+					//ANother Test
 
 #ifndef NDEBUG
 #ifdef DEBUGMESHNODESEARCH

--- a/FEM/rf_bc_new.cpp
+++ b/FEM/rf_bc_new.cpp
@@ -1804,6 +1804,7 @@ void CBoundaryCondition::SurfaceInterpolation(CRFProcess* m_pcs,
 	double Area1, Area2;
 	// NW. Default tolerance is 1e-9 but it can be changed in a BC file.
 	double Tol = this->epsilon;
+	Tol = 1e-9; // just a test: if this works, then I have to change the input files of the benchmarks
 	bool Passed;
 	double gC[3], p1[3], p2[3], vn[3], unit[3], NTri[3];
 	//

--- a/FEM/rf_bc_new.cpp
+++ b/FEM/rf_bc_new.cpp
@@ -149,7 +149,7 @@ CBoundaryCondition::CBoundaryCondition() : GeoInfo(), geo_name(""), _curve_index
 	// FCT
 	conditional = false;
 	time_dep_interpol = false;
-	epsilon = 1e-9; // NW
+	epsilon = -1; // NW
 	time_contr_curve = -1; // WX
 	bcExcav = -1; // WX
 	MatGr = -1; // WX
@@ -1378,6 +1378,8 @@ void CBoundaryConditionsGroup::Set(CRFProcess* pcs, int ShiftInNodeVector, const
 					//					debug_out.close();
 					//#endif
 					std::vector<size_t> msh_nod_vec;
+					if (bc->epsilon != -1) 
+						m_msh->setSearchLength(bc->epsilon);
 					m_msh->GetNODOnSFC(sfc, msh_nod_vec);
 #ifndef NDEBUG
 #ifdef DEBUGMESHNODESEARCH

--- a/FEM/rf_bc_new.cpp
+++ b/FEM/rf_bc_new.cpp
@@ -1378,9 +1378,12 @@ void CBoundaryConditionsGroup::Set(CRFProcess* pcs, int ShiftInNodeVector, const
 					//					debug_out.close();
 					//#endif
 					std::vector<size_t> msh_nod_vec;
+					double computed_search_length = m_msh->getSearchLength();
 					if (bc->epsilon != -1) 
 						m_msh->setSearchLength(bc->epsilon);
 					m_msh->GetNODOnSFC(sfc, msh_nod_vec);
+					m_msh->setSearchLength(computed_search_length);
+
 #ifndef NDEBUG
 #ifdef DEBUGMESHNODESEARCH
 					{

--- a/MSH/msh_mesh.cpp
+++ b/MSH/msh_mesh.cpp
@@ -882,7 +882,7 @@ void CFEMesh::ConstructGrid()
 
 	// computeSearchLength();
 	computeMinEdgeLength();
-	setSearchLength(_min_edge_length / 2);
+	setSearchLength(0.375 * _min_edge_length / 2);
 	constructMeshGrid();
 }
 
@@ -1738,9 +1738,10 @@ void CFEMesh::GetNODOnSFC(const GEOLIB::Surface* sfc,
 	const size_t nodes_in_usage((size_t)NodesInUsage());
 	for (size_t j(0); j < nodes_in_usage; j++)
 	{
-		if (sfc->isPntInBV((nod_vector[j])->getData(), _search_length * 0.375))
+		// Multiplicator * 0.375 should only be used if _search_length was calculated automatically. 
+		if (sfc->isPntInBV((nod_vector[j])->getData(), _search_length))
 		{
-			if (sfc->isPntInSfc((nod_vector[j])->getData(), _search_length * 0.375))
+			if (sfc->isPntInSfc((nod_vector[j])->getData(), _search_length))
 			{
 				msh_nod_vector.push_back(nod_vector[j]->GetIndex());
 			}


### PR DESCRIPTION
Making use of $EPSILON in the bc-file for boundary conditions. Should be initialized with -1, which means it is not active and can be activated via the keyword in the bc file.