### PR TITLE
Time interval Dirichlete BC

### DIFF
--- a/Base/TimeInterval.h
+++ b/Base/TimeInterval.h
@@ -1,0 +1,58 @@
+/**
+ * \copyright
+ * Copyright (c) 2012-2019, OpenGeoSys Community (http://www.opengeosys.org)
+ *            Distributed under a Modified BSD License.
+ *              See accompanying file LICENSE.txt or
+ *              http://www.opengeosys.org/project/license
+ *
+ * \file TimeInterval.h
+ *
+ * Created on July 17, 2019, 11:07 AM
+ *
+ */
+
+#pragma once
+
+namespace BaseLib
+{
+class TimeInterval
+{
+public:
+    TimeInterval(const double start_time_, const double end_time_)
+        : _start_time(start_time_), _end_time(end_time_)
+    {
+        assert(_end_time > _start_time);
+    }
+
+    bool isInTimeInterval(const double time) const
+    {
+        if (time < _start_time)
+            return false;
+        if (time > _end_time)
+            return false;
+
+        return true;
+    }
+
+private:
+    const double _start_time;
+    const double _end_time;
+};
+
+bool isInTimeInterval(const double time,
+                      std::vector<TimeInterval*> const& time_intervals)
+{
+    // No period defined. That means the time is always in period.
+    if (time_intervals.empty())
+        return true;
+
+    for (std::size_t i = 0; i < time_intervals.size(); i++)
+    {
+        if (time_intervals[i]->isInTimeInterval(time))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+}  // end of namespace BaseLib

--- a/Base/TimeInterval.h
+++ b/Base/TimeInterval.h
@@ -11,7 +11,10 @@
  *
  */
 
-#pragma once
+#ifndef TIME_INTERVAL_H
+#define TIME_INTERVAL_H
+
+#include <vector>
 
 namespace BaseLib
 {
@@ -56,3 +59,5 @@ bool isInTimeInterval(const double time,
     return false;
 }
 }  // end of namespace BaseLib
+
+#endif

--- a/FEM/rf_bc_new.cpp
+++ b/FEM/rf_bc_new.cpp
@@ -472,6 +472,15 @@ std::ios::pos_type CBoundaryCondition::Read(std::ifstream* bc_file,
             continue;
         }
 
+        if (line_string.find("$TIME_CONTROLLED_ACTIVE") != std::string::npos)
+        {
+            Display::ScreenMessage(
+                "This keyword has already been replaced with $TIME_INTERVAL, "
+                "which has a syntax of\n\t $TIME_INTERVAL\n\t [start time][end "
+                "time]\n\t $TIME_INTERVAL\n\t [start time][end time]\n ... ");
+            exit(EXIT_FAILURE);
+        }
+
         if (line_string.find("$TIME_INTERVAL") != std::string::npos)
         {
             in.str(readNonBlankLineFromInputStream(*bc_file));

--- a/FEM/rf_bc_new.cpp
+++ b/FEM/rf_bc_new.cpp
@@ -157,7 +157,6 @@ CBoundaryCondition::CBoundaryCondition()
     conditional = false;
     time_dep_interpol = false;
     epsilon = -1;                     // NW
-    time_contr_curve = -1;            // WX
     bcExcav = -1;                     // WX
     MatGr = -1;                       // WX
     NoDispIncre = -1;                 // WX:12.2012
@@ -527,14 +526,6 @@ std::ios::pos_type CBoundaryCondition::Read(std::ifstream* bc_file,
         {
             in.str(readNonBlankLineFromInputStream(*bc_file));
             in >> epsilon;
-            in.clear();
-        }
-        //....................................................................
-        // aktive state of the bc is time controlled  WX
-        if (line_string.find("$TIME_CONTROLLED_ACTIVE") != std::string::npos)
-        {
-            in.str(readNonBlankLineFromInputStream(*bc_file));
-            in >> time_contr_curve;
             in.clear();
         }
         //....................................................................

--- a/FEM/rf_bc_new.cpp
+++ b/FEM/rf_bc_new.cpp
@@ -150,7 +150,7 @@ CBoundaryCondition::CBoundaryCondition()
       geo_name(""),
       _curve_index(-1),
       dis_linear_f(NULL),
-      _time_period(NULL)
+      _time_interval(NULL)
 {
     this->setProcessDistributionType(FiniteElement::INVALID_DIS_TYPE);
     // FCT
@@ -176,7 +176,7 @@ CBoundaryCondition::CBoundaryCondition(const BoundaryCondition* bc)
     : ProcessInfo(bc->getProcessType(), bc->getProcessPrimaryVariable(), NULL),
       GeoInfo(bc->getGeoType(), bc->getGeoObj()),
       DistributionInfo(bc->getProcessDistributionType()),
-      _time_period(NULL)
+      _time_interval(NULL)
 {
     setProcess(PCSGet(this->getProcessType()));
     this->geo_name = bc->getGeoName();
@@ -222,8 +222,8 @@ CBoundaryCondition::~CBoundaryCondition()
         delete dis_linear_f;
     dis_linear_f = NULL;
 
-    if (_time_period)
-        delete _time_period;
+    if (_time_interval)
+        delete _time_interval;
 }
 
 const std::string& CBoundaryCondition::getGeoName() const
@@ -470,12 +470,12 @@ std::ios::pos_type CBoundaryCondition::Read(std::ifstream* bc_file,
             continue;
         }
 
-        if (line_string.find("$TIME_PERIOD") != std::string::npos)
+        if (line_string.find("$TIME_INTERVAL") != std::string::npos)
         {
             in.str(readNonBlankLineFromInputStream(*bc_file));
             double t1, t2;
             in >> t1 >> t2;
-            _time_period = new TimePeriod(t1, t2);
+            _time_interval = new TimeInterval(t1, t2);
             continue;
         }
 

--- a/FEM/rf_bc_new.h
+++ b/FEM/rf_bc_new.h
@@ -132,7 +132,11 @@ public:
 
     bool isInPeriod(const double time) const
     {
-        return _time_period ? _time_period->isInPeriod(time) : false;
+        // No period defined. That means the time is always in period.
+        if (_time_period == NULL)
+            return true;
+
+        return _time_period->isInPeriod(time);
     }
 
     const std::vector<int>& getPointsWithDistribedBC() const

--- a/FEM/rf_bc_new.h
+++ b/FEM/rf_bc_new.h
@@ -47,6 +47,27 @@ namespace MeshLib
 class CFEMesh;
 }
 
+struct TimePeriod
+{
+    TimePeriod(const double start_time_, const double end_time_)
+        : start_time(start_time_), end_time(end_time_)
+    {
+    }
+
+    bool isInPeriod(const double time) const
+    {
+        if (time < start_time)
+            return false;
+        if (time > end_time)
+            return false;
+
+        return true;
+    }
+
+    const double start_time;
+    const double end_time;
+};
+
 class BoundaryCondition;
 
 class CBoundaryCondition : public ProcessInfo,
@@ -109,6 +130,11 @@ public:
         return _periode_phase_shift;
     }
 
+    bool isInPeriod(const double time) const
+    {
+        return _time_period ? _time_period->isInPeriod(time) : false;
+    }
+
     const std::vector<int>& getPointsWithDistribedBC() const
     {
         return _PointsHaveDistribedBC;
@@ -154,7 +180,6 @@ public:
     bool isSeepageBC() const { return _isSeepageBC; }
     bool isSwitchBC() const { return _isSwitchBC; }
     SwitchBC const& getSwitchBC() const { return _switchBC; }
-
 private:
     std::vector<std::string> _PointsFCTNames;
     std::vector<int> _PointsHaveDistribedBC;
@@ -229,6 +254,8 @@ private:
 
     bool _isSwitchBC;
     SwitchBC _switchBC;
+
+    TimePeriod* _time_period;
 };
 
 class CBoundaryConditionNode  // OK raus

--- a/FEM/rf_bc_new.h
+++ b/FEM/rf_bc_new.h
@@ -47,14 +47,14 @@ namespace MeshLib
 class CFEMesh;
 }
 
-struct TimePeriod
+struct TimeInterval
 {
-    TimePeriod(const double start_time_, const double end_time_)
+    TimeInterval(const double start_time_, const double end_time_)
         : start_time(start_time_), end_time(end_time_)
     {
     }
 
-    bool isInPeriod(const double time) const
+    bool isInTimeInterval(const double time) const
     {
         if (time < start_time)
             return false;
@@ -130,13 +130,13 @@ public:
         return _periode_phase_shift;
     }
 
-    bool isInPeriod(const double time) const
+    bool isInTimeInterval(const double time) const
     {
         // No period defined. That means the time is always in period.
-        if (_time_period == NULL)
+        if (_time_interval == NULL)
             return true;
 
-        return _time_period->isInPeriod(time);
+        return _time_interval->isInTimeInterval(time);
     }
 
     const std::vector<int>& getPointsWithDistribedBC() const
@@ -259,7 +259,7 @@ private:
     bool _isSwitchBC;
     SwitchBC _switchBC;
 
-    TimePeriod* _time_period;
+    TimeInterval* _time_interval;
 };
 
 class CBoundaryConditionNode  // OK raus

--- a/FEM/rf_bc_new.h
+++ b/FEM/rf_bc_new.h
@@ -36,37 +36,17 @@ class BoundaryConditionIO;
 #include "Constrained.h"
 #include "SwitchBC.h"
 
-// GEOLib
-//#include "geo_ply.h"
-// MSHLib
-//#include "msh_lib.h"
-// PCSLib
-//#include "rf_pcs.h"
+
+
+namespace BaseLib
+{
+class TimeInterval;
+}
+
 namespace MeshLib
 {
 class CFEMesh;
 }
-
-struct TimeInterval
-{
-    TimeInterval(const double start_time_, const double end_time_)
-        : start_time(start_time_), end_time(end_time_)
-    {
-    }
-
-    bool isInTimeInterval(const double time) const
-    {
-        if (time < start_time)
-            return false;
-        if (time > end_time)
-            return false;
-
-        return true;
-    }
-
-    const double start_time;
-    const double end_time;
-};
 
 class BoundaryCondition;
 
@@ -130,14 +110,7 @@ public:
         return _periode_phase_shift;
     }
 
-    bool isInTimeInterval(const double time) const
-    {
-        // No period defined. That means the time is always in period.
-        if (_time_interval == NULL)
-            return true;
-
-        return _time_interval->isInTimeInterval(time);
-    }
+    bool isInTimeInterval(const double time) const;
 
     const std::vector<int>& getPointsWithDistribedBC() const
     {
@@ -253,7 +226,7 @@ private:
     bool _isSwitchBC;
     SwitchBC _switchBC;
 
-    TimeInterval* _time_interval;
+    std::vector<BaseLib::TimeInterval*> _time_intervals;
 };
 
 class CBoundaryConditionNode  // OK raus

--- a/FEM/rf_bc_new.h
+++ b/FEM/rf_bc_new.h
@@ -159,10 +159,6 @@ public:
     {
         return MatGr;
     }  // WX:12.2010 get excav material group
-    int getTimeContrCurve()
-    {
-        return time_contr_curve;
-    }  // WX:12.2010 get bc ativity controlled curve
     int getNoDispIncre() { return NoDispIncre; };  // WX:12.2012
     // give head bc for PRESSURE1 primary variable	//MW
     int getPressureAsHeadModel() const { return _pressure_as_head_model; }
@@ -243,8 +239,6 @@ private:
     // Excavation WX:12.2010
     int bcExcav;
     int MatGr;
-    // aktive state is controlled by time curve WX:01.2011
-    int time_contr_curve;
     // no displacement increment 12.2012
     int NoDispIncre;
     // give head bc for PRESSURE1 primary variable	//MW

--- a/FEM/rf_pcs.cpp
+++ b/FEM/rf_pcs.cpp
@@ -6625,7 +6625,7 @@ void CRFProcess::IncorporateBoundaryConditions(const int rank)
         m_bc_node = bc_node_value[gindex];
         m_bc = bc_node[gindex];
 
-        if (!m_bc->isInPeriod(aktuelle_zeit))
+        if (!m_bc->isInTimeInterval(aktuelle_zeit))
             continue;
 
         //

--- a/FEM/rf_pcs.cpp
+++ b/FEM/rf_pcs.cpp
@@ -6628,15 +6628,6 @@ void CRFProcess::IncorporateBoundaryConditions(const int rank)
         if (!m_bc->isInTimeInterval(aktuelle_zeit))
             continue;
 
-        //
-        // WX: check if bc is aktive, when Time_Controlled_Aktive for this bc is
-        // defined
-        if (m_bc->getTimeContrCurve() > 0)
-            if (GetCurveValue(m_bc->getTimeContrCurve(), 0, aktuelle_zeit,
-                              &valid) < MKleinsteZahl)
-                continue;
-
-
         // WX: 01.2011. for excavation bc, check if excavated and if on boundary
         if (m_bc->getExcav() > 0)
         {

--- a/FEM/rf_pcs.cpp
+++ b/FEM/rf_pcs.cpp
@@ -6624,6 +6624,10 @@ void CRFProcess::IncorporateBoundaryConditions(const int rank)
 #endif
         m_bc_node = bc_node_value[gindex];
         m_bc = bc_node[gindex];
+
+        if (!m_bc->isInPeriod(aktuelle_zeit))
+            continue;
+
         //
         // WX: check if bc is aktive, when Time_Controlled_Aktive for this bc is
         // defined


### PR DESCRIPTION
Added time interval Dirichlete BC with a new keyword of
**$TIME_INTERVAL**
where one can specify a Dirichlete BC existing in a time interval

Example
```
 $TIME_INTERVAL
  0.0 100.0
 $TIME_INTERVAL
  100.0 4.320000e+003
```
Also see a modified benchmark: https://github.com/ufz/ogs5-benchmarks/blob/master/H/h_frac.bc
