### PR TITLE
Unify the temperaure unit

### DIFF
--- a/FEM/Eclipse.cpp
+++ b/FEM/Eclipse.cpp
@@ -5953,12 +5953,8 @@ int CECLIPSEData::WriteDataBackToEclipse(CRFProcess* m_pcs, std::string folder)
 						// add it up
 						ele_temp += temp_temp * weight;
 					}
-					// depending on the temperature unit used in Geosys it has to be converted to °C for Ecl
-					if (ele_temp < 273.15)
-						ele_temp += 273.15;
-					// or: if(temperature_unit != Celsius)
-					// ele_temp += 273.15;
-					sstream << fixed << scientific << ele_temp; //+ 273.15;
+
+					sstream << fixed << scientific << ele_temp;
 					tempstring += sstream.str();
 					count++;
 					sstream.str("");

--- a/FEM/FEMEnums.h
+++ b/FEM/FEMEnums.h
@@ -18,6 +18,12 @@
 
 namespace FiniteElement
 {
+enum TemperatureUnit
+{
+	KELVIN,
+	CELSIUS
+};
+
 /** \brief Types of physical processes supported by OpenGeoSys.
  * If you change this enum, make sure you apply the changes to
  * the functions convertPorcessType(), convertProcessTypeToString(),

--- a/FEM/Output.h
+++ b/FEM/Output.h
@@ -11,17 +11,18 @@
 #ifndef OUTPUT_H
 #define OUTPUT_H
 
-#include "makros.h"
-#include "DistributionInfo.h"
-#include "GeoInfo.h"
-#include "ProcessInfo.h"
-
+#include <algorithm>
 #include <iostream>
 #include <vector>
 
 #if defined(USE_PETSC) || defined(USE_MPI) //|| defined(other parallel libs)//03.3012. WW
-#include "mpi.h"
+#include <mpi.h>
 #endif
+
+#include "makros.h"
+#include "DistributionInfo.h"
+#include "GeoInfo.h"
+#include "ProcessInfo.h"
 
 namespace MeshLib
 {
@@ -100,6 +101,12 @@ public:
 	std::ios::pos_type Read(std::ifstream& in, const GEOLIB::GEOObjects& geo_obj, const std::string& unique_name);
 
 	void Write(std::fstream*);
+
+	bool doesTheVariableExist(const std::string& variable_name)
+	{
+		return std::find(_nod_value_vector.begin(), _nod_value_vector.end(), variable_name)
+			!=  _nod_value_vector.end();
+	}
 
 	// TF not used (at the moment?) REMOVE CANDIDATE
 	//    int GetPointClose(CGLPoint);

--- a/FEM/ProcessInfo.cpp
+++ b/FEM/ProcessInfo.cpp
@@ -13,12 +13,13 @@
 #include "rf_pcs.h"
 #include <ProcessInfo.h>
 
-ProcessInfo::ProcessInfo() : _pcs_type(FiniteElement::INVALID_PROCESS), _pcs_pv(FiniteElement::INVALID_PV), _pcs(NULL)
+ProcessInfo::ProcessInfo() : _pcs_type(FiniteElement::INVALID_PROCESS), _pcs_pv(FiniteElement::INVALID_PV),
+	_pcs(NULL), _temp_unit(FiniteElement::KELVIN)
 {
 }
 
 ProcessInfo::ProcessInfo(FiniteElement::ProcessType pcs_type, FiniteElement::PrimaryVariable pcs_pv, CRFProcess* pcs)
-    : _pcs_type(pcs_type), _pcs_pv(pcs_pv), _pcs(pcs)
+    : _pcs_type(pcs_type), _pcs_pv(pcs_pv), _pcs(pcs), _temp_unit(FiniteElement::KELVIN)
 {
 }
 

--- a/FEM/ProcessInfo.cpp
+++ b/FEM/ProcessInfo.cpp
@@ -14,12 +14,12 @@
 #include <ProcessInfo.h>
 
 ProcessInfo::ProcessInfo() : _pcs_type(FiniteElement::INVALID_PROCESS), _pcs_pv(FiniteElement::INVALID_PV),
-	_pcs(NULL), _temp_unit(FiniteElement::KELVIN)
+	_pcs(NULL), _temp_unit(FiniteElement::CELSIUS)
 {
 }
 
 ProcessInfo::ProcessInfo(FiniteElement::ProcessType pcs_type, FiniteElement::PrimaryVariable pcs_pv, CRFProcess* pcs)
-    : _pcs_type(pcs_type), _pcs_pv(pcs_pv), _pcs(pcs), _temp_unit(FiniteElement::KELVIN)
+    : _pcs_type(pcs_type), _pcs_pv(pcs_pv), _pcs(pcs), _temp_unit(FiniteElement::CELSIUS)
 {
 }
 

--- a/FEM/ProcessInfo.h
+++ b/FEM/ProcessInfo.h
@@ -79,6 +79,12 @@ public:
 	 */
 	int getProcessCompVecIndex() const;
 
+	/// Get the temperature unit.
+	FiniteElement::TemperatureUnit getTemperatureUnit() const
+	{
+		return _temp_unit;
+	}
+
 	/**
    * Get a pointer to an object of type CRFProcess.
    * @return a pointer to an object of type CRFProcess
@@ -101,5 +107,8 @@ protected:
 	 * pointer to the object of class CRFProcess
 	 */
 	CRFProcess* _pcs;
+
+	//// Temperature unit
+	FiniteElement::TemperatureUnit _temp_unit;
 };
 #endif /* PROCESSINFO_H_ */

--- a/FEM/burgers.cpp
+++ b/FEM/burgers.cpp
@@ -39,7 +39,7 @@ SolidBurgers::SolidBurgers(const Math_Group::Matrix& data)
 		m_KM = 0.;
 		B = 1.;
 		Q = 0.; // for cutting off Arrhenius term
-		T_ref = 273.15;
+		T_ref = PhysicalConstant::CelsiusZeroInKelvin;
 	}
 }
 

