### PR TITLE
Fixed temperature value in the output of fluid properties when temperature is in Celsius

### DIFF
--- a/FEM/rf_mfp_new.cpp
+++ b/FEM/rf_mfp_new.cpp
@@ -3475,8 +3475,8 @@ double MFPGetNodeValue(long node, const std::string& mfp_name,
                 arguments[0] = pcs->GetNodeValue(node, var_idx);
             else if ((*vec_var_names)[i] == "TEMPERATURE1")
             {
-                arguments[1] = pcs->getTemperatureUnit() ==
-                                       (FiniteElement::CELSIUS && for_output)
+                arguments[1] = ((pcs->getTemperatureUnit() ==
+                                       FiniteElement::CELSIUS) && for_output)
                                    ? pcs->GetNodeValue(node, var_idx) +
                                          PhysicalConstant::CelsiusZeroInKelvin
                                    : pcs->GetNodeValue(node, var_idx);

--- a/FEM/rf_mfp_new.cpp
+++ b/FEM/rf_mfp_new.cpp
@@ -3422,7 +3422,8 @@ double CFluidProperties::CalcEnthalpy(double temperature)
    08/2008 OK
    last change: 11/2008 NB
 **************************************************************************/
-double MFPGetNodeValue(long node, const string& mfp_name, int phase_number)
+double MFPGetNodeValue(long node, const std::string& mfp_name,
+                       int phase_number, const bool for_output)
 {
     CFluidProperties* m_mfp = mfp_vector[max(phase_number, 0)];
     const int restore_mode = m_mfp->mode;
@@ -3473,7 +3474,13 @@ double MFPGetNodeValue(long node, const string& mfp_name, int phase_number)
             if ((*vec_var_names)[i] == "PRESSURE1")
                 arguments[0] = pcs->GetNodeValue(node, var_idx);
             else if ((*vec_var_names)[i] == "TEMPERATURE1")
-                arguments[1] = pcs->GetNodeValue(node, var_idx);
+            {
+                arguments[1] = pcs->getTemperatureUnit() ==
+                                       (FiniteElement::CELSIUS && for_output)
+                                   ? pcs->GetNodeValue(node, var_idx) +
+                                         PhysicalConstant::CelsiusZeroInKelvin
+                                   : pcs->GetNodeValue(node, var_idx);
+            }
             else if ((*vec_var_names)[i] == "CONCENTRATION1")
                 arguments[2] = pcs->GetNodeValue(node, var_idx);
             else

--- a/FEM/rf_mfp_new.h
+++ b/FEM/rf_mfp_new.h
@@ -305,7 +305,9 @@ private:
     friend CFluidProperties* MFPGet(const std::string&);
     friend CFluidProperties* MFPGet(int);
     friend void KNaplCalcDensity();
-    friend double MFPGetNodeValue(long, const std::string&, int);
+    friend double MFPGetNodeValue(long node, const std::string& mfp_name,
+                                  int phase_number,
+                                  const bool for_output);
     friend void MMPCalcSecondaryVariablesNew(CRFProcess*, bool);
 };
 
@@ -326,5 +328,6 @@ extern void MFPDelete();
 extern CFluidProperties* MFPGet(const std::string&);
 extern CFluidProperties* MFPGet(int);  // NB JUN 09
 // NB AUG 09
-double MFPGetNodeValue(long, const std::string&, int);
+double MFPGetNodeValue(long node, const std::string& mfp_name, int phase_number,
+                       const bool for_output = true);
 #endif

--- a/FEM/rf_pcs.cpp
+++ b/FEM/rf_pcs.cpp
@@ -7886,11 +7886,13 @@ double CRFProcess::calcPressureFromHead(CBoundaryCondition const& bc,
                                         double const& fac)
 {
     double local_density;
+    const bool for_ouput = false;
     switch (bc.getPressureAsHeadModel())
     {
         case 0:
             // use current density at node
-            local_density = MFPGetNodeValue(node_number, "DENSITY", 0);
+            local_density = MFPGetNodeValue(node_number, "DENSITY", 0,
+                                            for_ouput);
             break;
         case 1:
             // use given density
@@ -7900,7 +7902,8 @@ double CRFProcess::calcPressureFromHead(CBoundaryCondition const& bc,
             std::cout << "Warning! No PressureAsHeadDensity specified. "
                          "Calculating density (i.e. PressureAsHeadModel 0)!"
                       << std::endl;
-            local_density = MFPGetNodeValue(node_number, "DENSITY", 0);
+            local_density = MFPGetNodeValue(node_number, "DENSITY", 0,
+                                            for_ouput);
             break;
     }
 
@@ -7921,11 +7924,13 @@ double CRFProcess::calcHeadFromPressure(CBoundaryCondition const& bc,
                                         double const& fac)
 {
     double local_density;
+    const bool for_ouput = false;
     switch (bc.getPressureAsHeadModel())
     {
         case 0:
             // use current density at node
-            local_density = MFPGetNodeValue(node_number, "DENSITY", 0);
+            local_density = MFPGetNodeValue(node_number, "DENSITY", 0,
+                                            for_ouput);
             break;
         case 1:
             // use given density
@@ -7935,7 +7940,8 @@ double CRFProcess::calcHeadFromPressure(CBoundaryCondition const& bc,
             std::cout << "Warning! No PressureAsHeadDensity specified. "
                          "Calculating density (i.e. PressureAsHeadModel 0)!"
                       << std::endl;
-            local_density = MFPGetNodeValue(node_number, "DENSITY", 0);
+            local_density = MFPGetNodeValue(node_number, "DENSITY", 0,
+                                            for_ouput);
             break;
     }
 


### PR DESCRIPTION
The error occurs when $MFP_VALUES is used for output and the temperature unit is the default, Celsius. This PR corrects the error.