### PR TITLE
Improvement: Use the directly calculated nodal saturation in the pressure coupling term

### DIFF
--- a/FEM/fem_ele_vec.cpp
+++ b/FEM/fem_ele_vec.cpp
@@ -1119,18 +1119,35 @@ void CFiniteElementVec::LocalAssembly(const int update)
             _nodal_p2[i] = h_pcs->GetNodeValue(nodes[i], idx_P2);
         }
     }
+
     if (_nodal_S0)
     {
-        for (int i = 0; i < nnodes; i++)
+        if (_flow_type == FiniteElement::PS_GLOBAL)
         {
-            _nodal_S0[i] = h_pcs->GetNodeValue(nodes[i], idx_S0);
+            for (int i = 0; i < nnodes; i++)
+            {
+                _nodal_S0[i] = h_pcs->GetNodeValue(nodes[i], idx_S0);
+            }
+        }
+        else
+        {
+            const double fac =
+                (_flow_type == FiniteElement::RICHARDS_FLOW) ? -1.0 : 1.0;
+            for (int i = 0; i < nnodes; i++)
+            {
+                _nodal_S0[i] = m_mmp->SaturationCapillaryPressureFunction(
+                    fac * h_pcs->GetNodeValue(nodes[i], idx_P1 - 1));
+            }
         }
     }
-    if (_nodal_S)
+    if (_nodal_S && (_flow_type != FiniteElement::PS_GLOBAL))
     {
+        const double fac =
+            (_flow_type == FiniteElement::RICHARDS_FLOW) ? -1.0 : 1.0;
         for (int i = 0; i < nnodes; i++)
         {
-            _nodal_S[i] = h_pcs->GetNodeValue(nodes[i], idx_S);
+            _nodal_S[i] =
+                m_mmp->SaturationCapillaryPressureFunction(fac * _nodal_p1[0]);
         }
     }
 


### PR DESCRIPTION
In the current source code, the nodal saturations for the repressure coupling  term use the extrapolated nodal values, which are inaccuracy in the local assembly. In this PR, such nodal saturations are calculated  directly from the nodal capillary pressures. The reference results of the associated benchmarks have been updated (ufz/ogs5-benchmarks_ref#35). 