--- a/FEM/conversion_rate.cpp
+++ b/FEM/conversion_rate.cpp
@@ -310,7 +310,7 @@ double conversion_rate::get_ps(const double Tads)
 // Evaporation enthalpy of water from Nunez
 double conversion_rate::get_hv(double Tads) // in kJ/kg
 {
-	Tads -= 273.15;
+	Tads -= PhysicalConstant::CelsiusZeroInKelvin;
 	if (Tads <= 10.)
 	{
 		const double c[] = {2.50052e3,  -2.1068,     -3.57500e-1, 1.905843e-1, -5.11041e-2,

--- a/FEM/eos.cpp
+++ b/FEM/eos.cpp
@@ -26,6 +26,7 @@
 //#include "rf_num_new.h"
 #include "eos.h"
 #include "tools.h"
+#include "PhysicalConstant.h"
 
 using namespace std;
 
@@ -2724,7 +2725,7 @@ void CFluidProperties::therm_prop(string caption)
 			rhoc = 322; //[kg/m3]
 			Tc = 647.096; //[K]
 			pc = 22064000; // [Pa]
-			Tt = 273.16; //  [K]
+			Tt = PhysicalConstant::CelsiusZeroInKelvin; //  [K]
 			pt = 611.657; //  [Pa]
 			Rs = 461.51805; //  [J/kg/K]
 			molar_mass = 18.01528; //  [g/mol]

--- a/FEM/fem_ele_std.cpp
+++ b/FEM/fem_ele_std.cpp
@@ -1689,7 +1689,7 @@ double CFiniteElementStd::CalCoefMass()
 				if (MediaProp->heat_diffusion_model == 1)
 				{
 					//           PG = fabs(interpolate(NodalVal1));
-					TG = interpolate(NodalValC) + PhysicalConstant::CelsiusZeroInKelvin;
+					TG = interpolate(NodalValC);
 					const double humi = exp(PG / (SpecificGasConstant::WaterVapour * TG * rhow));
 					const double rhov = humi * FluidProp->vaporDensity(TG);
 					//
@@ -1742,7 +1742,7 @@ double CFiniteElementStd::CalCoefMass2(int dof_index)
 			dens_arg[0] = PG; // Should be P_w in some cases
 			if (diffusion)
 			{
-				TG = interpolate(NodalValC1) + PhysicalConstant::CelsiusZeroInKelvin;
+				TG = interpolate(NodalValC1);
 				dens_arg[1] = TG;
 			}
 			Sw = MediaProp->SaturationCapillaryPressureFunction(PG);
@@ -2180,7 +2180,7 @@ void CFiniteElementStd::CalCoefLaplace(bool Gravity, int ip)
 			if (MediaProp->permeability_stress_mode > 1)
 			{
 				if (cpl_pcs)
-					TG = interpolate(NodalValC1) + PhysicalConstant::CelsiusZeroInKelvin;
+					TG = interpolate(NodalValC1);
 				else
 					TG = 296.0;
 				MediaProp->CalStressPermeabilityFactor(w, TG);
@@ -2490,7 +2490,7 @@ void CFiniteElementStd::CalCoefLaplace(bool Gravity, int ip)
 			if (MediaProp->permeability_stress_mode > 1)
 			{
 				if (cpl_pcs)
-					TG = interpolate(NodalValC1) + PhysicalConstant::CelsiusZeroInKelvin;
+					TG = interpolate(NodalValC1);
 				else
 					TG = 296.0;
 				MediaProp->CalStressPermeabilityFactor(w, TG);
@@ -2505,7 +2505,7 @@ void CFiniteElementStd::CalCoefLaplace(bool Gravity, int ip)
 			{
 				rhow = FluidProp->Density();
 				// PG = fabs(interpolate(NodalVal1));
-				TG = interpolate(NodalValC) + PhysicalConstant::CelsiusZeroInKelvin;
+				TG = interpolate(NodalValC);
 				poro = MediaProp->Porosity(Index, pcs->m_num->ls_theta);
 				tort = MediaProp->TortuosityFunction(Index, unit, pcs->m_num->ls_theta);
 				humi = exp(PG / (SpecificGasConstant::WaterVapour * TG * rhow));
@@ -2521,7 +2521,7 @@ void CFiniteElementStd::CalCoefLaplace(bool Gravity, int ip)
 		//------------------------------------------------------------------
 		case EPT_GAS_FLOW: // Air flow
 			dens_arg[0] = interpolate(NodalVal1);
-			dens_arg[1] = interpolate(NodalValC1) + PhysicalConstant::CelsiusZeroInKelvin;
+			dens_arg[1] = interpolate(NodalValC1);
 			dens_arg[2] = Index;
 			double vis = FluidProp->Viscosity(dens_arg);
 			mat_fac = vis;
@@ -2680,7 +2680,7 @@ void CFiniteElementStd::CalCoefLaplace2(bool Gravity, int dof_index)
 				dens_arg[0] = PG; // Shdould be Pw in some cases
 				if (diffusion)
 				{
-					TG = interpolate(NodalValC1) + PhysicalConstant::CelsiusZeroInKelvin;
+					TG = interpolate(NodalValC1);
 					dens_arg[1] = TG;
 				}
 				//
@@ -2724,7 +2724,7 @@ void CFiniteElementStd::CalCoefLaplace2(bool Gravity, int dof_index)
 				dens_arg[0] = PG; // Shdould be Pw in some cases
 				if (diffusion)
 				{
-					TG = interpolate(NodalValC1) + PhysicalConstant::CelsiusZeroInKelvin;
+					TG = interpolate(NodalValC1);
 					dens_arg[1] = TG;
 				}
 				// Liquid density
@@ -3431,7 +3431,7 @@ double CFiniteElementStd::CalCoefAdvection()
 			if (FluidProp->density_model == 14 && MediaProp->heat_diffusion_model == 1 && cpl_pcs)
 			{
 				dens_arg[0] = interpolate(NodalValC1);
-				dens_arg[1] = interpolate(NodalVal1) + PhysicalConstant::CelsiusZeroInKelvin;
+				dens_arg[1] = interpolate(NodalVal1);
 				dens_arg[2] = Index;
 				val = FluidProp->SpecificHeatCapacity(dens_arg) * FluidProp->Density(dens_arg);
 			}
@@ -5137,7 +5137,7 @@ void CFiniteElementStd::CalcAdvection()
 		if (multiphase) // 02/2007 WW
 		{
 			dens_aug[0] = interpolate(NodalVal_p2);
-			dens_aug[1] = interpolate(NodalVal1) + PhysicalConstant::CelsiusZeroInKelvin;
+			dens_aug[1] = interpolate(NodalVal1);
 			rho_gw = 0.0;
 			if (MediaProp->heat_diffusion_model == 1)
 			{
@@ -5355,7 +5355,7 @@ void CFiniteElementStd::CalcRHS_by_ThermalDiffusion()
 		getShapefunctValues(gp, 1);
 		double rhow = FluidProp->Density();
 		PG = interpolate(NodalVal1);
-		TG = interpolate(NodalValC) + PhysicalConstant::CelsiusZeroInKelvin;
+		TG = interpolate(NodalValC);
 		// WW
 		Sw = MediaProp->SaturationCapillaryPressureFunction(-PG);
 		poro = MediaProp->Porosity(Index, pcs->m_num->ls_theta);
@@ -5396,7 +5396,7 @@ void CFiniteElementStd::CalcRHS_by_ThermalDiffusion()
 	{
 		for (j = 0; j < nnodes; j++)
 		{
-			(*RHS)[i] -= (*Laplace)(i, j) * (NodalValC[j] + PhysicalConstant::CelsiusZeroInKelvin);
+			(*RHS)[i] -= (*Laplace)(i, j) * (NodalValC[j]);
 			(*RHS)[i] += (*Mass)(i, j) * (NodalValC1[j] - NodalValC[j]) / dt;
 		}
 		eqs_rhs[cshift + eqs_number[i]] += (*RHS)[i];
@@ -9698,7 +9698,7 @@ void CFiniteElementStd::CalcNodeMatParatemer(MeshLib::CElem& elem)
 			if (MediaProp->permeability_stress_mode == 2 || MediaProp->permeability_stress_mode == 3)
 			{
 				if (cpl_pcs)
-					TG = interpolate(NodalValC1) + PhysicalConstant::CelsiusZeroInKelvin;
+					TG = interpolate(NodalValC1);
 				else
 					TG = 293.15;
 				MediaProp->CalStressPermeabilityFactor(w, TG);
@@ -9986,8 +9986,8 @@ double CFiniteElementStd::CalCoef_RHS_T_MPhase(int dof_index)
 		case 0:
 			PG = interpolate(NodalVal1);
 			Sw = MediaProp->SaturationCapillaryPressureFunction(PG);
-			TG = interpolate(NodalValC1) + PhysicalConstant::CelsiusZeroInKelvin;
-			TG0 = interpolate(NodalValC) + PhysicalConstant::CelsiusZeroInKelvin;
+			TG = interpolate(NodalValC1);
+			TG0 = interpolate(NodalValC);
 			PG2 = interpolate(NodalVal_p2);
 			rhow = FluidProp->Density();
 			poro = MediaProp->Porosity(Index, pcs->m_num->ls_theta);
@@ -10174,8 +10174,8 @@ double CFiniteElementStd::CalCoef_RHS_AIR_FLOW(int dof_index)
 	double val = 0.0;
 	int Index = MeshElement->GetIndex();
 	PG = interpolate(NodalVal1);
-	TG = interpolate(NodalValC1) + PhysicalConstant::CelsiusZeroInKelvin;
-	TG0 = interpolate(NodalValC) + PhysicalConstant::CelsiusZeroInKelvin;
+	TG = interpolate(NodalValC1);
+	TG0 = interpolate(NodalValC);
 	switch (dof_index)
 	{
 		case 0:
@@ -10203,11 +10203,11 @@ double CFiniteElementStd::CalCoef_RHS_HEAT_TRANSPORT(int dof_index)
 	int Index = MeshElement->GetIndex();
 	double dens_arg[3];
 	dens_arg[0] = interpolate(NodalValC1);
-	dens_arg[1] = interpolate(NodalVal1) + PhysicalConstant::CelsiusZeroInKelvin;
+	dens_arg[1] = interpolate(NodalVal1);
 	dens_arg[2] = Index;
 	rho_g = FluidProp->Density(dens_arg);
 	dens_arg[0] = 4.0e6;
-	dens_arg[1] = 120 + PhysicalConstant::CelsiusZeroInKelvin;
+	dens_arg[1] = 120;
 	rho_0 = FluidProp->Density(dens_arg);
 
 	switch (dof_index)
@@ -10286,7 +10286,7 @@ void CFiniteElementStd::Assemble_RHS_T_MPhaseFlow()
 				for (j = 0; j < nnodes; j++)
 					for (size_t k = 0; k < dim; k++)
 						NodalVal[i + ii * nnodes] += fac * dshapefct[k * nnodes + i] * dshapefct[k * nnodes + j]
-						                             * (NodalValC1[j] + PhysicalConstant::CelsiusZeroInKelvin);
+						                             * (NodalValC1[j]);
 			}
 		}
 	}
@@ -10721,14 +10721,14 @@ void CFiniteElementStd::Assemble_RHS_AIR_FLOW()
 				for (j = 0; j < nnodes; j++)
 					for (size_t k = 0; k < dim; k++)
 						NodalVal[i + ii * nnodes] += fkt * shapefct[i] * vel[k] * dshapefct[k * nnodes + j]
-						                             * (NodalValC1[j] + PhysicalConstant::CelsiusZeroInKelvin);
+						                             * (NodalValC1[j]);
 		}
 
 		// Body force term
 		if (GravityOn)
 		{
 			dens_arg[0] = interpolate(NodalVal1);
-			dens_arg[1] = interpolate(NodalValC1) + PhysicalConstant::CelsiusZeroInKelvin;
+			dens_arg[1] = interpolate(NodalValC1);
 			dens_arg[2] = Index;
 			fluid_density = FluidProp->Density(dens_arg);
 			mat_fac = FluidProp->Viscosity(dens_arg);
@@ -10849,7 +10849,7 @@ double CFiniteElementStd::CalCoef_RHS_HEAT_TRANSPORT2(int dof_index)
 	double H_vap = 0.0, dens_arg[3];
 	PG = interpolate(NodalValC1);
 	PG2 = interpolate(NodalVal_p2);
-	TG = interpolate(NodalVal1) + PhysicalConstant::CelsiusZeroInKelvin;
+	TG = interpolate(NodalVal1);
 	PG0 = interpolate(NodalValC);
 	PG20 = interpolate(NodalVal_p20);
 	dens_arg[1] = TG;
@@ -10936,7 +10936,7 @@ void CFiniteElementStd::Assemble_RHS_HEAT_TRANSPORT2()
 		// If no gravity, then set GravityOn to be zero.
 		if ((coordinate_system) % 10 != 2 && (!axisymmetry))
 			GravityOn = 0;
-		TG = interpolate(NodalVal1) + PhysicalConstant::CelsiusZeroInKelvin;
+		TG = interpolate(NodalVal1);
 		PG = interpolate(NodalValC1);
 		PG2 = interpolate(NodalVal_p2);
 		dens_arg[1] = TG;
@@ -11026,7 +11026,7 @@ double CFiniteElementStd::CalCoef_RHS_M_MPhase(int dof_index)
 			Sw = MediaProp->SaturationCapillaryPressureFunction(PG);
 			if (diffusion)
 			{
-				TG = interpolate(NodalValC1) + PhysicalConstant::CelsiusZeroInKelvin;
+				TG = interpolate(NodalValC1);
 				dens_aug[1] = TG;
 			}
 			//

--- a/FEM/fem_ele_vec.cpp
+++ b/FEM/fem_ele_vec.cpp
@@ -21,6 +21,9 @@
 #include "matrix_class.h"
 #include "matrix_routines.h"
 #include "pcs_dm.h"
+
+#include "PhysicalConstant.h"
+
 #include "rf_mfp_new.h"
 #include "rf_msp_new.h"
 #include "tools.h" //12.2009. WW
@@ -64,12 +67,13 @@ CFiniteElementVec::CFiniteElementVec(process::CRFProcessDeformation* dm_pcs,
 	const int C_Sys_Flad, const int order)
     : CElement(C_Sys_Flad, order), pcs(dm_pcs), h_pcs(NULL), t_pcs(NULL), excavation(false),
 	  ns((dim == 3)? 6: 4),  _flow_type(NO_PCS),
-      idx_P(-1), idx_P0(-1), idx_P1(-1), idx_P1_0(-1), idx_P2(-1),
+	  idx_P(-1), idx_P0(-1), idx_P1(-1), idx_P1_0(-1), idx_P2(-1),
 	  idx_T0(-1), idx_T1(-1), idx_S0(-1), idx_S(-1), idx_Snw(-1), idx_pls(-1),
 	  idx_p1_ini(-1), idx_p2_ini(-1),
 	  PressureC(NULL), PressureC_S(NULL), PressureC_S_dp(NULL), b_rhs(NULL),
 	  smat(NULL), m_mfp(NULL), m_mmp(NULL),
-	  Temp(NULL), T1(NULL), Tem(273.15 + 23.0), _wettingS(1.), eleV_DM(NULL),
+	  Temp(NULL), T1(NULL), Tem(PhysicalConstant::CelsiusZeroInKelvin + 20.0),
+	  _wettingS(1.), eleV_DM(NULL),
 	  _nodal_p1(NULL), _nodal_p2(NULL), _nodal_cp0(NULL), _nodal_dcp(NULL),
 	  _nodal_S0(NULL), _nodal_S(NULL), AuxNodal1(NULL),
 	  dynamic((dm_pcs->pcs_type_name_vector[0].find("DYNAMIC") != std::string::npos)

--- a/FEM/minkley.cpp
+++ b/FEM/minkley.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "minkley.h"
+#include "PhysicalConstant.h"
 
 namespace Minkley
 {
@@ -62,7 +63,7 @@ SolidMinkley::SolidMinkley(const Math_Group::Matrix& data)
 		m_KM = 0.;
 		Bt = 1.;
 		Q = 0.; // for cutting off Arrhenius term
-		T_ref = 273.15;
+		T_ref = PhysicalConstant::CelsiusZeroInKelvin;
 	}
 }
 

--- a/FEM/rf_bc_new.cpp
+++ b/FEM/rf_bc_new.cpp
@@ -82,7 +82,7 @@ double cputime(double x)
 }
 #endif
 
-CBoundaryConditionNode::CBoundaryConditionNode()
+CBoundaryConditionNode::CBoundaryConditionNode() : node_value_offset(0.0)
 {
 	conditional = false;
 	for (std::size_t i = 0; i < 3; i++)
@@ -1020,7 +1020,10 @@ CBoundaryConditionsGroup::~CBoundaryConditionsGroup(void)
    10/2008 WW/CB SetTransientBCtoNodes
    last modification:
 **************************************************************************/
-void CBoundaryConditionsGroup::Set(CRFProcess* pcs, int ShiftInNodeVector, const std::string& this_pv_name)
+void CBoundaryConditionsGroup::Set(CRFProcess* pcs,
+                                   int ShiftInNodeVector,
+                                   const double value_offset,
+                                   const std::string& this_pv_name)
 {
 	//	long number_of_nodes = 0;
 	long i, j; // WX
@@ -1038,6 +1041,8 @@ void CBoundaryConditionsGroup::Set(CRFProcess* pcs, int ShiftInNodeVector, const
 		_pcs_pv_name = this_pv_name;
 	CFEMesh* m_msh = pcs->m_msh;
 	// Tests //OK
+
+	const std::size_t previous_size = pcs->bc_node_value.size();
 
 	if (!m_msh)
 		std::cout << "Warning in CBoundaryConditionsGroup::Set - no MSH data"
@@ -1658,6 +1663,14 @@ void CBoundaryConditionsGroup::Set(CRFProcess* pcs, int ShiftInNodeVector, const
 	   if(no_bc<1)
 	   cout << "Warning: no boundary conditions specified for " << pcs_type_name << "\n";
 	 */
+	if (std::fabs(value_offset) > 0.0)
+	{
+		for (std::size_t i = previous_size; i < pcs->bc_node_value.size(); i++)
+		{
+			pcs->bc_node_value[i]->node_value_offset = value_offset;
+		}
+	}
+
 	end_time = clock();
 	std::cout << "\t[BC] set transient BC took " << (end_time - start_time) / (double)(CLOCKS_PER_SEC) << "\n";
 }

--- a/FEM/rf_bc_new.h
+++ b/FEM/rf_bc_new.h
@@ -213,6 +213,7 @@ public:
 	long msh_node_number_subst; // WW
 
 	double node_value;
+	double node_value_offset;
 	double node_value_pre_calc;
 	int CurveIndex; // Time dependent function index
 	std::string pcs_pv_name; // YD/WW
@@ -241,7 +242,7 @@ public:
 	CBoundaryConditionsGroup(void);
 	~CBoundaryConditionsGroup(void);
 
-	void Set(CRFProcess* pcs, int ShiftInNodeVector, const std::string& this_pv_name = "");
+	void Set(CRFProcess* pcs, int ShiftInNodeVector, const double value_offset, const std::string& this_pv_name = "");
 	CBoundaryConditionsGroup* Get(const std::string&);
 
 	const std::string& getProcessTypeName() const { return _pcs_type_name; }

--- a/FEM/rf_kinreact.cpp
+++ b/FEM/rf_kinreact.cpp
@@ -42,6 +42,7 @@
 #include "tools.h"
 #include "rf_react.h"
 #include "rf_react_int.h"
+#include "PhysicalConstant.h"
 
 #ifdef OGS_FEM_CAP // CAP_REACT  //CB merge CAP 0311
 #include "rf_react_cap.h"
@@ -7710,7 +7711,7 @@ void CKinReactData::PreprocessMinKin()
 
 		// then calculate T dependent parameters A & B, from Groundwater Geochemistry, Broder Merkel
 		// Todo: get T
-		TC = T - 273.15;
+		TC = T - PhysicalConstant::CelsiusZeroInKelvin;
 		dens = 1 - (TC - 3.9863) * (TC - 3.9863) * (TC + 288.9414) / 508929.2 / (TC + 68.12963)
 		       + 0.011445 * exp(-374.3 / TC);
 		epsi = 2727.586 + 0.6224107 * T - 466.9151 * log(T) - 52000.87 / T;

--- a/FEM/rf_mfp_new.cpp
+++ b/FEM/rf_mfp_new.cpp
@@ -926,7 +926,7 @@ void CFluidProperties::CalPrimaryVariable(std::vector<std::string>& pcs_name_vec
 		return;
 
 	primary_variable[0] = 0;
-	primary_variable[1] = 0;
+	primary_variable[1] = T_0;
 	primary_variable[2] = 0;
 
 	for (int i = 0; i < (int)pcs_name_vector.size(); i++)
@@ -983,8 +983,6 @@ double CFluidProperties::Density(double* variables)
 	//----------------------------------------------------------------------
 	if (variables) // This condition is added by WW
 	{
-		if (!T_Process)
-			variables[1] = T_0;
 		//----------------------------------------------------------------------
 		// Duplicate the following lines just to enhance computation. WW
 		switch (density_model)
@@ -1126,8 +1124,6 @@ double CFluidProperties::Density(double* variables)
 	{
 		CalPrimaryVariable(density_pcs_name_vector);
 
-		if (!T_Process)
-			primary_variable[1] = T_0;
 		//----------------------------------------------------------------------
 		switch (density_model)
 		{
@@ -1589,8 +1585,6 @@ double CFluidProperties::Viscosity(double* variables)
 				primary_variable[1] = m_pcs->GetNodeValue(node, m_pcs->GetNodeValueIndex("TEMPERATURE1") + 1);
 			}
 			// ToDo pcs_name
-			if (!T_Process)
-				primary_variable[1] = T_0;
 			// used within this model
 			viscosity = LiquidViscosity_Yaws_1976(primary_variable[1]);
 			break;
@@ -1611,9 +1605,6 @@ double CFluidProperties::Viscosity(double* variables)
 		case 9: // viscosity as function of density and temperature, NB
 		{
 			double mfp_arguments[2];
-
-			if (!T_Process)
-				primary_variable[1] = T_0;
 			// TODO: switch case different models...
 			// Problem.cpp 3 PS_GLOBAL, 1212,1313 pcs_type
 			// TODO: default fluid_ID, if not specified

--- a/FEM/rf_mfp_new.cpp
+++ b/FEM/rf_mfp_new.cpp
@@ -2143,7 +2143,7 @@ double MFPCalcFluidsHeatCapacity(CFiniteElementStd* assem)
 		PG = assem->interpolate(assem->NodalValC1);
 		Sw = assem->MediaProp->SaturationCapillaryPressureFunction(PG);
 		double PG2 = assem->interpolate(assem->NodalVal_p2);
-		TG = assem->interpolate(assem->NodalVal1) + PhysicalConstant::CelsiusZeroInKelvin;
+		TG = assem->interpolate(assem->NodalVal1);
 		rhow = assem->FluidProp->Density();
 		rho_gw = assem->FluidProp->vaporDensity(TG) * exp(-PG / (rhow * SpecificGasConstant::WaterVapour * TG));
 		p_gw = rho_gw * SpecificGasConstant::WaterVapour * TG;

--- a/FEM/rf_mfp_new.cpp
+++ b/FEM/rf_mfp_new.cpp
@@ -15,10 +15,7 @@
    last modified:
 **************************************************************************/
 #include "makros.h"
-// C++ STL
-//#include <math.h>
-//#include <fstream>
-//#include <iostream>
+
 #include <cfloat>
 
 // FEM-Makros
@@ -469,8 +466,6 @@ std::ios::pos_type CFluidProperties::Read(std::ifstream* mfp_file)
 			}
 			if (viscosity_model == 3) // my(T), Yaws et al. (1976)
 			{ // optional: read reference temperature for viscosity model
-				std::string arg1;
-				in >> arg1; // get one optional argument
 				viscosity_pcs_name_vector.push_back("PRESSURE1"); // JM dummy wird benoetigt!
 				// OK4704
 				viscosity_pcs_name_vector.push_back("TEMPERATURE1");

--- a/FEM/rf_mfp_new.cpp
+++ b/FEM/rf_mfp_new.cpp
@@ -67,7 +67,8 @@ double TemperatureUnitOffset()
    Programing:
    08/2004 OK Implementation
 **************************************************************************/
-CFluidProperties::CFluidProperties() : name("WATER")
+CFluidProperties::CFluidProperties() : name("WATER"),
+	_reference_temperature(PhysicalConstant::CelsiusZeroInKelvin + 20.0)
 {
 	phase = 0;
 	// Density
@@ -331,7 +332,6 @@ std::ios::pos_type CFluidProperties::Read(std::ifstream* mfp_file)
 				in >> T_0;
 				T_0 += TemperatureUnitOffset();
 				in >> drho_dT;
-				T_0 += TemperatureUnitOffset();
 				density_pcs_name_vector.push_back("TEMPERATURE1");
 			}
 			if (density_model == 5) // rho(C,T) = rho_0*(1+beta_C*(C-C_0)+beta_T*(T-T_0))
@@ -926,7 +926,7 @@ void CFluidProperties::CalPrimaryVariable(std::vector<std::string>& pcs_name_vec
 		return;
 
 	primary_variable[0] = 0;
-	primary_variable[1] = T_0;
+	primary_variable[1] = 0.;
 	primary_variable[2] = 0;
 
 	for (int i = 0; i < (int)pcs_name_vector.size(); i++)
@@ -952,9 +952,17 @@ void CFluidProperties::CalPrimaryVariable(std::vector<std::string>& pcs_name_vec
 			primary_variable_t0[i] = Fem_Ele_Std->elemnt_average(nidx0, m_pcs);
 			primary_variable_t1[i] = Fem_Ele_Std->elemnt_average(nidx1, m_pcs);
 		}
-		if (mode == 3) // NB, just testing
-
+		else if (mode == 3) // NB, just testing
+		{
 			primary_variable[i] = Fem_Ele_Std->interpolate(nidx0, m_pcs);
+		}
+		else
+		{
+			if (pcs_name_vector[i].compare("TEMPERATURE1") == 0)
+			{
+				primary_variable[i] = _reference_temperature;
+			}
+		}
 	}
 }
 

--- a/FEM/rf_mfp_new.h
+++ b/FEM/rf_mfp_new.h
@@ -96,6 +96,7 @@ public:
 	double PhaseDiffusion(double* variables = NULL);
 	double SpecificHeatCapacity(double* variables = NULL);
 	void therm_prop(std::string caption); // NB 4.9.05
+	double PhaseChange(); // JOD
 	double HeatConductivity(double* variables = NULL);
 	double CalcEnthalpy(double temperature);
 

--- a/FEM/rf_mfp_new.h
+++ b/FEM/rf_mfp_new.h
@@ -96,7 +96,6 @@ public:
 	double PhaseDiffusion(double* variables = NULL);
 	double SpecificHeatCapacity(double* variables = NULL);
 	void therm_prop(std::string caption); // NB 4.9.05
-	double PhaseChange(); // JOD
 	double HeatConductivity(double* variables = NULL);
 	double CalcEnthalpy(double temperature);
 
@@ -210,7 +209,6 @@ private:
 	double viscosity;
 	double viscosity0;
 	double viscosity_T_star;
-	double viscosity_T_shift; // JM in order to use some viscosity functions, based on total temperature, within
 	// Richards
 	double my_0;
 	double dmy_dp;

--- a/FEM/rf_mfp_new.h
+++ b/FEM/rf_mfp_new.h
@@ -225,6 +225,8 @@ private:
 	double heat_conductivity;
 	double temperature_buffer; // YD, shifted to public JOD
 
+	const double _reference_temperature;
+
 	// State variables
 	double p_0;
 	/**

--- a/FEM/rf_mmp_new.cpp
+++ b/FEM/rf_mmp_new.cpp
@@ -2625,7 +2625,7 @@ double* CMediumProperties::HeatConductivityTensor(int number)
 			{
 				double dens_arg[3];
 				dens_arg[0] = Fem_Ele_Std->interpolate(Fem_Ele_Std->NodalValC1); // Pressure
-				dens_arg[1] = Fem_Ele_Std->interpolate(Fem_Ele_Std->NodalVal1) + 273.15; // Temperature
+				dens_arg[1] = Fem_Ele_Std->interpolate(Fem_Ele_Std->NodalVal1); // Temperature
 				dens_arg[2] = Fem_Ele_Std->Index; // ELE index
 				heat_conductivity_fluids = Fem_Ele_Std->FluidProp->HeatConductivity(dens_arg);
 			}
@@ -2669,7 +2669,7 @@ double* CMediumProperties::HeatConductivityTensor(int number)
 		// Capillary pressure
 		double PG = Fem_Ele_Std->interpolate(Fem_Ele_Std->NodalValC1);
 		// Temperature
-		double TG = Fem_Ele_Std->interpolate(Fem_Ele_Std->NodalVal1) + 273.15;
+		double TG = Fem_Ele_Std->interpolate(Fem_Ele_Std->NodalVal1);
 		double Sw = Fem_Ele_Std->MediaProp->SaturationCapillaryPressureFunction(PG);
 		heat_conductivity_fluids = 0.0;
 		H_vap = 2257000; // pow((Tc - TG),0.38)*2.65E+5;
@@ -3724,7 +3724,7 @@ double CMediumProperties::Porosity(long number, double theta)
 	   int i;
 	   double w[3], TG = 0.0;
 	   if(assem->cpl_pcs)
-	      TG = assem->interpolate(assem->NodalValC1)+273.15;
+	      TG = assem->interpolate(assem->NodalValC1);
 	   else
 	      TG = 296.0;
 	   CalStressPermeabilityFactor(w, TG);
@@ -4055,7 +4055,7 @@ double CMediumProperties::PorosityEffectiveConstrainedSwellingConstantIonicStren
 	/* Interlayer Porositaet berechnen */
 	if (temperature < 0.0 || temperature > 600.0)
 		temperature = 298.0; // ToDo, MX
-	epsilon = 87.0 + exp(-0.00456 * (temperature - 273.0));
+	epsilon = 87.0 + exp(-0.00456 * (temperature - PhysicalConstant::CelsiusZeroInKelvin));
 	porosity_n = porosity_model_values[0];
 
 	/* Maximal inter layer porosity */
@@ -6403,7 +6403,7 @@ double CMediumProperties::PorosityVolumetricFreeSwellingConstantIonicstrength(lo
 	   //--------------------------------------------------------------------
 	   // Interlayer porosity calculation
 	   if (abs(temperature)>1.0e10) temperature=298.0;  //TODO MX
-	   epsilon = 87.0 + exp(-0.00456*(temperature-273.0));
+	   epsilon = 87.0 + exp(-0.00456*(temperature-PhysicalConstant::CelsiusZeroInKelvin));
 	   porosity_n = porosity_model_values[0];
 	   // Maximal inter layer porosity
 	   porosity_IL = fmon * psi * mat_mp_m * S_0 * (density_rock * 1.0e3) \
@@ -6493,7 +6493,7 @@ double CMediumProperties::PorosityEffectiveConstrainedSwelling(long index,
 	   //-----------------------------------------------------------------------
 	   // Interlayer Porositaet berechnen
 	   if (abs(temperature)>1.0e10) temperature=298.0;  //TODO MX
-	   epsilon =87.0+exp(-0.00456*(temperature-273.0));
+	   epsilon =87.0+exp(-0.00456*(temperature-PhysicalConstant::CelsiusZeroInKelvin));
 	   porosity_n = porosity_model_values[0];
 
 	   // Maximal inter layer porosity
@@ -6588,7 +6588,7 @@ double CMediumProperties::PorosityVolumetricFreeSwelling(long index, double satu
 	   satu_0 =       porosity_model_values[5];       // Initial saturation, if the sample is homogenous [-]
 	   //--------------------------------------------------------------------
 	   // Interlayer porosity calculation
-	   epsilon = 87.0 + exp(-0.00456*(temperature-273.0));
+	   epsilon = 87.0 + exp(-0.00456*(temperature-PhysicalConstant::CelsiusZeroInKelvin));
 	   porosity_n = porosity_model_values[0];
 	   // Maximal inter layer porosity
 	   porosity_IL = fmon * psi * mat_mp_m * S_0 * (density_rock * 1.0e3) \

--- a/FEM/rf_mmp_new.h
+++ b/FEM/rf_mmp_new.h
@@ -28,6 +28,8 @@
 #include "GeoType.h"
 #include "makros.h" // JT
 
+#include "PhysicalConstant.h"
+
 // PCSLib
 #include "rf_pcs.h"
 
@@ -120,9 +122,9 @@ public:
 	// WW
 	double KozenyCarmanNew(double k_init, double n_init, double n_t); // AB
 	double VermaPruess(double k_init, double n_init, double n_t); // AB
-	void CalStressPermeabilityFactor(double* kfac, const double T = 273.0);
+	void CalStressPermeabilityFactor(double* kfac, const double T = PhysicalConstant::CelsiusZeroInKelvin);
 	// WW
-	void CalStressPermeabilityFactor2(double* kfac, const double T = 273.0);
+	void CalStressPermeabilityFactor2(double* kfac, const double T = PhysicalConstant::CelsiusZeroInKelvin);
 	// WW
 	void CalStressPermeabilityFactor3(double* kfac);
 	void CalStressPermeabilityFactor3_Coef(); // WW

--- a/FEM/rf_msp_new.cpp
+++ b/FEM/rf_msp_new.cpp
@@ -1333,8 +1333,7 @@ double CSolidProperties::Heat_Capacity(double refence)
 			val = (*data_Capacity)(0);
 			break;
 		case 3:
-			// WW        val=1.38*(273.15+refence)+732.5;
-			val = 1.38 * refence + 732.5;
+			val = 1.38 * (refence - PhysicalConstant::CelsiusZeroInKelvin) + 732.5;
 			break;
 		case 4: // solid capacity depending on solid density (for thermochemical heat storage) - TN
 			// refence contains value of solid density (current)

--- a/FEM/rf_msp_new.cpp
+++ b/FEM/rf_msp_new.cpp
@@ -7858,19 +7858,19 @@ void CSolidProperties::AddStain_by_Creep(const int ns, double* stress_n, double*
 		case 2:
 			// gas constant = R = 8.314472(15) J ?K-1 ?mol-1
 			// ec= A*exp(-G/RT)s^n
-			fac = 1.5 * dt * (*data_Creep)(0) * exp(-(*data_Creep)(2) / (8.314472 * temperature))
+			fac = 1.5 * dt * (*data_Creep)(0) * exp(-(*data_Creep)(2) / (PhysicalConstant::IdealGasConstant * temperature))
 			      * pow(norn_S, (*data_Creep)(1));
 			break;
 		// TN: BGRb
 		case 3:
-			fac = 1.5 * dt * ((*data_Creep)(0) * exp(-(*data_Creep)(2) / (8.314472 * temperature))
+			fac = 1.5 * dt * ((*data_Creep)(0) * exp(-(*data_Creep)(2) / (PhysicalConstant::IdealGasConstant * temperature))
 			                      * pow(norn_S, (*data_Creep)(1))
-			                  + (*data_Creep)(3) * exp(-(*data_Creep)(5) / (8.314472 * temperature))
+			                  + (*data_Creep)(3) * exp(-(*data_Creep)(5) / (PhysicalConstant::IdealGasConstant * temperature))
 			                        * pow(norn_S, (*data_Creep)(4)));
 			break;
 		// TN: BGRsf
 		case 4:
-			fac = 1.5 * dt * ((*data_Creep)(0) * exp(-(*data_Creep)(2) / (8.314472 * temperature))
+			fac = 1.5 * dt * ((*data_Creep)(0) * exp(-(*data_Creep)(2) / (PhysicalConstant::IdealGasConstant * temperature))
 			                      * pow(norn_S, (*data_Creep)(1))
 			                  + (*data_Creep)(4) * pow(norn_S, 2));
 			break;

--- a/FEM/rf_msp_new.cpp
+++ b/FEM/rf_msp_new.cpp
@@ -54,6 +54,12 @@ using namespace std;
 using FiniteElement::ElementValue_DM;
 using Math_Group::Matrix;
 
+
+double TemperatureUnitOffset()
+{
+	return process::isTemperatureUnitCesius() ? PhysicalConstant::CelsiusZeroInKelvin : 0.0;
+}
+
 /**************************************************************************
    FEMLib-Method:
    Task: OBJ read function
@@ -214,6 +220,8 @@ std::ios::pos_type CSolidProperties::Read(std::ifstream* msp_file)
 					data_Capacity = new Matrix(5);
 					for (i = 0; i < 5; i++)
 						in_sd >> (*data_Capacity)(i);
+					(*data_Capacity)(2) += TemperatureUnitOffset();
+					(*data_Capacity)(3) += TemperatureUnitOffset();
 					in_sd.clear();
 					break;
 				case 3: // DECOVALEX THM1, Bentonite
@@ -291,6 +299,8 @@ std::ios::pos_type CSolidProperties::Read(std::ifstream* msp_file)
 					data_Conductivity = new Matrix(4);
 					for (i = 0; i < 4; i++)
 						in_sd >> (*data_Conductivity)(i);
+					(*data_Capacity)(2) += TemperatureUnitOffset();
+					(*data_Capacity)(3) += TemperatureUnitOffset();
 					in_sd.clear();
 					capacity_pcs_name_vector.push_back("TEMPERATURE1");
 					capacity_pcs_name_vector.push_back("SATURATION1");
@@ -323,6 +333,7 @@ std::ios::pos_type CSolidProperties::Read(std::ifstream* msp_file)
 					break;
 				case 5: // DECOVALEX2015, Task B2, Buffer: f(S,T) by matrix function
 					in_sd >> T_0;
+					T_0 += TemperatureUnitOffset();
 					in_sd.clear();
 					conductivity_pcs_name_vector.push_back("TEMPERATURE1");
 					conductivity_pcs_name_vector.push_back("SATURATION1");
@@ -604,6 +615,7 @@ std::ios::pos_type CSolidProperties::Read(std::ifstream* msp_file)
 					(*data_Creep)(i) = 0.;
 					in_sd >> (*data_Creep)(i);
 				}
+				(*data_Creep)(10) += TemperatureUnitOffset();
 				in_sd.clear();
 
 				// Local Newton scheme for Burgers model. TN 06.06.2014
@@ -641,6 +653,7 @@ std::ios::pos_type CSolidProperties::Read(std::ifstream* msp_file)
 					(*data_Creep)(i) = 0.;
 					in_sd >> (*data_Creep)(i);
 				}
+				(*data_Creep)(15) += TemperatureUnitOffset();
 				in_sd.clear();
 
 				// Local Newton scheme for Burgers model. TN 06.06.2014
@@ -906,6 +919,7 @@ std::ios::pos_type CSolidProperties::Read(std::ifstream* msp_file)
 		{
 			in_sd.str(GetLineFromFile1(msp_file));
 			in_sd >> T_ref_enthalpy_correction;
+			T_ref_enthalpy_correction += TemperatureUnitOffset();
 			in_sd.clear();
 		}
 
@@ -7844,19 +7858,19 @@ void CSolidProperties::AddStain_by_Creep(const int ns, double* stress_n, double*
 		case 2:
 			// gas constant = R = 8.314472(15) J ?K-1 ?mol-1
 			// ec= A*exp(-G/RT)s^n
-			fac = 1.5 * dt * (*data_Creep)(0) * exp(-(*data_Creep)(2) / (8.314472 * (temperature + 273.15)))
+			fac = 1.5 * dt * (*data_Creep)(0) * exp(-(*data_Creep)(2) / (8.314472 * temperature))
 			      * pow(norn_S, (*data_Creep)(1));
 			break;
 		// TN: BGRb
 		case 3:
-			fac = 1.5 * dt * ((*data_Creep)(0) * exp(-(*data_Creep)(2) / (8.314472 * (temperature + 273.15)))
+			fac = 1.5 * dt * ((*data_Creep)(0) * exp(-(*data_Creep)(2) / (8.314472 * temperature))
 			                      * pow(norn_S, (*data_Creep)(1))
-			                  + (*data_Creep)(3) * exp(-(*data_Creep)(5) / (8.314472 * (temperature + 273.15)))
+			                  + (*data_Creep)(3) * exp(-(*data_Creep)(5) / (8.314472 * temperature))
 			                        * pow(norn_S, (*data_Creep)(4)));
 			break;
 		// TN: BGRsf
 		case 4:
-			fac = 1.5 * dt * ((*data_Creep)(0) * exp(-(*data_Creep)(2) / (8.314472 * (temperature + 273.15)))
+			fac = 1.5 * dt * ((*data_Creep)(0) * exp(-(*data_Creep)(2) / (8.314472 * temperature))
 			                      * pow(norn_S, (*data_Creep)(1))
 			                  + (*data_Creep)(4) * pow(norn_S, 2));
 			break;
@@ -7936,7 +7950,7 @@ void CSolidProperties::AddStain_by_HL_ODS(const ElementValue_DM* ele_val, double
 	double max_etr = norn_S / ((*data_Creep)(6, 0) * exp((*data_Creep)(4, 0) * norn_S)); // WX:12.2012 bug fixed
 	double eta_k = (*data_Creep)(3, 0) * exp((*data_Creep)(5, 0) * norn_S);
 	double eta_m
-	    = (*data_Creep)(0, 0) * exp((*data_Creep)(1, 0) * norn_S) * exp((temperature + 273.16) * (*data_Creep)(2, 0));
+	    = (*data_Creep)(0, 0) * exp((*data_Creep)(1, 0) * norn_S) * exp(temperature * (*data_Creep)(2, 0));
 	if (max_etr < DBL_EPSILON)
 		return;
 	if (threshold_dev_str >= 0)

--- a/FEM/rf_pcs.cpp
+++ b/FEM/rf_pcs.cpp
@@ -193,6 +193,18 @@ vector<int> pcs_number_mass; // JT2012
 namespace process
 {
 class CRFProcessDeformation;
+
+bool isTemperatureUnitCesius()
+{
+	for (std::size_t i = 0; i < pcs_vector.size(); i++)
+	{
+		if (pcs_vector[i]->getTemperatureUnit() == FiniteElement::CELSIUS)
+		{
+			return true;
+		}
+	}
+	return false;
+}
 }
 using process::CRFProcessDeformation;
 using MeshLib::CNode;

--- a/FEM/rf_pcs.cpp
+++ b/FEM/rf_pcs.cpp
@@ -194,16 +194,17 @@ namespace process
 {
 class CRFProcessDeformation;
 
+// For the condition of the default temperature being CELSIUS
 bool isTemperatureUnitCesius()
 {
 	for (std::size_t i = 0; i < pcs_vector.size(); i++)
 	{
-		if (pcs_vector[i]->getTemperatureUnit() == FiniteElement::CELSIUS)
+		if (pcs_vector[i]->getTemperatureUnit() == FiniteElement::KELVIN)
 		{
-			return true;
+			return false;
 		}
 	}
-	return false;
+	return true;
 }
 }
 using process::CRFProcessDeformation;

--- a/FEM/rf_pcs.cpp
+++ b/FEM/rf_pcs.cpp
@@ -55,11 +55,8 @@
 // GEOLib
 #include "PointWithID.h"
 
-/*------------------------------------------------------------------------*/
-/* MshLib */
-//#include "msh_elem.h"
-//#include "msh_lib.h"
-/*-----------------------------------------------------------------------*/
+#include "PhysicalConstant.h"
+
 /* Objects */
 #include "pcs_dm.h"
 #include "rf_pcs.h"
@@ -1963,6 +1960,17 @@ std::ios::pos_type CRFProcess::Read(std::ifstream* pcs_file)
 			pcs_file->ignore(MAX_ZEILE, '\n');
 			continue;
 		}
+
+		if (line_string.find("$TEMPERATURE_UNIT") != string::npos)
+		{
+			std::string T_unit_name;
+			*pcs_file >> T_unit_name;
+			pcs_file->ignore(MAX_ZEILE, '\n');
+			_temp_unit = (T_unit_name.find("CELSIUS") != std::string::npos ) ?
+						FiniteElement::CELSIUS : FiniteElement::KELVIN;
+			continue;
+		}
+
 		//....................................................................
 		// subkeyword found
 		if (line_string.find("$ELEMENT_MATRIX_OUTPUT") != string::npos)

--- a/FEM/rf_pcs.h
+++ b/FEM/rf_pcs.h
@@ -1063,4 +1063,9 @@ extern REACT_BRNS* m_vec_BRNS;
 #endif
 
 extern bool hasAnyProcessDeactivatedSubdomains; // NW
+
+namespace process
+{
+bool isTemperatureUnitCesius();
+}
 #endif

--- a/FEM/rf_react.cpp
+++ b/FEM/rf_react.cpp
@@ -683,10 +683,8 @@ int REACT::WriteInputPQCString(long index, /*ifstream *pqc_iinfile,*/ stringstre
 						m_pcs = PCSGet("HEAT_TRANSPORT");
 						idx = m_pcs->GetNodeValueIndex("TEMPERATURE1");
 						dval = m_pcs->GetNodeValue(index, idx);
-						if (dval < 273.0)
-							dval += 273.15; // change from °C to Kelvin if necessary
-						dval -= 273.15; // Input to PHREEQC is in °C
-						*out_buff << "temp " << dval << "  # temp "
+						// Input to PHREEQC is in °C
+						*out_buff << "temp " << dval - PhysicalConstant::CelsiusZeroInKelvin << "  # temp "
 						          << "\n";
 						temp = dval; // save for gas phase input
 					}
@@ -843,7 +841,7 @@ int REACT::WriteInputPQCString(long index, /*ifstream *pqc_iinfile,*/ stringstre
 				mm += dval;
 			}
 			//  calculate Volume of gas phase in [mol * Pa * m^3 / K / mol * K / Pa = m^3 ]
-			volume = mm * 8.314472 * (273.15 + temp) / press;
+			volume = mm * 8.314472 * temp / press;
 			while (line_string.find("#ende") == string::npos)
 			{
 				pqc_infile.getline(line, MAX_ZEILE);
@@ -856,7 +854,7 @@ int REACT::WriteInputPQCString(long index, /*ifstream *pqc_iinfile,*/ stringstre
 					*out_buff << "        -volume       " << volume * 1000.0 << "\n";
 				else if (line_string.find("-temperature") != string::npos)
 					// temperature in °Celsius
-					*out_buff << "        -temperature       " << temp << "\n";
+					*out_buff << "        -temperature       " << temp - PhysicalConstant::CelsiusZeroInKelvin << "\n";
 				else if (line_string.find("# comp") != string::npos)
 				{
 					count++;
@@ -2240,6 +2238,7 @@ int REACT::ReadReactionModelNew(ifstream* pqc_infile)
 						in.str(line_string);
 						// save temperature
 						in >> speciesname >> this->temperature;
+						temperature += process::isTemperatureUnitCesius() ? PhysicalConstant::CelsiusZeroInKelvin : 0.0; 
 						in.clear();
 					}
 			}
@@ -2585,9 +2584,7 @@ int REACT::ReadInputPhreeqc(long index, FILE* fpqc, FILE* Fphinp)
 								//                        printf("Temperature is %lf", val_in[iheat][index]);
 								/* convert temperature from Kelvin to degree celsius for PHREEQC */
 								// MX 03.05
-								if (val_in[iheat][index] < 273.0)
-									val_in[iheat][index] += 273.15;
-								FilePrintDouble(f, val_in[iheat][index] - 273.15);
+								FilePrintDouble(f, val_in[iheat][index] - PhysicalConstant::CelsiusZeroInKelvin);
 								FilePrintString(f, " # temp ");
 								LineFeed(f);
 							}
@@ -3158,10 +3155,7 @@ int REACT::WriteInputPhreeqc(long index, /*ifstream *pqc_iinfile,*/ ofstream* ou
 						m_pcs = PCSGet("HEAT_TRANSPORT");
 						idx = m_pcs->GetNodeValueIndex("TEMPERATURE1");
 						dval = m_pcs->GetNodeValue(index, idx);
-						if (dval < 273.0)
-							dval += 273.15; // change from °C to Kelvin if necessary
-						dval -= 273.15; // Input to PHREEQC is in °C
-						*out_file << "temp " << dval << "  # temp "
+						*out_file << "temp " << dval - PhysicalConstant::CelsiusZeroInKelvin << "  # temp "
 						          << "\n";
 						temp = dval; // save for gas phase input
 					}
@@ -3359,7 +3353,7 @@ int REACT::WriteInputPhreeqc(long index, /*ifstream *pqc_iinfile,*/ ofstream* ou
 			}
 
 			//  calculate Volume of gas phase in [mol * Pa * m^3 / K / mol * K / Pa = m^3 ]
-			volume = mm * 8.314472 * (273.15 + temp) / press;
+			volume = mm * 8.314472 * temp / press;
 
 			while (line_string.find("#ende") == string::npos)
 			{
@@ -4871,10 +4865,8 @@ int REACT::WriteInputPhreeqcLib(long index, stringstream* out_buff, int* nl)
 						m_pcs = PCSGet("HEAT_TRANSPORT");
 						idx = m_pcs->GetNodeValueIndex("TEMPERATURE1");
 						dval = m_pcs->GetNodeValue(index, idx);
-						if (dval < 273.0)
-							dval += 273.15; // change from °C to Kelvin if necessary
-						dval -= 273.15; // Input to PHREEQC is in °C
-						*out_buff << "temp " << dval << "\n";
+						// Input to PHREEQC is in °C
+						*out_buff << "temp " << dval - PhysicalConstant::CelsiusZeroInKelvin << "\n";
 						nline++;
 						temp = dval; // save for gas phase input
 					}
@@ -5020,7 +5012,7 @@ int REACT::WriteInputPhreeqcLib(long index, stringstream* out_buff, int* nl)
 			}
 
 			//  calculate Volume of gas phase in [mol * Pa * m^3 / K / mol * K / Pa = m^3 ]
-			volume = mm * 8.314472 * (273.15 + temp) / press;
+			volume = mm * 8.314472 * temp / press;
 
 			while (line_string.find("#ende") == string::npos)
 			{


### PR DESCRIPTION
As titled.

With the changes, the temperature unit is set to Kelvin in the calculation. 

For the input data, there is an option to select the  the temperature unit by a new keyword of process: 
 `$TEMPERATURE_UNIT` with a value of  `KELVIN` or `CELSIUS`.

If  `CELSIUS` is selected for `$TEMPERATURE_UNIT`,  the temperature data in  initial conditions, Dirichlet boundary conditions and material properties are converted to the data in Kelvin during the initialization of the instance of process class, and the output of temperature result keeps in Celsius.

Questions: 
1. Do we need temperature unit option?
2. If we need it, which temperature unit should be the default one? One can omit the keyword of `$TEMPERATURE_UNIT` if the temperature unit is the same as the default. 
In the present implementation, the default temperature is Celsius. Most of temperature related benchmarks take Kelvin, while some applications  of projects use Celsius. If Kelvin is set as default temperature unit, the changes in PR ufz/ogs5-benchmarks#20 will drop.

Benchmarks results:
Most of temperature related benchmarks satisfy with the current changes and keep quiet during the result comparison. Only the THM benchmarks show tiny difference in the result comparison (see ufz/ogs5-benchmarks_ref#30).




