### PR TITLE
IAPWS models of water density and viscosity

### DIFF
--- a/FEM/CMakeLists.txt
+++ b/FEM/CMakeLists.txt
@@ -55,6 +55,7 @@ set( HEADERS
 	ShapeFunctionPool.h
 	Material/Fluid/GibbsFreeEnergy/DimensionLessGibbsFreeEnergyRegion1.h
 	Material/Fluid/Density/WaterDensityIAPWSIF97Region1.h
+	Material/Fluid/Viscosity/WaterViscosityIAPWS.h
 )
 
 set( SOURCES
@@ -113,6 +114,7 @@ set( SOURCES
 	vtk.cpp
 	ShapeFunctionPool.cpp
 	Material/Fluid/GibbsFreeEnergy/DimensionLessGibbsFreeEnergyRegion1.cpp
+	Material/Fluid/Viscosity/WaterViscosityIAPWS.cpp
 )
 
 if(NOT OGS_LSOLVER STREQUAL PETSC)

--- a/FEM/CMakeLists.txt
+++ b/FEM/CMakeLists.txt
@@ -53,6 +53,8 @@ set( HEADERS
 	vtk.h
 	OutputTools.h
 	ShapeFunctionPool.h
+	Material/Fluid/GibbsFreeEnergy/DimensionLessGibbsFreeEnergyRegion1.h
+	Material/Fluid/Density/WaterDensityIAPWSIF97Region1.h
 )
 
 set( SOURCES
@@ -110,6 +112,7 @@ set( SOURCES
 	tools.cpp
 	vtk.cpp
 	ShapeFunctionPool.cpp
+	Material/Fluid/GibbsFreeEnergy/DimensionLessGibbsFreeEnergyRegion1.cpp
 )
 
 if(NOT OGS_LSOLVER STREQUAL PETSC)

--- a/FEM/Material/Fluid/Density/WaterDensityIAPWSIF97Region1.h
+++ b/FEM/Material/Fluid/Density/WaterDensityIAPWSIF97Region1.h
@@ -1,0 +1,88 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * \file   WaterDensityIAPWSIF97Region1.h
+ *
+ * Created on December 8, 2016, 4:19 PM
+ */
+
+#pragma once
+
+#include <string>
+
+#include "Material/Fluid/GibbsFreeEnergy/DimensionLessGibbsFreeEnergyRegion1.h"
+
+namespace MaterialLib
+{
+namespace Fluid
+{
+/** Water density model
+ *  base on the IAPWS Industrial Formulation 1997
+ *  <a href="http://www.iapws.org/relguide/IF97-Rev.pdf">IF97-Rev</a>
+ */
+class WaterDensityIAPWSIF97Region1
+{
+public:
+    WaterDensityIAPWSIF97Region1()
+        : _gibbs_free_energy(DimensionLessGibbsFreeEnergyRegion1()),
+          _ref_T(1386.0), _ref_p(1.653e7), _sR(461.526) {}
+
+    /**  Get density value.
+         \param p   Pressure.
+         \param T   Temperature.
+    */
+    double getValue(const double p, const double T)
+    {
+        const double tau = _ref_T / T;
+        const double pi = p / _ref_p;
+
+        return _ref_p / (_sR * T * _gibbs_free_energy.get_dgamma_dpi(tau, pi));
+    }
+
+    /**
+     *  Get the partial differential of the density with respect to temperature.
+     *  \param p   Pressure.
+     *  \param T   Temperature.
+     */
+    double getdValuedT(const double p, const double T)
+    {
+        const double tau = _ref_T / T;
+        const double pi = p / _ref_p;
+
+        const double dgamma_dpi = _gibbs_free_energy.get_dgamma_dpi(tau, pi);
+        return -(_ref_p - tau * _ref_p *
+               _gibbs_free_energy.get_dgamma_dtau_dpi(tau, pi) / dgamma_dpi)
+			   / (_sR * T * T * dgamma_dpi);
+    }
+
+	
+	/**
+     *  Get the partial differential of the density with respect to pressure.
+     *  \param p   Pressure.
+     *  \param T   Temperature.
+     */
+    double getdValuedp(const double p, const double T)
+    {
+        const double tau = _ref_T / T;
+        const double pi = p / _ref_p;
+
+        const double dgamma_dpi = _gibbs_free_energy.get_dgamma_dpi(tau, pi);
+        return -_gibbs_free_energy.get_dgamma_dpi_dpi(tau, pi) /
+                       (_sR * T * dgamma_dpi * dgamma_dpi);
+    }
+
+private:
+    const DimensionLessGibbsFreeEnergyRegion1 _gibbs_free_energy;
+
+    const double _ref_T;     ///< reference temperature in K.
+    const double _ref_p;  ///< reference pressure in Pa.
+    /// Specific water vapour gas constant in J/(kgK).
+    const double _sR;
+};
+
+}  // end of namespace
+}  // end of namespace

--- a/FEM/Material/Fluid/GibbsFreeEnergy/DimensionLessGibbsFreeEnergyRegion1.cpp
+++ b/FEM/Material/Fluid/GibbsFreeEnergy/DimensionLessGibbsFreeEnergyRegion1.cpp
@@ -1,0 +1,123 @@
+/**
+ *  \brief Define members of the class for dimensionless Gibbs free energy.
+ *
+ *  \copyright
+ *   Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *              Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ *  \file   DimensionLessGibbsFreeEnergyRegion1.cpp
+ *
+ * Created on December 8, 2016, 12:31 PM
+ */
+
+#include "DimensionLessGibbsFreeEnergyRegion1.h"
+
+#include <cmath>
+
+namespace MaterialLib
+{
+namespace Fluid
+{
+static const double ni[34] = {
+    1.4632971213167E-01,  -8.4548187169114E-01, -3.7563603672040E+00,
+    3.3855169168385E+00,  -9.5791963387872E-01, 1.5772038513228E-01,
+    -1.6616417199501E-02, 8.1214629983568E-04,  2.8319080123804E-04,
+    -6.0706301565874E-04, -1.8990068218419E-02, -3.2529748770505E-02,
+    -2.1841717175414E-02, -5.2838357969930E-05, -4.7184321073267E-04,
+    -3.0001780793026E-04, 4.7661393906987E-05,  -4.4141845330846E-06,
+    -7.2694996297594E-16, -3.1679644845054E-05, -2.8270797985312E-06,
+    -8.5205128120103E-10, -2.2425281908000E-06, -6.5171222895601E-07,
+    -1.4341729937924E-13, -4.0516996860117E-07, -1.2734301741641E-09,
+    -1.7424871230634E-10, -6.8762131295531E-19, 1.4478307828521E-20,
+    2.6335781662795E-23,  -1.1947622640071E-23, 1.8228094581404E-24,
+    -9.35370872924580E-26};
+
+static const double li[34] = {0, 0, 0, 0, 0,  0,  0,  0,  1,  1, 1, 1,
+                              1, 1, 2, 2, 2,  2,  2,  3,  3,  3, 4, 4,
+                              4, 5, 8, 8, 21, 23, 29, 30, 31, 32};
+
+static const double ji[34] = {
+    -2, -1, 0,  1, 2, 3,  4,  5,  -9, -7,  -1, 0,   1,   3,   -3,  0,   1,
+    3,  17, -4, 0, 6, -5, -2, 10, -8, -11, -6, -29, -31, -38, -39, -40, -41};
+
+double DimensionLessGibbsFreeEnergyRegion1::get_gamma(const double tau,
+                                                      const double pi) const
+{
+    double val = 0.;
+    for (int i = 0; i < 34; i++)
+    {
+        val += ni[i] * std::pow(7.1 - pi, li[i]) * std::pow(tau - 1.222, ji[i]);
+    }
+
+    return val;
+}
+
+double DimensionLessGibbsFreeEnergyRegion1::get_dgamma_dtau(
+    const double tau, const double pi) const
+{
+    double val = 0.;
+    for (int i = 0; i < 34; i++)
+    {
+        val += ni[i] * ji[i] * std::pow(7.1 - pi, li[i]) *
+               std::pow(tau - 1.222, ji[i] - 1.0);
+    }
+
+    return val;
+}
+
+double DimensionLessGibbsFreeEnergyRegion1::get_dgamma_dtau_dtau(
+    const double tau, const double pi) const
+{
+    double val = 0.;
+    for (int i = 0; i < 34; i++)
+    {
+        val += ni[i] * ji[i] * (ji[i] - 1.0) * std::pow(7.1 - pi, li[i]) *
+               std::pow(tau - 1.222, ji[i] - 2.0);
+    }
+
+    return val;
+}
+
+double DimensionLessGibbsFreeEnergyRegion1::get_dgamma_dpi(
+    const double tau, const double pi) const
+{
+    double val = 0.;
+    for (int i = 0; i < 34; i++)
+    {
+        val -= ni[i] * li[i] * std::pow(7.1 - pi, li[i] - 1.0) *
+               std::pow(tau - 1.222, ji[i]);
+    }
+
+    return val;
+}
+
+double DimensionLessGibbsFreeEnergyRegion1::get_dgamma_dpi_dpi(
+    const double tau, const double pi) const
+{
+    double val = 0.;
+    for (int i = 0; i < 34; i++)
+    {
+        val += ni[i] * li[i] * (li[i] - 1.0) * std::pow(7.1 - pi, li[i] - 2.0) *
+               std::pow(tau - 1.222, ji[i]);
+    }
+
+    return val;
+}
+
+double DimensionLessGibbsFreeEnergyRegion1::get_dgamma_dtau_dpi(
+    const double tau, const double pi) const
+{
+    double val = 0.;
+    for (int i = 0; i < 34; i++)
+    {
+        val -= ni[i] * ji[i] * li[i] * std::pow(7.1 - pi, li[i] - 1.0) *
+               std::pow(tau - 1.222, ji[i] - 1.0);
+    }
+
+    return val;
+}
+
+}  // end namespace
+}  // end namespace

--- a/FEM/Material/Fluid/GibbsFreeEnergy/DimensionLessGibbsFreeEnergyRegion1.h
+++ b/FEM/Material/Fluid/GibbsFreeEnergy/DimensionLessGibbsFreeEnergyRegion1.h
@@ -1,0 +1,98 @@
+/**
+ *  \brief Declare a class for dimensionless Gibbs free energy, region1.
+ *
+ *  \copyright
+ *   Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *              Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ *  \file   DimensionLessGibbsFreeEnergyRegion1.h
+ *
+ * Created on December 8, 2016, 12:31 PM
+ */
+
+#pragma once
+
+namespace MaterialLib
+{
+namespace Fluid
+{
+/**
+ *  A class for dimensionless Gibbs free energy defined by
+ *  \f[
+ *     \gamma=\sum_{i=1}^{34}\left[
+ *       n_i * (7.1-\pi)^{l_i}(\tau - 1.222)^{j_i}
+ *     \right]
+ *  \f]
+ *  <a href="http://www.iapws.org/relguide/IF97-Rev.pdf">IF97-Rev</a>
+ *
+ *  Coefficients \f$n_i\f$, \f$j_i\f$ and \f$l_i\f$ are given in three static
+ *  arrays in the cpp file.
+ */
+class DimensionLessGibbsFreeEnergyRegion1
+{
+public:
+	DimensionLessGibbsFreeEnergyRegion1() {};
+
+    /**
+     * Get the value
+     * @param pi  Dimension less temperature
+     * @param tau Dimension less pressure
+     * @return    The value
+     */
+    double get_gamma(const double tau, const double pi) const;
+
+    /**
+     * Get the 1st order partial derivative of the dimension less Gibbs free
+     * energy with respect to dimension less temperature, tau
+     *
+     * @param pi  Dimension less temperature
+     * @param tau Dimension less pressure
+     * @return    The value
+     */
+    double get_dgamma_dtau(const double tau, const double pi) const;
+
+    /**
+     * Get the 2nd order partial derivative of the dimension less Gibbs free
+     * energy with respect to dimension less temperature, tau
+     *
+     * @param pi  Dimension less temperature
+     * @param tau Dimension less pressure
+     * @return    The value
+     */
+    double get_dgamma_dtau_dtau(const double tau, const double pi) const;
+
+    /**
+     * Get the 1st order partial derivative of the dimension less Gibbs free
+     * energy with respect to dimension less pressure, pi
+     *
+     * @param pi  Dimension less temperature
+     * @param tau Dimension less pressure
+     * @return    The value
+     */
+    double get_dgamma_dpi(const double tau, const double pi) const;
+
+    /**
+     * Get the 2nd order partial derivative of the dimension less Gibbs free
+     * energy with respect to dimension less pressure, pi
+     *
+     * @param pi  Dimension less temperature
+     * @param tau Dimension less pressure
+     * @return    The value
+     */
+    double get_dgamma_dpi_dpi(const double tau, const double pi) const;
+
+    /**
+     * Get the 2nd order partial derivative of the dimension less Gibbs free
+     * energy with respect to dimension less temperature, tau, and dimension
+     * less pressure, pi
+     * @param pi  Dimension less temperature
+     * @param tau Dimension less pressure
+     * @return    The value
+     */
+    double get_dgamma_dtau_dpi(const double tau, const double pi) const;
+};
+
+}  // end namespace
+}  // end namespace

--- a/FEM/Material/Fluid/Viscosity/WaterViscosityIAPWS.cpp
+++ b/FEM/Material/Fluid/Viscosity/WaterViscosityIAPWS.cpp
@@ -1,0 +1,206 @@
+/**
+ *  \copyright
+ *   Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *              Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * \file   WaterViscosityIAPWS.cpp
+ *
+ * Created on December 1, 2016, 1:41 PM
+ */
+
+#include "WaterViscosityIAPWS.h"
+
+#include <vector>
+#include <cmath>
+
+namespace MaterialLib
+{
+namespace Fluid
+{
+static const double Hi[4] = {1.67752, 2.20462, 0.6366564, -0.241605};
+static const double Hij[6][7] = {
+    {0.520094, 0.222531, -0.281378, 0.161913, -0.0325372, 0, 0},
+    {0.0850895, 0.999115, -0.906851, 0.257399, 0, 0, 0},
+    {-1.08374, 1.88797, -0.772479, 0, 0, 0, 0},
+    {-0.289555, 1.26613, -0.489837, 0, 0.0698452, 0, -0.00435673},
+    {0, 0, -0.25704, 0, 0, 0.00872102, 0},
+    {0, 0.120573, 0, 0, 0, 0, -0.000593264}};
+
+static double computeBarMu0Factor(const double barT);
+
+static std::vector<double> computeSeriesFactorTForMu1(const double barT);
+static std::vector<double> computeSeriesFactorRhoForMu1(const double bar_rho);
+static double computeBarMu1Factor(
+    const std::vector<double>& series_factorT,
+    const std::vector<double>& series_factorRho);
+
+static double computedBarMu_dbarT(const double barT, double bar_rho);
+static double computedBarMu_dbarRho(const double barT, double bar_rho);
+
+double WaterViscosityIAPWS::getValue(const double T, const double rho)
+{
+    const double _ref_T = 647.096;  // reference temperature in K
+    const double _ref_rho = 322.0;  // reference density in `kg/m^3`
+    const double _ref_mu = 1.0e-6;  // reference viscosity in Pa.s
+
+    const double bar_T = T / _ref_T;
+    const double bar_rho = rho / _ref_rho;
+
+    const double mu0 = 100. * std::sqrt(bar_T) / computeBarMu0Factor(bar_T);
+
+    const std::vector<double>& series_factorT = computeSeriesFactorTForMu1(bar_T);
+    const std::vector<double>& series_factorRho = computeSeriesFactorRhoForMu1(bar_rho);
+    const double mu1 = std::exp(
+        bar_rho * computeBarMu1Factor(series_factorT, series_factorRho));
+
+    return mu0 * mu1 * _ref_mu;
+}
+
+double WaterViscosityIAPWS::getdValuedT(const double T, const double rho)
+{
+    const double _ref_T = 647.096;  // reference temperature in K
+    const double _ref_rho = 322.0;  // reference density in `kg/m^3`
+    const double _ref_mu = 1.0e-6;  // reference viscosity in Pa.s
+
+    const double bar_T = T / _ref_T;
+    const double bar_rho = rho / _ref_rho;
+
+    return _ref_mu * computedBarMu_dbarT(bar_T, bar_rho) / _ref_T;
+}
+
+double WaterViscosityIAPWS::getdValuedRho(const double T, const double rho)
+{
+    const double _ref_T = 647.096;  // reference temperature in K
+    const double _ref_rho = 322.0;  // reference density in `kg/m^3`
+    const double _ref_mu = 1.0e-6;  // reference viscosity in Pa.s
+
+    const double bar_T = T / _ref_T;
+    const double bar_rho = rho / _ref_rho;
+
+    return _ref_mu * computedBarMu_dbarRho(bar_T, bar_rho) / _ref_rho;
+}
+
+double computeBarMu0Factor(const double barT)
+{
+    double sum_val = 0.;
+    double barT_i = 1.;
+    for (int i = 0; i < 4; i++)
+    {
+        sum_val += (Hi[i] / barT_i);
+        barT_i *= barT;
+    }
+    return sum_val;
+}
+
+std::vector<double> computeSeriesFactorTForMu1(const double barT)
+{
+    std::vector<double> series_factorT(6);
+    series_factorT[0] = 1.;
+    const double barT_fac = 1 / barT - 1.0;
+    for (int i = 1; i < 6; i++)
+    {
+        series_factorT[i] = series_factorT[i - 1] * barT_fac;
+    }
+
+    return series_factorT;
+}
+
+std::vector<double> computeSeriesFactorRhoForMu1(const double bar_rho)
+{
+    std::vector<double> series_factorRho(7);
+    series_factorRho[0] = 1.;
+    for (int i = 1; i < 7; i++)
+    {
+        series_factorRho[i] = series_factorRho[i - 1] * (bar_rho - 1.0);
+    }
+
+    return series_factorRho;
+}
+
+double computeBarMu1Factor(const std::vector<double>& series_factorT,
+                           const std::vector<double>& series_factorRho)
+{
+    double sum_val = 0.;
+    for (int i = 0; i < 6; i++)
+    {
+        double sum_val_j = 0;
+        for (int j = 0; j < 7; j++)
+        {
+            sum_val_j += Hij[i][j] * series_factorRho[j];
+        }
+        sum_val += series_factorT[i] * sum_val_j;
+    }
+
+    return sum_val;
+}
+
+double computedBarMu_dbarT(const double barT, double bar_rho)
+{
+    const double mu0_factor = computeBarMu0Factor(barT);
+    const double sqrt_barT = std::sqrt(barT);
+
+    double dmu0_factor_dbarT = 0.0;
+    double barT_i = barT * barT;
+    for (int i = 1; i < 4; i++)
+    {
+        dmu0_factor_dbarT -= static_cast<double>(i) * (Hi[i] / barT_i);
+        barT_i *= barT;
+    }
+
+    const double dbar_mu0_dbarT =
+        50. / (mu0_factor * sqrt_barT) -
+        100. * sqrt_barT * dmu0_factor_dbarT / (mu0_factor * mu0_factor);
+
+    const std::vector<double>& series_factorT = computeSeriesFactorTForMu1(barT);
+    const std::vector<double>& series_factorRho = computeSeriesFactorRhoForMu1(bar_rho);
+
+    double dmu1_factor_dbarT = 0.0;
+    for (int i = 1; i < 6; i++)
+    {
+        double sum_val_j = 0;
+        for (int j = 0; j < 7; j++)
+        {
+            sum_val_j += Hij[i][j] * series_factorRho[j];
+        }
+        dmu1_factor_dbarT -= static_cast<double>(i) * series_factorT[i - 1] *
+                             sum_val_j / (barT * barT);
+    }
+
+    const double mu1_factor =
+        computeBarMu1Factor(series_factorT, series_factorRho);
+    const double dbar_mu1_dbarT =
+        bar_rho * std::exp(bar_rho * mu1_factor) * dmu1_factor_dbarT;
+
+    return dbar_mu0_dbarT * std::exp(bar_rho * mu1_factor) +
+           dbar_mu1_dbarT * 100. * sqrt_barT / mu0_factor;
+}
+
+double computedBarMu_dbarRho(const double barT, double bar_rho)
+{
+    const std::vector<double>& series_factorT = computeSeriesFactorTForMu1(barT);
+    const std::vector<double>& series_factorRho = computeSeriesFactorRhoForMu1(bar_rho);
+
+    double dmu1_factor_dbar_rho = 0.0;
+    for (int i = 0; i < 6; i++)
+    {
+        double sum_val_j = 0;
+        for (int j = 1; j < 7; j++)
+        {
+            sum_val_j +=
+                static_cast<double>(j) * Hij[i][j] * series_factorRho[j - 1];
+        }
+        dmu1_factor_dbar_rho += series_factorT[i] * sum_val_j;
+    }
+
+    const double mu0 = 100. * std::sqrt(barT) / computeBarMu0Factor(barT);
+
+    const double mu1_factor =
+        computeBarMu1Factor(series_factorT, series_factorRho);
+    return mu0 * std::exp(bar_rho * mu1_factor) *
+           (mu1_factor + bar_rho * dmu1_factor_dbar_rho);
+}
+
+}  // end namespace
+}  // end namespace

--- a/FEM/Material/Fluid/Viscosity/WaterViscosityIAPWS.h
+++ b/FEM/Material/Fluid/Viscosity/WaterViscosityIAPWS.h
@@ -1,0 +1,73 @@
+/**
+ *  \brief Viscosity model according to
+ *         Release on the IAPWS Formulation 2008 for the Viscosity of Ordinary
+ *         Water Substance
+ *
+ *  \copyright
+ *   Copyright (c) 2012-2017, OpenGeoSys Community (http://www.opengeosys.org)
+ *              Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * \file   WaterViscosityIAPWS.h
+ *
+ * Created on December 1, 2016, 1:41 PM
+ */
+
+#pragma once
+
+#include <string>
+
+namespace MaterialLib
+{
+namespace Fluid
+{
+/**
+ * \brief A class for viscosity model that is defined by
+ *        The International Association for the Properties of Water and Steam
+ *        <a href="http://www.iapws.org/relguide/visc.pdf">IAPWS</a>
+ *
+ *        With the definition, the viscosity is a function of temperature and
+ *        water density
+ *
+ *  \attention The critical enhancement, \f$\bar{\mu}_2\f$, which is significant
+ *             only within the boundaries specified by
+ *                 \f[ T (\mbox{in K}) \in (645.91, 650.77) \f]
+ *             and
+ *                 \f[ \rho (\mbox{in kg m}^{-3}) \in (245.8, 405.3)\f],
+ *             is not considered.
+ */
+class WaterViscosityIAPWS
+{
+public:
+	WaterViscosityIAPWS() {}
+
+    /// Get model name.
+    std::string getName()
+    {
+        return "IAPWS temperature-density dependent viscosity model";
+    }
+
+    /**  Get density value.
+         \param rho   Density.
+         \param T     Temperature.
+    */
+    static double getValue(const double T, const double rho);
+
+    /**  Get density value.
+         \param rho   Density.
+         \param T     Temperature.
+    */
+    static double getdValuedT(const double T, const double rho);
+
+	/**  Get density value.
+         \param rho   Density.
+         \param T     Temperature.
+    */
+    static double getdValuedRho(const double T, const double rho); 
+
+    // Coefficients Hi and Hij are given in two static arrays in the cpp file.
+};
+
+}  // end namespace
+}  // end namespace

--- a/FEM/eos.cpp
+++ b/FEM/eos.cpp
@@ -28,6 +28,8 @@
 #include "tools.h"
 #include "PhysicalConstant.h"
 
+#include "Material/Fluid/Viscosity/WaterViscosityIAPWS.h"
+
 using namespace std;
 
 /**********************************************************************
@@ -960,8 +962,10 @@ double Fluid_Viscosity(double rho, double T, double p, int fluid)
 			h = co2_viscosity(rho, T);
 			break;
 		case 1: // WATER
-			// h = 1E-3;
-			h = h2o_viscosity_IAPWS(rho, T);
+			//h = h2o_viscosity_IAPWS(rho, T);
+			{
+				return MaterialLib::Fluid::WaterViscosityIAPWS::getValue(T, rho);
+			}
 			break;
 		case 2: // METHANE
 			// h = ch4_viscosity_295K(p);

--- a/FEM/rf_mfp_new.cpp
+++ b/FEM/rf_mfp_new.cpp
@@ -487,6 +487,11 @@ std::ios::pos_type CFluidProperties::Read(std::ifstream* mfp_file)
 				viscosity_pcs_name_vector.push_back("PRESSURE1");
 				viscosity_pcs_name_vector.push_back("TEMPERATURE1");
 			}
+			if (viscosity_model == 8) // IAPWS
+			{
+				viscosity_pcs_name_vector.push_back("PRESSURE1");
+				viscosity_pcs_name_vector.push_back("TEMPERATURE1");
+			}
 			if (viscosity_model == 9) // my(rho,T)
 			{
 				std::string arg1, arg2;
@@ -585,6 +590,12 @@ std::ios::pos_type CFluidProperties::Read(std::ifstream* mfp_file)
 				enthalpy_pcs_name_vector.push_back("TEMPERATURE1");
 			}
 
+			if (heat_capacity_model == 8) // IAPWS
+			{
+				specific_heat_capacity_pcs_name_vector.push_back("PRESSURE1");
+				specific_heat_capacity_pcs_name_vector.push_back("TEMPERATURE1");
+			}
+
 			// AKS
 			if (density_model == 15) // components constant density
 			{
@@ -640,6 +651,11 @@ std::ios::pos_type CFluidProperties::Read(std::ifstream* mfp_file)
 
 				heat_conductivity_pcs_name_vector.push_back(arg1);
 				heat_conductivity_pcs_name_vector.push_back(arg2);
+			}
+			if (heat_conductivity_model == 8) // IAPWS
+			{
+				heat_conductivity_pcs_name_vector.push_back("PRESSURE1");
+				heat_conductivity_pcs_name_vector.push_back("TEMPERATURE1");
 			}
 			// AKS
 			if (density_model == 15) // components constant density

--- a/FEM/rf_mfp_new.cpp
+++ b/FEM/rf_mfp_new.cpp
@@ -369,7 +369,7 @@ std::ios::pos_type CFluidProperties::Read(std::ifstream* mfp_file)
 				densityIAPWS = new MaterialLib::Fluid::WaterDensityIAPWSIF97Region1();
 				compressibility_model_temperature = 8;
 				compressibility_model_pressure = 8;
-                                density_pcs_name_vector.push_back("PRESSURE1");
+				density_pcs_name_vector.push_back("PRESSURE1");
 				density_pcs_name_vector.push_back("TEMPERATURE1");
 			}
 			if (density_model == 9) // WW

--- a/FEM/rf_mfp_new.cpp
+++ b/FEM/rf_mfp_new.cpp
@@ -3237,6 +3237,13 @@ double CFluidProperties::drhodP(double* variables)
 		case 7: // use of fct file
 			drhodP = 1.0 / p; // to be done
 			break;
+		case 8:
+			{
+				const double perturbation = 1.e-4;
+				drhodP = (MATCalcFluidDensityMethod8(p+perturbation, T, 0.0)
+					      -MATCalcFluidDensityMethod8(p, T, 0.0)) / perturbation;
+				break;
+			}
 
 		case 15: // volume translated Peng-Robinson
 			if (eos_name == "VTPR" || eos_name == "PR" || eos_name == "IDEAL")
@@ -3363,7 +3370,13 @@ double CFluidProperties::drhodT(double* variables)
 		case 7: // use of fct file
 			drhodT = 1.0 / T;
 			break;
-
+		case 8:
+			{
+				const double perturbation = 1.e-4;
+				drhodT = (MATCalcFluidDensityMethod8(p, T+perturbation, 0.0)
+					      -MATCalcFluidDensityMethod8(p, T, 0.0)) / perturbation;
+				break;
+			}
 		case 15: // volume translated Peng-Robinson
 			if (eos_name == "VTPR" || eos_name == "PR" || eos_name == "IDEAL")
 			{

--- a/FEM/rf_mfp_new.cpp
+++ b/FEM/rf_mfp_new.cpp
@@ -17,6 +17,7 @@
 #include "makros.h"
 
 #include <cfloat>
+#include <limits>
 
 // FEM-Makros
 //#include "mathlib.h"
@@ -1067,9 +1068,10 @@ double CFluidProperties::Density(double* variables)
 			case 8: // M14 von JdJ // 25.1.12 Added by CB for density output AB-model
 				{
 					const double T = variables[1];
-					density = densityIAPWS->getValue(variables[0], T);
+					const double p = std::max(0.0, variables[0]);
+					density = densityIAPWS->getValue(p, T);
 					// // M14 von JdJ // 25.1.12 Added by CB for density output AB-model, 
-					//MATCalcFluidDensityMethod8(variables[0], variables[1], variables[2]);
+					//MATCalcFluidDensityMethod8(p, T, variables[2]);
 				}
 				break;
 			case 10: // Get density from temperature-pressure values from fct-file	NB 4.8.01
@@ -1221,9 +1223,10 @@ double CFluidProperties::Density(double* variables)
 			case 8: // M14 von JdJ
 				{
 					const double T = primary_variable[1];
-					density = densityIAPWS->getValue(primary_variable[0], T);
+					const double p = std::max(0.0, primary_variable[0]);
+					density = densityIAPWS->getValue(p, T);
 					// // M14 von JdJ // 25.1.12 Added by CB for density output AB-model, 
-					//MATCalcFluidDensityMethod8(primary_variable[0], primary_variable[1], primary_variable[2]);
+					//MATCalcFluidDensityMethod8(p, T, primary_variable[2]);
 				}
 				break;
 			case 10: // Get density from temperature-pressure values from fct-file NB
@@ -3419,7 +3422,8 @@ double CFluidProperties::drhodT(double* variables)
 		case 8:
 			{
 				const double T = variables[1];
-				drhodT = densityIAPWS->getdValuedT(variables[0], T);
+				const double p = std::max(0.0, variables[0]);
+				drhodT = densityIAPWS->getdValuedT(p, T);
 				/*
 				const double perturbation = 1.e-4;
 				drhodT = (MATCalcFluidDensityMethod8(p, T+perturbation, 0.0)

--- a/FEM/rf_mfp_new.h
+++ b/FEM/rf_mfp_new.h
@@ -24,6 +24,13 @@
 class CompProperties;
 class CRFProcess;
 
+namespace MaterialLib
+{
+namespace Fluid
+{
+class WaterDensityIAPWSIF97Region1;
+}
+}
 /*!
    \class hash_table
 
@@ -272,6 +279,8 @@ private:
 	double PhaseDiffusion_Yaws_1976(double);
 	double MATCalcHeatConductivityMethod2(double p, double T, double C);
 	double MATCalcFluidHeatCapacityMethod2(double p, double T, double C);
+
+	MaterialLib::Fluid::WaterDensityIAPWSIF97Region1* densityIAPWS;
 
 	friend class FiniteElement::CFiniteElementStd;
 	friend class Problem;


### PR DESCRIPTION
This PR replaced IAPWS models of water density and viscosity with new classes, which was implemented for ogs6. The models were added to ogs5 for a DECOVALEX project.
