### PR TITLE
Advective heat transport using coupling of Heat_Transport and Deformation_Flow

### DIFF
--- a/FEM/fem_ele_std.cpp
+++ b/FEM/fem_ele_std.cpp
@@ -811,6 +811,10 @@ void CFiniteElementStd::ConfigureCoupling(CRFProcess* pcs, const int* Shift,
                 cpl_pcs = PCSGet("LIQUID_FLOW");
                 if (cpl_pcs == NULL)
                 {
+                    cpl_pcs = PCSGet("DEFORMATION_FLOW");
+                }
+                if (cpl_pcs == NULL)
+                {
                     // OK
                     cpl_pcs = PCSGet("RICHARDS_FLOW");
                     if (cpl_pcs)


### PR DESCRIPTION
The advective heat transport seem not to work for this coupling.

So far I initialized the coupling pointer of heat transport process to flow process in case the monolithic HM (Deformation_Flow) is used.

Not working yet. See https://github.com/ufz/ogs5/issues/162
