### PR TITLE
Changed the term of LiquidFlow for time unit scaling factor

### DIFF
--- a/FEM/Output.cpp
+++ b/FEM/Output.cpp
@@ -482,21 +482,23 @@ ios::pos_type COutput::Read(std::ifstream& in_str, const GEOLIB::GEOObjects& geo
 		// OK
 		if (line_string.find("$MFP_VALUES") != string::npos)
 		{
-			ok = true;
-			while (ok)
+			while ((!new_keyword) && (!new_subkeyword))
 			{
-				position_line = in_str.tellg();
+				position_subkeyword = in_str.tellg();
 				line_string = GetLineFromFile1(&in_str);
-				if (SubKeyword(line_string))
-				{
-					in_str.seekg(position_line, ios::beg);
-					ok = false;
-					continue;
-				}
-				if (Keyword(line_string))
+				if (line_string.find("#") != string::npos)
 					return position;
-				std::remove_if(line_string.begin(), line_string.end(), ::isspace);
-				mfp_value_vector.push_back(line_string);
+				if (line_string.find("$") != string::npos)
+				{
+					new_subkeyword = true;
+					break;
+				}
+				if (line_string.size() == 0)
+					break;
+				in.str(line_string);
+				in >> name;
+				mfp_value_vector.push_back(name);
+				in.clear();
 			}
 
 			continue;
@@ -1198,7 +1200,7 @@ void COutput::WriteTECNodeData(fstream& tec_file)
 			// OK4704
 			for (size_t k = 0; k < mfp_value_vector.size(); k++)
 				// tec_file << MFPGetNodeValue(m_msh->nod_vector[j]->GetIndex(),mfp_value_vector[k]) << " "; //NB
-				tec_file << MFPGetNodeValue(n_id, mfp_value_vector[k],
+				tec_file << " " << MFPGetNodeValue(n_id, mfp_value_vector[k],
 				                            atoi(&mfp_value_vector[k][mfp_value_vector[k].size() - 1]) - 1)
 				         << " "; // NB: MFP output for all phases
 		}
@@ -1789,7 +1791,7 @@ double COutput::NODWritePLYDataTEC(int number)
 		// OK4704
 		for (size_t k = 0; k < mfp_value_vector.size(); k++)
 			//     tec_file << MFPGetNodeValue(gnode,mfp_value_vector[k],0) << " "; //NB
-			tec_file << MFPGetNodeValue(gnode, mfp_value_vector[k],
+			tec_file << " " << MFPGetNodeValue(gnode, mfp_value_vector[k],
 			                            atoi(&mfp_value_vector[k][mfp_value_vector[k].size() - 1]) - 1)
 			         << " "; // NB: MFP output for all phases
 
@@ -2078,7 +2080,7 @@ void COutput::NODWritePNTDataTEC(double time_current, int time_step_number)
 		}
 		// OK411
 		for (size_t k = 0; k < mfp_value_vector.size(); k++)
-			tec_file << MFPGetNodeValue(msh_node_number, mfp_value_vector[k],
+			tec_file << " " << MFPGetNodeValue(msh_node_number, mfp_value_vector[k],
 			                            atoi(&mfp_value_vector[k][mfp_value_vector[k].size() - 1]) - 1)
 			         << " "; // NB
 	}

--- a/FEM/Output.cpp
+++ b/FEM/Output.cpp
@@ -73,8 +73,9 @@ using MeshLib::CNode;
 using namespace std;
 
 COutput::COutput()
-    : GeoInfo(GEOLIB::GEODOMAIN), ProcessInfo(), _id(0), out_amplifier(0.0), m_msh(NULL), nSteps(-1),
-      _new_file_opened(false), dat_type_name("TECPLOT")
+    : GeoInfo(GEOLIB::GEODOMAIN), ProcessInfo(), DistributionInfo(),
+      dat_type_name("TECPLOT"), _id(0), out_amplifier(0.0), m_msh(NULL),
+      nSteps(-1), _new_file_opened(false)
 {
 	tim_type_name = "TIMES";
 	m_pcs = NULL;
@@ -89,8 +90,8 @@ COutput::COutput()
 }
 
 COutput::COutput(size_t id)
-    : GeoInfo(GEOLIB::GEODOMAIN), ProcessInfo(), _id(id), out_amplifier(0.0), m_msh(NULL), nSteps(-1),
-      _new_file_opened(false), dat_type_name("TECPLOT")
+    : GeoInfo(GEOLIB::GEODOMAIN), ProcessInfo(), dat_type_name("TECPLOT"), _id(id), out_amplifier(0.0), m_msh(NULL), nSteps(-1),
+      _new_file_opened(false)
 {
 	tim_type_name = "TIMES";
 	m_pcs = NULL;

--- a/FEM/fem_ele_std.cpp
+++ b/FEM/fem_ele_std.cpp
@@ -1615,7 +1615,7 @@ double CFiniteElementStd::CalCoefMass()
 				val *= storage_effstress;
 			}
 
-			val /= time_unit_factor;
+			//val /= time_unit_factor;
 			break;
 		case EPT_UNCONFINED_FLOW: // Unconfined flow
 			break;
@@ -2233,7 +2233,7 @@ void CFiniteElementStd::CalCoefLaplace(bool Gravity, int ip)
 					tensor[i * dim + i] *= w[i];
 			}
 			for (size_t i = 0; i < dim * dim; i++)
-				mat[i] = tensor[i] / mat_fac * perm_effstress * k_rel; // AS:perm. dependent eff stress.
+				mat[i] = time_unit_factor * tensor[i] / mat_fac * perm_effstress * k_rel; // AS:perm. dependent eff stress.
 
 			break;
 		case EPT_GROUNDWATER_FLOW: // Groundwater flow
@@ -10569,7 +10569,7 @@ void CFiniteElementStd::Assemble_RHS_LIQUIDFLOW()
 		//---------------------------------------------------------
 		//  Compute RHS+=int{N^T alpha_T dT/dt}
 		//---------------------------------------------------------
-		const double fac = eff_thermal_expansion * dT / dt / time_unit_factor; // WX:bug fixed
+		const double fac = eff_thermal_expansion * dT / dt; // WX:bug fixed
 #if defined(USE_PETSC) //|| defined (other parallel solver) //WW 04.2014
 		for (int ia = 0; ia < act_nodes; ia++)
 		{

--- a/FEM/rf_out_new.cpp
+++ b/FEM/rf_out_new.cpp
@@ -269,8 +269,14 @@ void OUTData(double time_current, int time_step_number, bool force_output)
 		if (!m_pcs)
 			m_pcs = m_out->GetPCS(); // OK
 		if (!m_pcs)
+		{
+			// In case an output is defined for an undefined procsse, i.e. not given in pcs file.
+			if (m_out->getProcessType() != FiniteElement::INVALID_PROCESS)
+				continue;
+
 			cout << "Warning in OUTData - no PCS data"
 			     << "\n";
+		}
 		// OK4704 continue;
 		//--------------------------------------------------------------------
 		m_out->setTime(time_current);


### PR DESCRIPTION
For LiquidFlow, this PR moves the time unit scaling factor from the mass term to the Jacobian term. With this change, the time unit in the source term of  LiquidFlow has to be consistency with the time unit defined in tim file.  Accordingly, the NeumannBC value of one benchmark was changed (ufz/ogs5-benchmarks#19).

This PR also fixes the fluid property output and a compilation warning.
