### PR TITLE
Upgrade numdiff and use gcc 6.2

### DIFF
--- a/scripts/env/envinf1/cli.sh
+++ b/scripts/env/envinf1/cli.sh
@@ -13,8 +13,8 @@ module load petsc/3.7.6_maint_gcc6.2.0_openmpi_gcc_1.8.8-1
 
 # Tools
 module load openmpi/gcc/1.8.8-1
-module load numdiff/5.8.1-1
-module rm gmp/5.1.2-1
+module load numdiff/5.9_gcc_6.2.0_1
+#module rm gmp/5.1.2-1
 module load gmp-shared/6.1.2-1
 
 export PATH=$PATH:/data/ogs/phreeqc/bin


### PR DESCRIPTION
This PR upgrades numdiff and uses gcc 6.2 on jenkins.

There are two benchmarks  are marked as failed in the recent PRs
```
	 85 - NB-M/pressure/Sphere_elastic/m_sphere_elastic (Failed)
	164 - YS-RWPT/2DGrains/2d_grains (Failed)
```
Benchmark 85 has a special BC of normal traction, and Benchmark 164 is about random walk.

On Jenkins, loading numdiff downgrades the gcc from 6.2 to 4.8.  For the two failed benchmarks, the codes compiled with gcc 4.8 and 6.2, respectively, give results with a slight difference. The reference results were generated by using the code compiled with gcc 6.2, while Jenkin uses gcc 4.8 after running cli.sh. This makes the two  benchmarks failed.

The following figures shows the displacement magnitude by the codes compiled with gcc 4.8, and 6.2, respectively: 
![comp1](https://user-images.githubusercontent.com/1343839/51400262-4920ea80-1b48-11e9-945c-ea68eeeb2141.png)

