### PR TITLE
 Enable $EPSILON for ST that is is consistent with BCs 

### DIFF
--- a/FEM/rf_st_new.cpp
+++ b/FEM/rf_st_new.cpp
@@ -118,6 +118,7 @@ CSourceTerm::CSourceTerm()
 	//  display_mode = false; //OK
 	this->TimeInterpolation = 0; // BG
 	_isConstrainedST = false;
+	epsilon = -1;
 }
 
 // KR: Conversion from GUI-ST-object to CSourceTerm
@@ -319,6 +320,13 @@ std::ios::pos_type CSourceTerm::Read(std::ifstream* st_file, const GEOLIB::GEOOb
 		{
 			ReadGeoType(st_file, geo_obj, unique_name);
 			continue;
+		}
+
+		if (line_string.find("$EPSILON") != std::string::npos)
+		{
+			in.str(readNonBlankLineFromInputStream(*st_file));
+			in >> epsilon;
+			in.clear();
 		}
 
 		// 05.09.2008 WW
@@ -3284,10 +3292,10 @@ void CSourceTermGroup::SetSFC(CSourceTerm* m_st, const int ShiftInNodeVector)
 	{
 		GEOLIB::Surface const& sfc(*(dynamic_cast<GEOLIB::Surface const*>(m_st->getGeoObj())));
 		std::cout << "Surface " << m_st->geo_name << ": " << sfc.getNTriangles() << "\n";
-		SetSurfaceNodeVector(&sfc, sfc_node_ids);
+		SetSurfaceNodeVector(&sfc, sfc_node_ids, m_st);
 
 		/*
-		      SetSurfaceNodeVector(m_sfc, sfc_nod_vector);
+		      SetSurfaceNodeVector(m_sfc, sfc_nod_vector,m_st);
 		*/
 		sfc_nod_vector.insert(sfc_nod_vector.begin(), sfc_node_ids.begin(), sfc_node_ids.end());
 		if (m_st->isCoupled())
@@ -3371,16 +3379,25 @@ void CSourceTerm::SetNOD()
  11/2007 JOD
  last modification:
  **************************************************************************/
-void CSourceTermGroup::SetSurfaceNodeVector(Surface* m_sfc, std::vector<long>& sfc_nod_vector)
+void CSourceTermGroup::SetSurfaceNodeVector(Surface* m_sfc, std::vector<long>& sfc_nod_vector, CSourceTerm* st)
 {
+	double computed_search_length = m_msh->getSearchLength();
+	if (st->epsilon != -1)
+		m_msh->setSearchLength(st->epsilon);
 	const bool for_source = true;
 	m_msh->GetNODOnSFC(m_sfc, sfc_nod_vector, for_source);
+	m_msh->setSearchLength(computed_search_length);
 }
 
-void CSourceTermGroup::SetSurfaceNodeVector(GEOLIB::Surface const* sfc, std::vector<std::size_t>& sfc_nod_vector)
+void CSourceTermGroup::SetSurfaceNodeVector(GEOLIB::Surface const* sfc, std::vector<std::size_t>& sfc_nod_vector, CSourceTerm* st)
 {
+	double computed_search_length = m_msh->getSearchLength();
+	if (st->epsilon != -1)
+		m_msh->setSearchLength(st->epsilon);
 	const bool for_source = true;
 	m_msh->GetNODOnSFC(sfc, sfc_nod_vector, for_source);
+	m_msh->setSearchLength(computed_search_length);
+
 }
 
 /**************************************************************************

--- a/FEM/rf_st_new.cpp
+++ b/FEM/rf_st_new.cpp
@@ -3292,11 +3292,8 @@ void CSourceTermGroup::SetSFC(CSourceTerm* m_st, const int ShiftInNodeVector)
 	{
 		GEOLIB::Surface const& sfc(*(dynamic_cast<GEOLIB::Surface const*>(m_st->getGeoObj())));
 		std::cout << "Surface " << m_st->geo_name << ": " << sfc.getNTriangles() << "\n";
-		SetSurfaceNodeVector(&sfc, sfc_node_ids, m_st);
+		SetSurfaceNodeVector(&sfc, sfc_node_ids, m_st->epsilon);
 
-		/*
-		      SetSurfaceNodeVector(m_sfc, sfc_nod_vector,m_st);
-		*/
 		sfc_nod_vector.insert(sfc_nod_vector.begin(), sfc_node_ids.begin(), sfc_node_ids.end());
 		if (m_st->isCoupled())
 			m_st->SetSurfaceNodeVectorConditional(sfc_nod_vector, sfc_nod_vector_cond);
@@ -3379,21 +3376,21 @@ void CSourceTerm::SetNOD()
  11/2007 JOD
  last modification:
  **************************************************************************/
-void CSourceTermGroup::SetSurfaceNodeVector(Surface* m_sfc, std::vector<long>& sfc_nod_vector, CSourceTerm* st)
+void CSourceTermGroup::SetSurfaceNodeVector(Surface* m_sfc, std::vector<long>& sfc_nod_vector, const double epsilon)
 {
 	double computed_search_length = m_msh->getSearchLength();
-	if (st->epsilon != -1)
-		m_msh->setSearchLength(st->epsilon);
+	if (epsilon != -1)
+		m_msh->setSearchLength(epsilon);
 	const bool for_source = true;
 	m_msh->GetNODOnSFC(m_sfc, sfc_nod_vector, for_source);
 	m_msh->setSearchLength(computed_search_length);
 }
 
-void CSourceTermGroup::SetSurfaceNodeVector(GEOLIB::Surface const* sfc, std::vector<std::size_t>& sfc_nod_vector, CSourceTerm* st)
+void CSourceTermGroup::SetSurfaceNodeVector(GEOLIB::Surface const* sfc, std::vector<std::size_t>& sfc_nod_vector, const double epsilon)
 {
 	double computed_search_length = m_msh->getSearchLength();
-	if (st->epsilon != -1)
-		m_msh->setSearchLength(st->epsilon);
+	if (epsilon != -1)
+		m_msh->setSearchLength(epsilon);
 	const bool for_source = true;
 	m_msh->GetNODOnSFC(sfc, sfc_nod_vector, for_source);
 	m_msh->setSearchLength(computed_search_length);

--- a/FEM/rf_st_new.h
+++ b/FEM/rf_st_new.h
@@ -386,8 +386,8 @@ private:
 	                                std::vector<double>& ply_nod_val_vector) const;
 
 	// JOD
-	void SetSurfaceNodeVector(Surface* m_sfc, std::vector<long>& sfc_nod_vector, CSourceTerm* st);
-	void SetSurfaceNodeVector(GEOLIB::Surface const* sfc, std::vector<std::size_t>& sfc_nod_vector, CSourceTerm* st);
+	void SetSurfaceNodeVector(Surface* m_sfc, std::vector<long>& sfc_nod_vector, const double epsilon);
+	void SetSurfaceNodeVector(GEOLIB::Surface const* sfc, std::vector<std::size_t>& sfc_nod_vector, const double epsilon);
 	void SetSurfaceNodeValueVector(CSourceTerm* m_st,
 	                               Surface* m_sfc,
 	                               std::vector<long> const& sfc_nod_vector,

--- a/FEM/rf_st_new.h
+++ b/FEM/rf_st_new.h
@@ -232,6 +232,7 @@ private: // TF, KR
 	void DeleteHistoryNodeMemory();
 
 	double geo_node_value;
+	double epsilon;
 
 	/**
 	 * is the source term coupled with another source term
@@ -385,8 +386,8 @@ private:
 	                                std::vector<double>& ply_nod_val_vector) const;
 
 	// JOD
-	void SetSurfaceNodeVector(Surface* m_sfc, std::vector<long>& sfc_nod_vector);
-	void SetSurfaceNodeVector(GEOLIB::Surface const* sfc, std::vector<std::size_t>& sfc_nod_vector);
+	void SetSurfaceNodeVector(Surface* m_sfc, std::vector<long>& sfc_nod_vector, CSourceTerm* st);
+	void SetSurfaceNodeVector(GEOLIB::Surface const* sfc, std::vector<std::size_t>& sfc_nod_vector, CSourceTerm* st);
 	void SetSurfaceNodeValueVector(CSourceTerm* m_st,
 	                               Surface* m_sfc,
 	                               std::vector<long> const& sfc_nod_vector,

--- a/MSH/msh_lib.cpp
+++ b/MSH/msh_lib.cpp
@@ -524,6 +524,7 @@ void MSHSelectFreeSurfaceNodes(MeshLib::CFEMesh* m_msh)
 				nextnode = MSHGetNextNode(startnode, m_msh);
 				if (m_msh->nod_vector[nextnode]->free_surface == 4)
 				{
+					
 					strang[j + 1] = nextnode;
 					no_unconfined_layer++;
 				}

--- a/MSH/msh_lib.cpp
+++ b/MSH/msh_lib.cpp
@@ -524,7 +524,6 @@ void MSHSelectFreeSurfaceNodes(MeshLib::CFEMesh* m_msh)
 				nextnode = MSHGetNextNode(startnode, m_msh);
 				if (m_msh->nod_vector[nextnode]->free_surface == 4)
 				{
-					
 					strang[j + 1] = nextnode;
 					no_unconfined_layer++;
 				}


### PR DESCRIPTION
This gives the opportunity to specify the tolerance in ST directly.  Taking the default value or using the tolerance from GLI  is still enabled.